### PR TITLE
Tech: réutilise la liste des pages du questionnaire

### DIFF
--- a/src/scripts/tests/test.updater.js
+++ b/src/scripts/tests/test.updater.js
@@ -1,0 +1,20 @@
+import { assert } from 'chai'
+
+import Updater from '../updater.js'
+
+describe('Updater', function () {
+    it('La page d’introduction n’est pas interactive', function () {
+        const updater = new Updater(undefined)
+        assert.isFalse(updater.onInteractivePage('introduction'))
+    })
+
+    it('La page de dépistage est interactive', function () {
+        const updater = new Updater(undefined)
+        assert.isTrue(updater.onInteractivePage('depistage'))
+    })
+
+    it('La page de suivi des symptômes est interactive', function () {
+        const updater = new Updater(undefined)
+        assert.isTrue(updater.onInteractivePage('suivisymptomes'))
+    })
+})

--- a/src/scripts/updater.js
+++ b/src/scripts/updater.js
@@ -1,5 +1,6 @@
 import { getCurrentPageName } from './pagination.js'
 import { showElement } from './affichage.js'
+import { ORDRE } from './questionnaire.js'
 
 export default class Updater {
     constructor(router) {
@@ -94,25 +95,16 @@ export default class Updater {
 
     notifyUser() {
         const pageName = getCurrentPageName()
-        if (this.isFillingQuestionnaire()) {
+        if (this.onInteractivePage(pageName)) {
             this.notifyUserWithoutInterrupting(pageName)
         } else {
             this.redirectUserToUpdatePage(pageName)
         }
     }
 
-    isFillingQuestionnaire() {
-        const pageName = getCurrentPageName()
-        return (
-            pageName === 'residence' ||
-            pageName === 'activitepro' ||
-            pageName === 'foyer' ||
-            pageName === 'caracteristiques' ||
-            pageName === 'antecedents' ||
-            pageName === 'symptomesactuels' ||
-            pageName === 'symptomespasses' ||
-            pageName === 'contactarisque'
-        )
+    onInteractivePage(pageName) {
+        const interactivePages = ORDRE.concat(['suivisymptomes'])
+        return interactivePages.indexOf(pageName) > -1
     }
 
     notifyUserWithoutInterrupting(pageName) {


### PR DESCRIPTION
Lorsqu’on teste les pages qui sont interactives dans l’updater pour laisser finir le remplissage sans rediriger l’utilisateur·ice.