### PR TITLE
Fix: le bloc foyer pouvait afficher un contenu vide

### DIFF
--- a/src/scripts/algorithme/orientation.js
+++ b/src/scripts/algorithme/orientation.js
@@ -248,10 +248,7 @@ export default class AlgorithmeOrientation {
         if (this.profil.symptomes_actuels) {
             return []
         }
-        if (this.profil.symptomes_passes || this.profil.contact_a_risque) {
-            blockNames.push('conseils-foyer')
-            blockNames.push('conseils-foyer-fragile-suivi')
-        } else if (this.profil.foyer_enfants || this.profil.foyer_fragile) {
+        if (this.profil.foyer_enfants || this.profil.foyer_fragile) {
             blockNames.push('conseils-foyer')
             if (this.profil.foyer_enfants && this.profil.foyer_fragile) {
                 blockNames.push('conseils-foyer-enfants-fragile')

--- a/src/scripts/tests/test.algorithme.orientation.js
+++ b/src/scripts/tests/test.algorithme.orientation.js
@@ -544,28 +544,6 @@ describe('Algorithme d’orientation', function () {
             assert.deepEqual(algoOrientation.foyerBlockNamesToDisplay(), [])
         })
 
-        it('Symptômes passés affiche suivi', function () {
-            var profil = new Profil('mes_infos', {
-                symptomes_passes: true,
-            })
-            var algoOrientation = new AlgorithmeOrientation(profil, {})
-            assert.deepEqual(algoOrientation.foyerBlockNamesToDisplay(), [
-                'conseils-foyer',
-                'conseils-foyer-fragile-suivi',
-            ])
-        })
-
-        it('Contact à risque affiche suivi', function () {
-            var profil = new Profil('mes_infos', {
-                contact_a_risque: true,
-            })
-            var algoOrientation = new AlgorithmeOrientation(profil, {})
-            assert.deepEqual(algoOrientation.foyerBlockNamesToDisplay(), [
-                'conseils-foyer',
-                'conseils-foyer-fragile-suivi',
-            ])
-        })
-
         it('Risque enfant', function () {
             var profil = new Profil('mes_infos', {
                 foyer_enfants: true,

--- a/src/template.html
+++ b/src/template.html
@@ -789,8 +789,6 @@
                         </div>
                         {{ conseils_foyer_enfants_infos }}
                     </div>
-                    <div id="conseils-foyer-fragile-suivi" hidden>
-                    </div>
                 </details>
             </div>
 


### PR DESCRIPTION
Suite de https://github.com/Delegation-numerique-en-sante/mesconseilscovid/commit/d92e2fd39f39feab22f24b71da05a21ac2c9a02f

Un fichier a été supprimé mais la logique associée n’a pas été mise à jour ce qui conduisait à l’affichage d’un bloc pouvant être vide donnant l’impression que son dépliement avant un problème.