### PR TITLE
Tech: réduire le temps d'execution du build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v2.x
+        uses: rlespinasse/github-slug-action@v3.x
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2


### PR DESCRIPTION
En passant sur la branch v3.x de rlespinasse/github-slug-action, le temps du GitHub workflow est réduit du temps nécessaire à la construction de l'image docker lié à la branche v2.x.