### PR TITLE
Corrige une des conditions de déconfinement post-suivi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ endif
 check: check-links check-versions check-documentation check-service-worker
 
 check-links:  # Check that links to external pages are still valid.
-	python3 check.py links --timeout 30
+	python3 check.py links --timeout 30 --delay 0.2
 
 check-versions:  # Check that current version matches service-worker one.
 	python3 check.py versions

--- a/check.py
+++ b/check.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 import json
+import time
 from html.parser import HTMLParser
-from pathlib import Path
-from time import perf_counter
 from http import HTTPStatus
+from pathlib import Path
 
 import httpx
-from minicli import cli, run, wrap
+from minicli import cli, run
 
 from build import each_folder_from, each_file_from
 
@@ -26,7 +26,7 @@ class LinkExtractor(HTMLParser):
 
 
 @cli
-def links(timeout: int = 10):
+def links(timeout: int = 10, delay: float = 0.1):
     parser = LinkExtractor()
     content = open(HERE / "src" / "index.html").read()
     parser.feed(content)
@@ -35,6 +35,7 @@ def links(timeout: int = 10):
         response = httpx.get(link, timeout=timeout)
         if response.status_code != HTTPStatus.OK:
             raise Exception(f"{link} is broken! ({response.status_code})")
+        time.sleep(delay)  # avoid being throttled
 
 
 @cli

--- a/check.py
+++ b/check.py
@@ -32,7 +32,11 @@ def links(timeout: int = 10, delay: float = 0.1):
     parser.feed(content)
     for link in sorted(parser.links):
         print(link)
-        response = httpx.get(link, timeout=timeout)
+        response = httpx.get(
+            link,
+            timeout=timeout,
+            verify=False,  # ignore SSL certificate validation errors
+        )
         if response.status_code != HTTPStatus.OK:
             raise Exception(f"{link} is broken! ({response.status_code})")
         time.sleep(delay)  # avoid being throttled

--- a/src/scripts/algorithme/deconfinement.js
+++ b/src/scripts/algorithme/deconfinement.js
@@ -16,9 +16,12 @@ class AlgorithmeDeconfinement {
 
     isSuiviRegulier() {
         // Au moins une entrée ces dernières 24h + une entrée ces dernières 48h.
+        const maintenant = utils.joursAvant(0)
+        const ilYA24h = utils.joursAvant(1)
+        const ilYA48h = utils.joursAvant(2)
         return (
-            this.profil.suiviDerniersJours(1).length >= 1 &&
-            this.profil.suiviDerniersJours(2).length >= 2
+            this.profil.suiviEntre(ilYA24h, maintenant).length >= 1 &&
+            this.profil.suiviEntre(ilYA48h, ilYA24h).length >= 1
         )
     }
 

--- a/src/scripts/profil.js
+++ b/src/scripts/profil.js
@@ -280,6 +280,13 @@ class Profil {
         )
     }
 
+    suiviEntre(strictementApres, avant) {
+        return this.suivi.filter((etat) => {
+            const date = new Date(etat.date)
+            return date > strictementApres && date <= avant
+        })
+    }
+
     estMonProfil() {
         return this.nom == 'mes_infos'
     }

--- a/src/scripts/tests/test.algorithme.deconfinement.js
+++ b/src/scripts/tests/test.algorithme.deconfinement.js
@@ -134,9 +134,49 @@ describe('Algorithme déconfinement', function () {
             assert.strictEqual(algoDeconfinement.isSuiviRegulier(), false)
         })
 
+        it('Faux si deux entrées ces dernières 24h seulement', function () {
+            const data = {
+                suivi: [
+                    {
+                        date: new Date().toJSON(),
+                    },
+                    {
+                        date: new Date().toJSON(),
+                    },
+                ],
+            }
+            profil.fillData(data)
+            const algoOrientation = new AlgorithmeOrientation(profil)
+            const algoDeconfinement = new AlgorithmeDeconfinement(
+                profil,
+                algoOrientation
+            )
+            assert.strictEqual(algoDeconfinement.isSuiviRegulier(), false)
+        })
+
         it('Faux si une entrée ces dernières 48h seulement', function () {
             const data = {
                 suivi: [
+                    {
+                        date: utils.joursAvant(1).toJSON(),
+                    },
+                ],
+            }
+            profil.fillData(data)
+            const algoOrientation = new AlgorithmeOrientation(profil)
+            const algoDeconfinement = new AlgorithmeDeconfinement(
+                profil,
+                algoOrientation
+            )
+            assert.strictEqual(algoDeconfinement.isSuiviRegulier(), false)
+        })
+
+        it('Faux si deux entrées ces dernières 48h seulement', function () {
+            const data = {
+                suivi: [
+                    {
+                        date: utils.joursAvant(1).toJSON(),
+                    },
                     {
                         date: utils.joursAvant(1).toJSON(),
                     },


### PR DESCRIPTION
Il faut au moins une réponse dans les dernières 24h, et au moins une réponse dans les 24h qui précèdent.

