### PR TITLE
Tech: met en cache local les PDF distants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ cert.pem
 dist/
 node_modules/
 src/index.html
+src/pdfs/*
 .cache
 .nyc_output
 __pycache__

--- a/build.py
+++ b/build.py
@@ -68,7 +68,7 @@ class PDFLinkExtractor(HTMLParser):
             attrs = dict(attrs)
             url = attrs["href"]
             if url.startswith("http") and url.endswith(".pdf"):
-                self.pdf_links.update([url])
+                self.pdf_links.add(url)
 
 
 def url_to_file_name(url: str) -> str:

--- a/build.py
+++ b/build.py
@@ -36,9 +36,9 @@ def each_folder_from(source_dir, exclude=None):
             yield direntry
 
 
-def each_file_from(source_dir, file_name="*", exclude=None):
+def each_file_from(source_dir, pattern="*", exclude=None):
     """Walk across the `source_dir` and return the md file paths."""
-    for filename in fnmatch.filter(sorted(os.listdir(source_dir)), file_name):
+    for filename in fnmatch.filter(sorted(os.listdir(source_dir)), pattern):
         if exclude is not None and filename in exclude:
             continue
         yield os.path.join(source_dir, filename), filename
@@ -48,7 +48,7 @@ def build_responses(source_dir):
     """Extract and convert markdown from a `source_dir` directory into a dict."""
     responses = {}
     for folder in each_folder_from(source_dir):
-        for file_path, filename in each_file_from(folder, file_name="*.md"):
+        for file_path, filename in each_file_from(folder, pattern="*.md"):
             html_content = markdown.read(file_path)
             # Remove empty comments set to hack markdown rendering
             # when we do not want paragraphs.

--- a/build.py
+++ b/build.py
@@ -89,7 +89,10 @@ def save_binary_response(file_path: Path, response: "httpx.Response"):
             download_file.write(chunk)
 
 
-def put_pdfs_in_local_cache(content: str, timeout: int = 10) -> str:
+def cache_external_pdfs(content: str, timeout: int = 10) -> str:
+    """
+    Download external PDFs and replace links with the local copy
+    """
     pdfs_file_path = HERE / "src" / "pdfs"
     if not pdfs_file_path.exists():
         pdfs_file_path.mkdir(parents=True)
@@ -124,7 +127,7 @@ def index():
     """Build the index with contents from markdown dedicated folder."""
     responses = build_responses(CONTENUS_DIR)
     content = render_template("template.html", **responses)
-    content = put_pdfs_in_local_cache(content)
+    content = cache_external_pdfs(content)
     (SRC_DIR / "index.html").write_text(content)
 
 

--- a/check.py
+++ b/check.py
@@ -11,6 +11,8 @@ from minicli import cli, run
 from build import each_folder_from, each_file_from
 
 HERE = Path(__file__).parent
+SRC_DIR = HERE / "src"
+CONTENUS_DIR = HERE / "contenus"
 
 
 class LinkExtractor(HTMLParser):
@@ -37,7 +39,7 @@ class LinkExtractor(HTMLParser):
 @cli
 def links(timeout: int = 10, delay: float = 0.1):
     parser = LinkExtractor()
-    content = open(HERE / "src" / "index.html").read()
+    content = (SRC_DIR / "index.html").read_text()
     parser.feed(content)
     for link in sorted(parser.links):
         print(link)
@@ -61,7 +63,7 @@ def versions():
     data = json.loads(content)
     version = data["version"]
     line_prefix = "const CACHE_NAME = "
-    for line in open(HERE / "src" / "service-worker.js"):
+    for line in open(SRC_DIR / "service-worker.js"):
         if line.startswith(line_prefix):
             break
     if version not in line:
@@ -90,7 +92,7 @@ def service_worker():
     # Retrieving the list from CACHE_FILES.
     sw_filenames = set()
     start = False
-    for line in open(HERE / "src" / "service-worker.js"):
+    for line in open(SRC_DIR / "service-worker.js"):
         # Parsing a JS file in Python, what could potentially go wrong?
         if line.startswith("const CACHE_FILES = ["):
             start = True
@@ -125,7 +127,7 @@ def service_worker():
     fonts_file_names = {
         f"fonts/{filename}"
         for file_path, filename in each_file_from(
-            HERE / "src" / "fonts", file_name="*.woff2", exclude=[".DS_Store"]
+            SRC_DIR / "fonts", file_name="*.woff2", exclude=[".DS_Store"]
         )
     }
     if not fonts_file_names.issubset(sw_filenames):
@@ -137,7 +139,7 @@ def service_worker():
     illustrations_file_names = {
         f"illustrations/{filename}"
         for file_path, filename in each_file_from(
-            HERE / "src" / "illustrations",
+            SRC_DIR / "illustrations",
             exclude=[".DS_Store"],
         )
     }
@@ -150,7 +152,7 @@ def service_worker():
     src_file_names = {
         filename
         for file_path, filename in each_file_from(
-            HERE / "src",
+            SRC_DIR,
             file_name="*.*",
             exclude=[".DS_Store"],
         )
@@ -163,8 +165,8 @@ def service_worker():
 
 @cli
 def orphelins():
-    template = (HERE / "src" / "template.html").read_text()
-    for folder in each_folder_from(HERE / "contenus", exclude=["nouveaux_contenus"]):
+    template = (SRC_DIR / "template.html").read_text()
+    for folder in each_folder_from(CONTENUS_DIR, exclude=["nouveaux_contenus"]):
         for file_path, filename in each_file_from(
             folder, file_name="*.md", exclude=["README.md"]
         ):

--- a/check.py
+++ b/check.py
@@ -33,7 +33,7 @@ class LinkExtractor(HTMLParser):
                     )
                 ):
                     return
-                self.links.update([url])
+                self.links.add(url)
 
 
 @cli

--- a/check.py
+++ b/check.py
@@ -127,7 +127,7 @@ def service_worker():
     fonts_file_names = {
         f"fonts/{filename}"
         for file_path, filename in each_file_from(
-            SRC_DIR / "fonts", file_name="*.woff2", exclude=[".DS_Store"]
+            SRC_DIR / "fonts", pattern="*.woff2", exclude=[".DS_Store"]
         )
     }
     if not fonts_file_names.issubset(sw_filenames):
@@ -153,7 +153,7 @@ def service_worker():
         filename
         for file_path, filename in each_file_from(
             SRC_DIR,
-            file_name="*.*",
+            pattern="*.*",
             exclude=[".DS_Store"],
         )
     }
@@ -168,7 +168,7 @@ def orphelins():
     template = (SRC_DIR / "template.html").read_text()
     for folder in each_folder_from(CONTENUS_DIR, exclude=["nouveaux_contenus"]):
         for file_path, filename in each_file_from(
-            folder, file_name="*.md", exclude=["README.md"]
+            folder, pattern="*.md", exclude=["README.md"]
         ):
             if filename.startswith("meta_") or filename.startswith("config_"):
                 continue

--- a/src/style.css
+++ b/src/style.css
@@ -950,7 +950,7 @@ a[href*='youtube.com']::after {
 }
 /* L’ordre est important, l’icône d’infographie écrase celle de fiche. */
 .conseils a[href="https://www.has-sante.fr/jcms/p_3185131/fr/accompagner-les-enfants-et-les-adolescents-dont-ceux-vivant-avec-une-maladie-chronique-lors-de-la-levee-du-confinement"]::before,
-.conseils a[href*="https://solidarites-sante.gouv.fr/IMG/pdf/"]::before,
+.conseils a[href*="solidarites-sante-gouv-fr-IMG-pdf-"]::before,
 .conseils a[href*="fiche"]::before {
     background: no-repeat bottom left url('icone_fiche.svg');
     content: '';
@@ -959,9 +959,12 @@ a[href*='youtube.com']::after {
     width: 25px;
     height: 22px;
 }
-.conseils a[href="https://www.gouvernement.fr/sites/default/files/arbre_decisionnel_covid_-_nouveau.pdf"]::before,
-.conseils a[href="https://solidarites-sante.gouv.fr/IMG/pdf/affiche_masque_mode_d_emploi.pdf"]::before,
-{
+.conseils
+    a[href$='www-gouvernement-fr-sites-default-files-arbre_decisionnel_covid_-_nouveau.pdf']::before,
+.conseils
+    a[href$='www-gouvernement-fr-sites-default-files-coronavirus_mesures_barrieres_nouveau.pdf']::before,
+.conseils
+    a[href$='solidarites-sante-gouv-fr-IMG-pdf-affiche_masque_mode_d_emploi.pdf']::before {
     background: no-repeat bottom left url('icone_infographie.svg');
     content: '';
     display: inline-flex;


### PR DESCRIPTION
Pour éviter les liens cassés en production.

Cf. https://github.com/Delegation-numerique-en-sante/mesconseilscovid/pulls?q=is%3Apr+label%3Alien-cass%C3%A9+