### PR TITLE
changement libellé equipe médicale

### DIFF
--- a/contenus/questions/question_symptômes_contact_à_risque_libellé.md
+++ b/contenus/questions/question_symptômes_contact_à_risque_libellé.md
@@ -1,1 +1,1 @@
-<!---->J’ai passé du temps avec une personne <b>COVID confirmée</b> (sans mesure de protection dédiée<sup>*</sup>)
+<!---->J’ai passé du temps avec une personne <b>testée positive au COVID</b> (sans mesure de protection dédiée<sup>*</sup>)


### PR DESCRIPTION
clarification du terme covid confirmée = peu intelligible