### PR TITLE
Ajoute les règles particulières du couvre-feu en Martinique

### DIFF
--- a/contenus/conseils/README.md
+++ b/contenus/conseils/README.md
@@ -147,7 +147,7 @@ Un **couvre-feu** s’applique en Guadeloupe de 22 h à 6 h du matin.
 
 <div class="conseil conseil-jaune">
 
-Un **couvre-feu** s’applique en Martinique de 22 h à 5 h du matin. À partir du jeudi 1<sup>er</sup> avril, il sera avancé à 19h.
+Un **couvre-feu** s’applique en Martinique de 22 h à 5 h du matin. À partir du jeudi 1<sup>er</sup> avril, il sera avancé à 19 h.
 
 </div>
 
@@ -820,5 +820,4 @@ Pour vos **déplacements** :
   * pour plus d’informations sur [vos déplacements ou voyages](https://www.gouvernement.fr/info-coronavirus#questions__reponses) (choisir la thématique « Sur mes déplacements et mes voyages »).
 
 Si vous êtes victime ou témoin de **violences conjugales**, vous pouvez contacter le <a href="tel:3919">39 19</a> (appel gratuit, de 9 h à 19 h du lundi au samedi) ou le <a href="tel:17">17</a> en cas d’urgence.
-
 

--- a/contenus/conseils/README.md
+++ b/contenus/conseils/README.md
@@ -143,6 +143,17 @@ Un **couvre-feu** s’applique en Guadeloupe de 22 h à 6 h du matin.
 
 
 
+## [conseils_couvre_feu_972.md](conseils_couvre_feu_972.md)
+
+<div class="conseil conseil-jaune">
+
+Un **couvre-feu** s’applique en Martinique de 22 h à 5 h du matin. À partir du jeudi 1<sup>er</sup> avril, il sera avancé à 19h.
+
+</div>
+
+
+
+
 ## [conseils_couvre_feu_973.md](conseils_couvre_feu_973.md)
 
 <div class="conseil conseil-jaune">

--- a/contenus/conseils/conseils_couvre_feu_972.md
+++ b/contenus/conseils/conseils_couvre_feu_972.md
@@ -1,0 +1,6 @@
+<div class="conseil conseil-jaune">
+
+Un **couvre-feu** s’applique en Martinique de 22 h à 5 h du matin. À partir du jeudi 1<sup>er</sup> avril, il sera avancé à 19h.
+
+</div>
+

--- a/contenus/conseils/conseils_couvre_feu_972.md
+++ b/contenus/conseils/conseils_couvre_feu_972.md
@@ -1,6 +1,5 @@
 <div class="conseil conseil-jaune">
 
-Un **couvre-feu** s’applique en Martinique de 22 h à 5 h du matin. À partir du jeudi 1<sup>er</sup> avril, il sera avancé à 19h.
+Un **couvre-feu** s’applique en Martinique de 22 h à 5 h du matin. À partir du jeudi 1<sup>er</sup> avril, il sera avancé à 19 h.
 
 </div>
-

--- a/src/scripts/algorithme/orientation.js
+++ b/src/scripts/algorithme/orientation.js
@@ -474,6 +474,8 @@ export default class AlgorithmeOrientation {
             blockNames.push('conseils-confinement')
         } else if (this.profil.departement === '971') {
             blockNames.push('conseils-couvre-feu-971')
+        } else if (this.profil.departement === '972') {
+            blockNames.push('conseils-couvre-feu-972')
         } else if (this.profil.departement === '973') {
             blockNames.push('conseils-couvre-feu-973')
         } else if (this.profil.departement === '974') {

--- a/src/scripts/tests/test.algorithme.orientation.js
+++ b/src/scripts/tests/test.algorithme.orientation.js
@@ -820,6 +820,16 @@ describe('Blocs d’informations additionnels', function () {
                 'conseils-couvre-feu-971',
             ])
         })
+        it('En Martinique, c’est un couvre-feu adapté', function () {
+            var profil = new Profil('mes_infos', {
+                departement: '972',
+            })
+            var algoOrientation = new AlgorithmeOrientation(profil)
+            assert.deepEqual(algoOrientation.vieQuotidienneBlockNamesToDisplay(), [
+                'conseils-vie-quotidienne',
+                'conseils-couvre-feu-972',
+            ])
+        })
         it('En Guyane, c’est un couvre-feu adapté', function () {
             var profil = new Profil('mes_infos', {
                 departement: '973',

--- a/src/template.html
+++ b/src/template.html
@@ -1213,6 +1213,9 @@
                         <div id="conseils-couvre-feu-971" hidden>
                             {{ conseils_couvre_feu_971 }}
                         </div>
+                        <div id="conseils-couvre-feu-972" hidden>
+                            {{ conseils_couvre_feu_972 }}
+                        </div>
                         <div id="conseils-couvre-feu-973" hidden>
                             {{ conseils_couvre_feu_973 }}
                         </div>


### PR DESCRIPTION
https://www.martinique.gouv.fr/Politiques-publiques/Environnement-sante-publique/Sante/Informations-COVID-19/Renforcement-des-mesures-sanitaires-pour-freiner-la-circulation-du-virus-de-la-covid-19