### PR TITLE
N’enregistre pas le profil avant qu’il ait un nom

### DIFF
--- a/src/scripts/page/questionnaire/nom.js
+++ b/src/scripts/page/questionnaire/nom.js
@@ -1,13 +1,6 @@
 import { toggleFormButtonOnTextFieldsRequired } from '../../formutils.js'
 
 export default function nom(form, app) {
-    // Premier démarrage du formulaire ?
-    if (!app.profil.questionnaire_started) {
-        app.profil.questionnaire_started = true
-        app.enregistrerProfilActuel()
-        window.plausible(`Questionnaire commencé`)
-    }
-
     var button = form.querySelector('input[type=submit]')
     const requiredLabel = 'Cette information est requise'
     toggleFormButtonOnTextFieldsRequired(form, button.value, requiredLabel)


### PR DESCRIPTION
Sinon, lorsque l’on revient immédiatement à l’accueil sans saisir de nom, on se trouve face à un profil appelé `undefined`.

En conséquence, l’événement de suivi de démarrage du questionnaire ne sera déclenché que sur la page suivante.