### PR TITLE
Tech: remonte le "user agent" dans les retours utilisateurs

### DIFF
--- a/feedback/mesconseilscovid_feedback/app.py
+++ b/feedback/mesconseilscovid_feedback/app.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 from pykeybasebot import Bot
 from roll import HttpError, Roll
 from roll.extensions import cors, options, simple_server, traceback
+from user_agents import parse
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,10 @@ class FeedbackView:
             raise HttpError(HTTPStatus.BAD_REQUEST)
 
         message = f"{self.KIND_EMOJI[kind]} ({page}): {message}"
+
+        user_agent = request.headers.get("USER-AGENT")
+        if user_agent:
+            message += f" [envoyé depuis {parse(user_agent)}]"
 
         if request.host.startswith("127.0.0.1"):
             print(message)

--- a/feedback/requirements.txt
+++ b/feedback/requirements.txt
@@ -24,5 +24,7 @@ stringcase==1.2.0
 toml==0.10.1
 typing-extensions==3.7.4.3
 typing-inspect==0.6.0
+ua-parser==0.10.0
+user-agents==2.2.0
 websockets==8.1
 zipp==3.1.0

--- a/feedback/setup.py
+++ b/feedback/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup
 
 setup(
     name="mesconseilscovid-feedback",
-    version="1.0.0",
+    version="1.1.0",
     url="https://github.com/Delegation-numerique-en-sante/mesconseilscovid",
     author="Délégation ministérielle du numérique en santé",
     author_email="mesconseilscovid@sante.gouv.fr",
     description="Retours utilisateurs pour Mes Conseils Covid",
     packages=["mesconseilscovid_feedback"],
     python_requires=">=3.7",
-    install_requires=["roll", "pykeybasebot"],
+    install_requires=["roll", "pykeybasebot", "user-agents"],
 )

--- a/feedback/tests/test_app.py
+++ b/feedback/tests/test_app.py
@@ -19,7 +19,7 @@ def app(monkeypatch):
         yield app_
 
 
-async def test_post_feedback(client, app):
+async def test_post_feedback_without_user_agent(client, app):
     resp = await client.post(
         "/feedback",
         {"kind": "flag", "message": "J’ai rien compris", "page": "introduction",},
@@ -30,6 +30,24 @@ async def test_post_feedback(client, app):
     }
     app.bot.chat.send.assert_called_once_with(
         "abcd1234", ":golf: (introduction): J’ai rien compris"
+    )
+
+
+async def test_post_feedback_with_user_agent(client, app):
+    resp = await client.post(
+        "/feedback",
+        {"kind": "flag", "message": "J’ai rien compris", "page": "introduction",},
+        headers={
+            "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B179 Safari/7534.48.3",
+        },
+    )
+    assert resp.status == HTTPStatus.ACCEPTED
+    assert json.loads(resp.body) == {
+        "message": ":golf: (introduction): J’ai rien compris [envoyé depuis iPhone / iOS 5.1 / Mobile Safari 5.1]"
+    }
+    app.bot.chat.send.assert_called_once_with(
+        "abcd1234",
+        ":golf: (introduction): J’ai rien compris [envoyé depuis iPhone / iOS 5.1 / Mobile Safari 5.1]",
     )
 
 


### PR DESCRIPTION
Cela permettra d’identifier plus facilement des problèmes qui seraient liés à un navigateur web particulier.