### PR TITLE
Tech: corrige la soumission dépistage + suivi

### DIFF
--- a/src/scripts/formutils.js
+++ b/src/scripts/formutils.js
@@ -33,7 +33,7 @@ class Form {
     }
     get secondariesRequired() {
         return Array.from(
-            this.form.querySelectorAll('.secondary.required[role="radiogroup"]')
+            this.form.querySelectorAll('.secondary.required [role="radiogroup"]')
         )
     }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -674,9 +674,10 @@ fieldset legend {
     font-size: 150%;
     margin: 1rem 0 0.5rem 0;
 }
-fieldset .secondary legend {
+fieldset .secondary .secondary-title {
     font-size: 120%;
     margin: 2rem 0 0.5rem 0;
+    color: #000091;
 }
 fieldset div {
     margin: 0.5rem 0;

--- a/src/template.html
+++ b/src/template.html
@@ -518,11 +518,11 @@
                 <div class="details">{{ question_dépistage_aide }}</div>
             </div>
 
-            <div class="secondary disabled required" aria-labelledby="depistage-date-label">
+            <div class="secondary disabled required">
                 <legend id="depistage-date-label">
                     {{ question_dépistage_date_libellé }}
                 </legend>
-                <div class="row">
+                <div class="row" aria-labelledby="depistage-date-label">
                     <label for="depistage_start_date">
                     {{ question_dépistage_date_aide }}
                     </label>
@@ -530,33 +530,27 @@
                 </div>
             </div>
 
-            <div class="secondary disabled required" role="radiogroup" aria-labelledby="depistage-type-label">
+            <div class="secondary disabled required">
                 <legend id="depistage-type-label">
                     {{ question_dépistage_type_libellé }}
                 </legend>
-                <div>
+                <div role="radiogroup" aria-labelledby="depistage-type-label">
                     <input id="depistage_type_rtpcr" type="radio" required name="depistage_type" value="rt-pcr">
                     <label for="depistage_type_rtpcr"><span>{{ question_dépistage_rtpcr_libellé }}</span></label>
-                </div>
-                <div>
                     <input id="depistage_type_antigenique" type="radio" required name="depistage_type" value="antigenique">
                     <label for="depistage_type_antigenique"><span>{{ question_dépistage_antigénique_libellé }}</span></label>
                 </div>
             </div>
 
-            <div class="secondary disabled required" role="radiogroup" aria-labelledby="depistage-resultat-label">
+            <div class="secondary disabled required">
                 <legend id="depistage-resultat-label">
                     {{ question_dépistage_résultat_libellé }}
                 </legend>
-                <div>
+                <div role="radiogroup" aria-labelledby="depistage-resultat-label">
                     <input id="depistage_resultat_positif" type="radio" required name="depistage_resultat" value="positif">
                     <label for="depistage_resultat_positif"><span>{{ question_dépistage_positif_libellé }}</span></label>
-                </div>
-                <div>
                     <input id="depistage_resultat_negatif" type="radio" required name="depistage_resultat" value="negatif">
                     <label for="depistage_resultat_negatif"><span>{{ question_dépistage_négatif_libellé }}</span></label>
-                </div>
-                <div>
                     <input id="depistage_resultat_en_attente" type="radio" required name="depistage_resultat" value="en_attente">
                     <label for="depistage_resultat_en_attente"><span>{{ question_dépistage_attente_libellé|me_or_them }}</span></label>
                 </div>

--- a/src/template.html
+++ b/src/template.html
@@ -519,9 +519,9 @@
             </div>
 
             <div class="secondary disabled required">
-                <legend id="depistage-date-label">
+                <div id="depistage-date-label" class="secondary-title">
                     {{ question_dépistage_date_libellé }}
-                </legend>
+                </div>
                 <div class="row" aria-labelledby="depistage-date-label">
                     <label for="depistage_start_date">
                     {{ question_dépistage_date_aide }}
@@ -531,9 +531,9 @@
             </div>
 
             <div class="secondary disabled required">
-                <legend id="depistage-type-label">
+                <div id="depistage-type-label" class="secondary-title">
                     {{ question_dépistage_type_libellé }}
-                </legend>
+                </div>
                 <div role="radiogroup" aria-labelledby="depistage-type-label">
                     <input id="depistage_type_rtpcr" type="radio" required name="depistage_type" value="rt-pcr">
                     <label for="depistage_type_rtpcr"><span>{{ question_dépistage_rtpcr_libellé }}</span></label>
@@ -543,9 +543,9 @@
             </div>
 
             <div class="secondary disabled required">
-                <legend id="depistage-resultat-label">
+                <div id="depistage-resultat-label" class="secondary-title">
                     {{ question_dépistage_résultat_libellé }}
-                </legend>
+                </div>
                 <div role="radiogroup" aria-labelledby="depistage-resultat-label">
                     <input id="depistage_resultat_positif" type="radio" required name="depistage_resultat" value="positif">
                     <label for="depistage_resultat_positif"><span>{{ question_dépistage_positif_libellé }}</span></label>


### PR DESCRIPTION
En partie introduit dans a666b19da8ea931602382adfd45325509823c873 pour le suivi et mise en conformité du côté du dépistage (les balises aria n’étaient pas cohérentes).