### PR TITLE
Tech: ajoute des dates (vs. booléens) aux début/fin de formulaires

### DIFF
--- a/src/scripts/page/conseils.js
+++ b/src/scripts/page/conseils.js
@@ -36,8 +36,8 @@ export default function conseils(element, app) {
     var algoOrientation = new AlgorithmeOrientation(app.profil)
 
     // Première complétion du formulaire ?
-    if (!app.profil.questionnaire_completed) {
-        app.profil.questionnaire_completed = true
+    if (typeof app.profil.questionnaire_completion_date === 'undefined') {
+        app.profil.questionnaire_completion_date = new Date()
         app.enregistrerProfilActuel()
         window.plausible(`Questionnaire terminé`)
     }

--- a/src/scripts/page/questionnaire/symptomesactuels.js
+++ b/src/scripts/page/questionnaire/symptomesactuels.js
@@ -6,8 +6,8 @@ import {
 
 export default function symptomesactuels(form, app) {
     // Premier démarrage du formulaire ?
-    if (!app.profil.questionnaire_started) {
-        app.profil.questionnaire_started = true
+    if (typeof app.profil.questionnaire_start_date === 'undefined') {
+        app.profil.questionnaire_start_date = new Date()
         app.enregistrerProfilActuel()
         window.plausible(`Questionnaire commencé`)
     }

--- a/src/scripts/profil.js
+++ b/src/scripts/profil.js
@@ -42,7 +42,7 @@ export default class Profil {
     }
 
     get deconfinement_date() {
-        if (typeof this._suivi_start_date === 'undefined') return undefined
+        if (typeof this._deconfinement_date === 'undefined') return undefined
         return new Date(this._deconfinement_date)
     }
 

--- a/src/scripts/profil.js
+++ b/src/scripts/profil.js
@@ -25,7 +25,6 @@ export default class Profil {
     }
 
     set symptomes_start_date(date) {
-        // Turn the date into a readable string.
         this._symptomes_start_date =
             typeof date !== 'undefined' ? date.toJSON() : undefined
     }
@@ -36,7 +35,6 @@ export default class Profil {
     }
 
     set depistage_start_date(date) {
-        // Turn the date into a readable string.
         this._depistage_start_date =
             typeof date !== 'undefined' ? date.toJSON() : undefined
     }
@@ -48,6 +46,26 @@ export default class Profil {
 
     set deconfinement_date(date) {
         this._deconfinement_date =
+            typeof date !== 'undefined' ? date.toJSON() : undefined
+    }
+
+    get questionnaire_start_date() {
+        if (typeof this._questionnaire_start_date === 'undefined') return undefined
+        return new Date(this._questionnaire_start_date)
+    }
+
+    set questionnaire_start_date(date) {
+        this._questionnaire_start_date =
+            typeof date !== 'undefined' ? date.toJSON() : undefined
+    }
+
+    get questionnaire_completion_date() {
+        if (typeof this._questionnaire_completion_date === 'undefined') return undefined
+        return new Date(this._questionnaire_completion_date)
+    }
+
+    set questionnaire_completion_date(date) {
+        this._questionnaire_completion_date =
             typeof date !== 'undefined' ? date.toJSON() : undefined
     }
 
@@ -117,8 +135,13 @@ export default class Profil {
         this.suivi_active = false
         this.resetSuivi()
 
+        // Legacy: to be removed once migrated.
         this.questionnaire_started = false
         this.questionnaire_completed = false
+        // End of Legacy
+
+        this._questionnaire_start_date = undefined
+        this._questionnaire_completion_date = undefined
     }
 
     fillData(data) {
@@ -183,8 +206,62 @@ export default class Profil {
         this.suivi_active = data['suivi_active'] || false
         this.suivi = data['suivi'] || []
 
+        // Legacy
         this.fillQuestionnaireStarted(data['questionnaire_started'])
         this.fillQuestionnaireCompleted(data['questionnaire_completed'])
+
+        this.fillQuestionnaireStartDate(data['_questionnaire_start_date'])
+        this.fillQuestionnaireCompletionDate(data['_questionnaire_completion_date'])
+        // End of Legacy
+
+        /* At some point we would want to do instead:
+        this._questionnaire_start_date = data['_questionnaire_start_date']
+        this._questionnaire_completion_date = data['_questionnaire_completion_date']
+        */
+    }
+
+    // Legacy: at some point we will want to remove this method.
+    fillQuestionnaireStarted(value) {
+        if (typeof value !== 'undefined') {
+            this.questionnaire_started = value
+        } else {
+            // Migration d’un ancien profil : calculer la donnée manquante
+            this.questionnaire_started = !this.isEmpty()
+        }
+    }
+
+    // Legacy: at some point we will want to remove this method.
+    fillQuestionnaireCompleted(value) {
+        if (typeof value !== 'undefined') {
+            this.questionnaire_completed = value
+        } else {
+            // Migration d’un ancien profil : calculer la donnée manquante
+            this.questionnaire_completed = this.isComplete()
+        }
+    }
+
+    // Legacy: at some point we will want to remove this method.
+    fillQuestionnaireStartDate(value) {
+        if (typeof value !== 'undefined') {
+            this._questionnaire_start_date = value
+        } else {
+            // Migration d’un ancien profil : calculer la donnée manquante
+            this.questionnaire_start_date = this.questionnaire_started
+                ? new Date()
+                : undefined
+        }
+    }
+
+    // Legacy: at some point we will want to remove this method.
+    fillQuestionnaireCompletionDate(value) {
+        if (typeof value !== 'undefined') {
+            this._questionnaire_completion_date = value
+        } else {
+            // Migration d’un ancien profil : calculer la donnée manquante
+            this.questionnaire_completion_date = this.questionnaire_completed
+                ? new Date()
+                : undefined
+        }
     }
 
     fillTestData(depistage, symptomes, personneFragile, foyerFragile) {
@@ -292,24 +369,6 @@ export default class Profil {
         return this.fillData(data)
     }
 
-    fillQuestionnaireStarted(value) {
-        if (typeof value !== 'undefined') {
-            this.questionnaire_started = value
-        } else {
-            // Migration d’un ancien profil : calculer la donnée manquante
-            this.questionnaire_started = !this.isEmpty()
-        }
-    }
-
-    fillQuestionnaireCompleted(value) {
-        if (typeof value !== 'undefined') {
-            this.questionnaire_completed = value
-        } else {
-            // Migration d’un ancien profil : calculer la donnée manquante
-            this.questionnaire_completed = this.isComplete()
-        }
-    }
-
     getData() {
         return {
             departement: this.departement,
@@ -364,6 +423,8 @@ export default class Profil {
             suivi: this.suivi,
             questionnaire_started: this.questionnaire_started,
             questionnaire_completed: this.questionnaire_completed,
+            _questionnaire_start_date: this._questionnaire_start_date,
+            _questionnaire_completion_date: this._questionnaire_completion_date,
         }
     }
 

--- a/src/scripts/tests/test.profil.js
+++ b/src/scripts/tests/test.profil.js
@@ -63,6 +63,8 @@ describe('Profil', function () {
             suivi: [],
             questionnaire_started: false,
             questionnaire_completed: false,
+            _questionnaire_start_date: undefined,
+            _questionnaire_completion_date: undefined,
         })
         assert.isFalse(profil.isComplete())
         assert.isTrue(profil.isEmpty())
@@ -181,6 +183,8 @@ describe('Profil', function () {
             suivi: [],
             questionnaire_started: true,
             questionnaire_completed: true,
+            _questionnaire_start_date: '2020-07-09T14:03:41.000Z',
+            _questionnaire_completion_date: '2020-07-09T14:03:41.000Z',
         }
         profil.fillData(data)
         assert.deepEqual(profil.getData(), data)
@@ -243,6 +247,8 @@ describe('Profil', function () {
             suivi: [],
             questionnaire_started: true,
             questionnaire_completed: true,
+            _questionnaire_start_date: '2020-07-09T14:03:41.000Z',
+            _questionnaire_completion_date: '2020-07-09T14:03:41.000Z',
         }
         profil.fillData(data)
         assert.deepEqual(profil.getData(), data)
@@ -303,6 +309,8 @@ describe('Profil', function () {
             suivi: [{ foo: 'bar' }],
             questionnaire_started: true,
             questionnaire_completed: true,
+            _questionnaire_start_date: '2020-07-09T14:03:41.000Z',
+            _questionnaire_completion_date: '2020-07-09T14:03:41.000Z',
         })
         profil.resetData()
         assert.deepEqual(profil.getData(), {
@@ -357,6 +365,8 @@ describe('Profil', function () {
             suivi: [],
             questionnaire_started: false,
             questionnaire_completed: false,
+            _questionnaire_start_date: undefined,
+            _questionnaire_completion_date: undefined,
         })
         assert.isFalse(profil.isComplete())
         assert.isTrue(profil.isEmpty())
@@ -415,6 +425,8 @@ describe('Profil', function () {
             suivi: [{ foo: 'bar' }],
             questionnaire_started: true,
             questionnaire_completed: true,
+            _questionnaire_start_date: '2020-07-09T14:03:41.000Z',
+            _questionnaire_completion_date: '2020-07-09T14:03:41.000Z',
         })
         profil.resetSuivi()
         assert.deepEqual(profil.getData(), {
@@ -469,6 +481,8 @@ describe('Profil', function () {
             suivi: [],
             questionnaire_started: true,
             questionnaire_completed: true,
+            _questionnaire_start_date: '2020-07-09T14:03:41.000Z',
+            _questionnaire_completion_date: '2020-07-09T14:03:41.000Z',
         })
         assert.isTrue(profil.isComplete())
         assert.isFalse(profil.isEmpty())
@@ -477,24 +491,30 @@ describe('Profil', function () {
     it('Le questionnaire n’est pas commencé par défaut', function () {
         var profil = new Profil('mes_infos')
         assert.isFalse(profil.questionnaire_started)
+        assert.isUndefined(profil.questionnaire_start_date)
     })
 
     it('Le questionnaire n’est pas terminé par défaut', function () {
         var profil = new Profil('mes_infos')
         assert.isFalse(profil.questionnaire_completed)
+        assert.isUndefined(profil.questionnaire_completion_date)
     })
     it('Le questionnaire n’est pas commencé après réinitialisation', function () {
         var profil = new Profil('mes_infos')
         profil.questionnaire_started = true
+        profil.questionnaire_start_date = new Date()
         profil.resetData()
         assert.isFalse(profil.questionnaire_started)
+        assert.isUndefined(profil.questionnaire_start_date)
     })
 
     it('Le questionnaire n’est pas terminé après réinitialisation', function () {
         var profil = new Profil('mes_infos')
         profil.questionnaire_completed = true
+        profil.questionnaire_start_date = new Date()
         profil.resetData()
         assert.isFalse(profil.questionnaire_completed)
+        assert.isUndefined(profil.questionnaire_completion_date)
     })
 
     it('Le questionnaire est commencé si on a au moins une réponse', function () {
@@ -502,6 +522,8 @@ describe('Profil', function () {
             departement: '80',
         })
         assert.isTrue(profil.questionnaire_started)
+        assert.isString(profil._questionnaire_start_date)
+        assert.instanceOf(profil.questionnaire_start_date, Date)
     })
 
     it('Le questionnaire est terminé si on a toutes les réponses', function () {
@@ -549,6 +571,7 @@ describe('Profil', function () {
             depistage: false,
         })
         assert.isTrue(profil.questionnaire_completed)
+        assert.instanceOf(profil.questionnaire_completion_date, Date)
         assert.isFalse(profil.estPositifAsymptomatique())
     })
 })


### PR DESCRIPTION
J'ai pris l'option de garder le `legacy` finalement car ça simplifie la migration et ça pourrait nous servir pour un temps.