### PR TITLE
Tech: mise à jour script d’appel à Plausible

### DIFF
--- a/src/scripts/plausible.js
+++ b/src/scripts/plausible.js
@@ -18,26 +18,27 @@
             '//' +
             location.hostname +
             location.pathname +
-            location.hash.slice(1)
+            location.hash.slice(1) +
+            location.search
         )
-    }
-
-    function getSourceFromQueryParam() {
-        var result = location.search.match(/[?&](ref|source|utm_source)=([^?&]+)/)
-        return result ? result[2] : null
     }
 
     function trigger(eventName, options) {
         if (document.visibilityState === 'prerender') return ignore('prerendering')
 
         var payload = {}
-        payload.name = eventName
-        payload.url = getUrl()
-        payload.domain = CONFIG['domain']
-        payload.referrer = document.referrer || null
-        payload.source = getSourceFromQueryParam()
-        payload.user_agent = window.navigator.userAgent
-        payload.screen_width = window.innerWidth
+        payload.n = eventName
+        payload.u = getUrl()
+        payload.d = CONFIG['domain']
+        payload.r = document.referrer || null
+        payload.w = window.innerWidth
+
+        if (options && options.meta) {
+            payload.m = JSON.stringify(options.meta)
+        }
+        if (options && options.props) {
+            payload.p = JSON.stringify(options.props)
+        }
 
         if (
             /^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*:)*?:?0*1$/.test(

--- a/src/scripts/plausible.js
+++ b/src/scripts/plausible.js
@@ -48,7 +48,7 @@
         ) {
             ignore('running locally')
             window.app._plausibleTrackingEvents.push(
-                `${payload.name}:${location.hash.slice(1)}`
+                `${payload.n}:${location.hash.slice(1)}`
             )
             console.debug('[Plausible]', payload)
             return


### PR DESCRIPTION
Principalement car la détermination de la source est maintenant réalisée côté serveur mais il faut pour cela lui transmettre `location.search` qui contient les paramètres en query (source=FOO)

Le payload a été réduit avec des clés raccourcies, au passage on a perdu le `user_agent` et j’ai demandé pourquoi :

https://github.com/plausible/analytics/commit/1519359bbf1156fb27b3132bda9f7395fd042ac8#commitcomment-44565370

On prépare aussi le fait de pouvoir passer des meta/props.