### PR TITLE
Tech: lance les tests d’abord avec WebKit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,17 @@ jobs:
         run: |
           make test-tools
 
+      - name: Run browser tests (webkit)
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 3
+          command: npm run-script test-integration
+        env:
+          BROWSER: "webkit"
+          DEBUG: "pw:api"
+
       - name: Run browser tests (chromium)
         uses: nick-invision/retry@v2
         with:
@@ -70,17 +81,6 @@ jobs:
           command: npm run-script test-integration
         env:
           BROWSER: "firefox"
-          DEBUG: "pw:api"
-
-      - name: Run browser tests (webkit)
-        uses: nick-invision/retry@v2
-        with:
-          max_attempts: 3
-          retry_on: error
-          timeout_minutes: 3
-          command: npm run-script test-integration
-        env:
-          BROWSER: "webkit"
           DEBUG: "pw:api"
 
       - name: Check links


### PR DESCRIPTION
C’est fréquent qu’ils échouent en ce moment, donc on va gagner du temps !