### PR TITLE
Tech: facilite la mise au point des tests d’intégration

### DIFF
--- a/src/scripts/tests/integration/setup-browser.js
+++ b/src/scripts/tests/integration/setup-browser.js
@@ -3,10 +3,9 @@ import playwright from 'playwright'
 let browser
 
 before(async function () {
-    // Lance un navigateur « headless ».
-    browser = await playwright[process.env.npm_config_browser].launch({
-        headless: true,
-    })
+    // Lance un navigateur « headless » (définir la variable
+    // d’environnement PWDEBUG=1 pour afficher le navigateur)
+    browser = await playwright[process.env.npm_config_browser].launch()
 })
 
 after(async function () {


### PR DESCRIPTION
Ne pas passer explicitement le paramètre `headless: true` permet d’afficher le navigateur en définissant une variable d’environnement pendant les tests d’intégration.