### PR TITLE
Règles a11y : couleur arrière-plan/premier plan

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -21,6 +21,7 @@
 
 body {
     background-color: #ffffff;
+    color: #000091;
     margin: 0;
     padding: 0;
     font-family: 'Marianne', Sans-Serif;

--- a/src/style.css
+++ b/src/style.css
@@ -21,7 +21,7 @@
 
 body {
     background-color: #ffffff;
-    color: #000091;
+    color: #000000;
     margin: 0;
     padding: 0;
     font-family: 'Marianne', Sans-Serif;


### PR DESCRIPTION
Règle a11y de base : quand on fixe une couleur d'arrière-plan il faut fixer une couleur de premier plan (et inversement). Elle était absente, on a un risque d'avoir un réglage utilisateur par exemple blanc sur noir. Les éléments non stylés risquaient d'être blanc sur blanc dans plusieurs contextes discutés avec @davidbgk