### PR TITLE
Tech: incomptabilité entre Parcel et @babel/preset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.13.8",
     "@babel/eslint-parser": "^7.13.8",
     "@babel/eslint-plugin": "^7.13.0",
-    "@babel/preset-env": "^7.13.5",
+    "@babel/preset-env": "<7.13.9",
     "@babel/register": "^7.13.8",
     "@mermaid-js/mermaid-cli": "^8.9.1",
     "chai": "^4.3.3",


### PR DESCRIPTION
La version 7.13.9 de @babel/preset-env a introduit un changement incompatible avec Parcel v1.

https://github.com/parcel-bundler/parcel/issues/5943