### PR TITLE
Tech: remplace node-static par serve-static pour les tests navigateur

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2482,12 +2482,6 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true
-    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -6074,17 +6068,6 @@
       "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
       "dev": true
     },
-    "node-static": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/node-static/-/node-static-0.7.11.tgz",
-      "integrity": "sha512-zfWC/gICcqb74D9ndyvxZWaI1jzcoHmf4UTHWQchBNuNMxdBLJMDiUgZ1tjGLEIe/BMhj2DxKD8HOuc2062pDQ==",
-      "dev": true,
-      "requires": {
-        "colors": ">=0.6.0",
-        "mime": "^1.2.9",
-        "optimist": ">=0.3.4"
-      }
-    },
     "normalize-html-whitespace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/normalize-html-whitespace/-/normalize-html-whitespace-1.0.0.tgz",
@@ -6527,24 +6510,6 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -9782,12 +9747,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "workerpool": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "eslint-plugin-compat": "^3.8.0",
     "jsdom": "^16.2.2",
     "mocha": "^8.0.1",
-    "node-static": "^0.7.11",
     "nyc": "^15.1.0",
     "parcel-bundler": "^1.12.4",
     "parcel-plugin-html-externals": "^0.2.0",
@@ -16,7 +15,8 @@
     "parcel-plugin-static-files-copy": "^2.3.1",
     "parcel-plugin-sw-asset-urls": "^0.1.2",
     "playwright": "^1.4.2",
-    "prettier": "^2.1.2"
+    "prettier": "^2.1.2",
+    "serve-static": "^1.14.1"
   },
   "dependencies": {
     "core-js": "3.6.5",

--- a/src/scripts/tests/integration/setup-app.js
+++ b/src/scripts/tests/integration/setup-app.js
@@ -1,15 +1,16 @@
 import http from 'http'
-import nodeStatic from 'node-static'
+import serveStatic from 'serve-static'
 
 let server
 
 before(function () {
     // Lance un serveur HTTP
-    let file = new nodeStatic.Server('./dist')
+    let serve = new serveStatic('./dist')
+
     server = http.createServer(function (request, response) {
         request
             .addListener('end', function () {
-                file.serve(request, response)
+                serve(request, response)
             })
             .resume()
     })


### PR DESCRIPTION
Le paquet node-static n’est plus maintenu: https://github.com/cloudhead/node-static/issues/218