### PR TITLE
Tech: revient à une version de localforage qui marche avec IE et Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "core-js": "3.6.5",
-    "localforage": "1.9.0",
+    "localforage": "1.7.3",
     "navigo": "7.1.2",
     "timeago.js": "4.0.2",
     "whatwg-fetch": "3.4.0"


### PR DESCRIPTION
Le problème a été introduit dans la 1.7.4 : https://github.com/localForage/localForage/issues/970

Un correctif est en attente d’intégration : https://github.com/localForage/localForage/pull/971