### PR TITLE
Repositionnement des boutons sur la page d’accueil

### DIFF
--- a/contenus/meta/README.md
+++ b/contenus/meta/README.md
@@ -95,6 +95,8 @@ Si votre situation change, vous pouvez **mettre à jour vos réponses**, par exe
 
 ## Des conseils personnalisés pour agir contre le virus
 
+<ul id="profils-cards" class="cards"></ul>
+
 <div class="js-intro">
 
 <p class="tagline">

--- a/contenus/meta/meta_introduction.md
+++ b/contenus/meta/meta_introduction.md
@@ -1,5 +1,7 @@
 ## Des conseils personnalisés pour agir contre le virus
 
+<ul id="profils-cards" class="cards"></ul>
+
 <div class="js-intro">
 
 <p class="tagline">

--- a/src/scripts/page/introduction.js
+++ b/src/scripts/page/introduction.js
@@ -14,14 +14,11 @@ export default function introduction(element, app) {
         if (noms.indexOf('mes_infos') === -1) {
             const card = container.appendChild(
                 createElementFromHTML(`
-                    <li class="profil-card card">
-                        <h3><span class="nouveau-profil">Pour moi</span></h3>
-                        <div class="form-controls">
-                            <a class="button button-full-width"
-                                data-set-profil="mes_infos"
-                                href="#${app.questionnaire.firstPage}"
-                                >Démarrer</a>
-                        </div>
+                    <li class="profil-empty">
+                        <a class="button button-full-width"
+                            data-set-profil="mes_infos"
+                            href="#${app.questionnaire.firstPage}"
+                            >Démarrer</a>
                     </li>
                 `)
             )
@@ -29,13 +26,10 @@ export default function introduction(element, app) {
         }
         container.appendChild(
             createElementFromHTML(`
-                <li class="profil-card card">
-                    <h3><span class="nouveau-profil">Pour un proche</span></h3>
-                    <div class="form-controls">
-                        <a class="button button-full-width js-profil-new"
-                            href="#nom"
-                            >Démarrer</a>
-                    </div>
+                <li class="profil-empty">
+                    <a class="button button-full-width button-outline js-profil-new"
+                        href="#nom"
+                        >Faire pour un proche</a>
                 </li>
             `)
         )

--- a/src/scripts/tests/integration/test.parcours.js
+++ b/src/scripts/tests/integration/test.parcours.js
@@ -14,12 +14,6 @@ describe('Parcours', function () {
         // Page d’accueil.
         {
             let bouton = await page.waitForSelector('text="Démarrer"')
-            assert.equal(
-                await bouton.evaluate(
-                    (e) => e.parentElement.parentElement.querySelector('h3').innerText
-                ),
-                'Pour moi'
-            )
             await Promise.all([
                 bouton.click(),
                 page.waitForNavigation({ url: '**/#symptomes' }),

--- a/src/scripts/tests/integration/test.plausible.js
+++ b/src/scripts/tests/integration/test.plausible.js
@@ -100,7 +100,9 @@ describe('Plausible', function () {
         const page = this.test.page
 
         await page.goto('http://localhost:8080/#introduction')
-        let bouton = await page.waitForSelector('.js-profil-new >> text="Démarrer"')
+        let bouton = await page.waitForSelector(
+            '.js-profil-new >> text="Faire pour un proche"'
+        )
 
         await Promise.all([bouton.click(), page.waitForNavigation({ url: '**/#nom' })])
 
@@ -209,7 +211,9 @@ describe('Plausible', function () {
         const page = this.test.page
 
         await page.goto('http://localhost:8080/#introduction')
-        let bouton = await page.waitForSelector('.js-profil-new >> text="Démarrer"')
+        let bouton = await page.waitForSelector(
+            '.js-profil-new >> text="Faire pour un proche"'
+        )
         await Promise.all([bouton.click(), page.waitForNavigation({ url: '**/#nom' })])
         await remplirQuestionnaire(page, {
             nom: 'Papy',

--- a/src/scripts/tests/integration/test.profils.js
+++ b/src/scripts/tests/integration/test.profils.js
@@ -13,12 +13,8 @@ describe('Profils', function () {
 
         // Page d’accueil.
         {
-            let bouton = await page.waitForSelector('.js-profil-new >> text="Démarrer"')
-            assert.equal(
-                await bouton.evaluate(
-                    (e) => e.parentElement.parentElement.querySelector('h3').innerText
-                ),
-                'Pour un proche'
+            let bouton = await page.waitForSelector(
+                '.js-profil-new >> text="Faire pour un proche"'
             )
             await Promise.all([
                 bouton.click(),

--- a/src/scripts/tests/integration/test.suivi.js
+++ b/src/scripts/tests/integration/test.suivi.js
@@ -218,12 +218,8 @@ describe('Suivi', function () {
 
         // Page d’accueil.
         {
-            let bouton = await page.waitForSelector('.js-profil-new >> text="Démarrer"')
-            assert.equal(
-                await bouton.evaluate(
-                    (e) => e.parentElement.parentElement.querySelector('h3').innerText
-                ),
-                'Pour un proche'
+            let bouton = await page.waitForSelector(
+                '.js-profil-new >> text="Faire pour un proche"'
             )
             await Promise.all([
                 bouton.click(),

--- a/src/style.css
+++ b/src/style.css
@@ -172,6 +172,10 @@ a .profil {
 .introduction-block {
     text-align: center;
 }
+.introduction-block h2 {
+    margin: 1rem auto;
+    padding-top: 1rem;
+}
 .introduction-block p {
     margin-left: auto;
     margin-right: auto;
@@ -191,9 +195,9 @@ a .profil {
 
 @media only screen and (max-width: 680px) {
     .introduction-block h2 {
-        font-size: 175%;
-        padding-top: 1rem;
-        margin-bottom: 2rem;
+        font-size: 170%;
+        padding-top: 0.5rem;
+        margin: 0.5rem auto 1.5rem;
     }
     .introduction-block .tagline {
         font-size: 125%;
@@ -211,6 +215,7 @@ a .profil {
     flex-flow: row wrap;
     justify-content: center;
     list-style-type: none;
+    align-items: center;
 }
 .block ul.cards {
     padding: 0;
@@ -239,6 +244,29 @@ a .profil {
 .break {
     flex-basis: 100%;
     height: 0;
+}
+.profil-empty {
+    width: 100%;
+    font-size: 1.2rem;
+    font-weight: bold;
+}
+.profil-empty a.button {
+    max-width: 18rem;
+    margin: auto;
+}
+.profil-empty a.button-outline {
+    font-weight: normal;
+}
+.cards > li {
+    margin-top: 1rem;
+}
+@media only screen and (min-width: 680px) {
+    .cards .card:first-child {
+        margin-bottom: 1rem;
+    }
+    .profil-empty {
+        width: 50%;
+    }
 }
 
 main footer .feedback-block {

--- a/src/style.css
+++ b/src/style.css
@@ -88,9 +88,22 @@ header h1 a {
 header h1 a:hover {
     border: 2px solid black;
 }
+header h1 a #logo-carre {
+    width: 50px;
+    height: 50px;
+}
+header h1 a #logo-titre {
+    width: 64px;
+    height: 29px;
+}
+
 @media only screen and (min-width: 680px) {
     header h1 a {
         flex-direction: row;
+    }
+    header h1 a #logo-carre {
+        width: 75px;
+        height: 75px;
     }
     header h1 a #logo-titre {
         width: 100px;
@@ -105,10 +118,11 @@ header #js-profil-full-header {
 }
 main {
     background-color: #f9f8f6;
-    padding: 18px 0 48px 0;
+    padding: 1px 0 48px 0;
 }
 @media only screen and (min-width: 680px) {
     main {
+        padding-top: 18px;
         padding-left: 15px;
         padding-right: 15px;
     }

--- a/src/template.html
+++ b/src/template.html
@@ -84,7 +84,6 @@
 <section id="introduction" hidden>
     <div id="introduction-block" class="block introduction-block">
         {{ meta_introduction }}
-        <ul id="profils-cards" class="cards"></ul>
 
         <p>Vos informations personnelles sont seulement stockées sur cet appareil et ne sont pas partagées.</p>
 


### PR DESCRIPTION
Notamment sur petits écrans, on veut qu’ils soient visibles le plus rapidement possible, si possible sans scroll.

<img width="375" alt="Capture d’écran, le 2021-02-02 à 13 15 22" src="https://user-images.githubusercontent.com/3556/106644183-c31e4380-6558-11eb-8f63-b51764bb2143.png">

<img width="366" alt="Capture d’écran, le 2021-02-02 à 13 14 54" src="https://user-images.githubusercontent.com/3556/106644192-c6193400-6558-11eb-83ff-79c4ed6a6d7c.png">

<img width="973" alt="Capture d’écran, le 2021-02-02 à 13 15 32" src="https://user-images.githubusercontent.com/3556/106644205-c9acbb00-6558-11eb-83f9-9123b138e221.png">
