### PR TITLE
Tech: rétrograde importlib-metadata pour résoudre un conflit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ h11==0.9.0
 httpcore==0.12.2
 httpx==0.16.1
 idna==2.10
-importlib-metadata==3.1.0
+importlib-metadata==1.7.0
 Jinja2==2.11.2
 livereload==2.6.3
 MarkupSafe==1.1.1


### PR DESCRIPTION
```
ERROR: Cannot install importlib-metadata==3.1.0, pluggy 0.13.1 and tox 3.20.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested importlib-metadata==3.1.0
    pluggy 0.13.1 depends on importlib-metadata>=0.12; python_version < "3.8"
    tox 3.20.1 depends on importlib-metadata<3 and >=0.12; python_version < "3.8"

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```