### PR TITLE
Ajout de statistiques basiques sur le parcours

### DIFF
--- a/src/scripts/actions.js
+++ b/src/scripts/actions.js
@@ -1,3 +1,4 @@
+import { ping } from './stats.js'
 import { ICS } from './ics.js'
 
 module.exports = {
@@ -54,6 +55,11 @@ module.exports = {
                     }
                 })
             }
+        })
+    },
+    bindStatistics: function (document) {
+        document.addEventListener('pageChanged', (event) => {
+            ping(event.detail)
         })
     },
 }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -17,6 +17,7 @@ window.app = app
 ;(function () {
     app.init()
         .then(() => {
+            actions.bindStatistics(document)
             var router = Router.initRouter(app)
             app.router = router
             router.resolve()

--- a/src/scripts/router.js
+++ b/src/scripts/router.js
@@ -49,7 +49,7 @@ function initRouter(app) {
         after: function () {
             // Global hook to send a custom event on each page change.
             var pageName = pagination.getCurrentPageName()
-            document.dispatchEvent(new CustomEvent('pageChanged:' + pageName))
+            document.dispatchEvent(new CustomEvent('pageChanged', { detail: pageName }))
         },
     })
 

--- a/src/scripts/stats.js
+++ b/src/scripts/stats.js
@@ -1,0 +1,23 @@
+import { fetch } from 'whatwg-fetch'
+
+function ping(pageName) {
+    // https://hacks.mozilla.org/2016/03/referrer-and-cache-control-apis-for-fetch/
+    fetch(`/stats/${pageName}`, {
+        referrerPolicy: 'unsafe-url',
+        cache: 'no-cache',
+        headers: {
+            'Cache-Control': 'no-cache',
+            Pragma: 'no-cache',
+        },
+    })
+        .then((response) => {
+            console.debug(`Stats: ${pageName} (${response.status})`)
+        })
+        .catch((exception) => {
+            console.warn(`Stats: ${pageName} (${exception})`)
+        })
+}
+
+module.exports = {
+    ping,
+}

--- a/src/scripts/updater.js
+++ b/src/scripts/updater.js
@@ -57,19 +57,19 @@ module.exports = function (router) {
                 })
                 this.showBanner(document)
             } else {
-                document.addEventListener(
-                    'pageChanged:nouvelleversiondisponible',
-                    () => {
-                        const refreshButton = document.querySelector(
-                            '#nouvelle-version-disponible-block #refresh-button'
-                        )
-                        refreshButton.setAttribute('href', '#' + pageName)
-                        refreshButton.addEventListener(
-                            'click',
-                            this.forceReloadCurrentPageWithHash
-                        )
+                document.addEventListener('pageChanged', (event) => {
+                    if (event.detail !== 'nouvelleversiondisponible') {
+                        return
                     }
-                )
+                    const refreshButton = document.querySelector(
+                        '#nouvelle-version-disponible-block #refresh-button'
+                    )
+                    refreshButton.setAttribute('href', '#' + pageName)
+                    refreshButton.addEventListener(
+                        'click',
+                        this.forceReloadCurrentPageWithHash
+                    )
+                })
                 router.navigate('nouvelleversiondisponible')
             }
         }


### PR DESCRIPTION
Seules les pages parcourues sont consignées dans les logs serveurs au même titre qu’une navigation classique (non-SPA).

Aucune donnée personnelle liée aux saisies n’est transmise.