### PR TITLE
Dynamisation des liens pour dépistage/vaccination

### DIFF
--- a/check.py
+++ b/check.py
@@ -39,10 +39,20 @@ class LinkExtractor(HTMLParser):
 
 @cli
 def links(timeout: int = 10, delay: float = 0.1):
+    dynamically_generated_links_via_injection = {
+        "https://www.sante.fr/cf/centres-vaccination-covid/departement-22-cotes-d'armor.html",
+        "https://www.sante.fr/cf/centres-vaccination-covid/departement-20A-corse-du-sud.html",
+        "https://www.sante.fr/cf/centres-vaccination-covid/departement-01-ain.html",
+        "https://www.sante.fr/cf/centres-vaccination-covid.html",
+        "https://www.sante.fr/cf/centres-depistage-covid/departement-01.html",
+        "https://www.sante.fr/cf/centres-depistage-covid/departement-2A.html",
+        "https://www.sante.fr/cf/centres-depistage-covid.html",
+    }
     parser = LinkExtractor()
     content = (SRC_DIR / "index.html").read_text()
     parser.feed(content)
-    for link in sorted(parser.links):
+    links = parser.links.union(dynamically_generated_links_via_injection)
+    for link in sorted(links):
         print(link)
         with httpx.stream(
             "GET",

--- a/contenus/conseils/README.md
+++ b/contenus/conseils/README.md
@@ -399,7 +399,7 @@ Vous avez passé du temps avec quelqu’un de positif, mais il ne s’agit pas *
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement**.
-2. **Refaire un test antigénique immédiatement**, si votre dernier test date d’avant votre dernier contact à risque (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+2. **Refaire un test antigénique immédiatement**, si votre dernier test date d’avant votre dernier contact à risque (voir la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>.
     * Si le test est **positif**, restez **en isolement au moins 10 jours** à partir de la date du test, et renseignez le [résultat du test](#depistage) pour mettre à jour ces conseils.
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après le dernier contact à risque** ;
         * s’il est **négatif**, vous pourrez lever votre isolement ;
@@ -429,7 +429,7 @@ Nous vous conseillons de :
 Même si vous avez été vacciné‚ nous vous conseillons de :
 
 1. Vous maintenir **en isolement**.
-2. Faire un **test antigénique immédiatement** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+2. Faire un **test antigénique immédiatement** (voir la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>).
     * Si le test est **positif**, restez **en isolement au moins 10 jours** à partir de la date du test, et renseignez le [résultat du test](#depistage) pour mettre à jour ces conseils.
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après la guérison** de la personne malade ;
         * s’il est **négatif**, vous pourrez lever votre isolement ;
@@ -445,7 +445,7 @@ Même si vous avez été vacciné‚ nous vous conseillons de :
 Même si vous avez été vacciné‚ nous vous conseillons de :
 
 1. Vous maintenir **en isolement**.
-2. Faire un **test antigénique immédiatement** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+2. Faire un **test antigénique immédiatement** (voir la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>).
     * Si le test est **positif**, restez **en isolement au moins 10 jours** à partir de la date du test, et renseignez le [résultat du test](#depistage) pour mettre à jour ces conseils.
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après le dernier contact à risque** ;
         * s’il est **négatif**, vous pourrez lever votre isolement ;
@@ -460,11 +460,11 @@ Même si vous avez été vacciné‚ nous vous conseillons de :
 
 Nous vous conseillons de :
 
-1. **Réaliser un test RT-PCR en laboratoire** en consultant [la carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html) (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
+1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes. Jusqu’au résultat du test RT-PCR :
     * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Si vous constatez l’apparition de **symptômes**, vous pouvez suivre leur évolution avec le [questionnaire de suivi](#suivisymptomes).
 5. Contacter vos proches et les personnes que vous avez croisés dernièrement pour **limiter la chaîne de transmission**. Des outils, comme par exemple l’outil [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées et des lieux que vous avez fréquentés depuis le début de votre période contagieuse.
 6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
@@ -476,11 +476,11 @@ Nous vous conseillons de :
 
 Nous vous conseillons de :
 
-1. **Réaliser un test RT-PCR en laboratoire** en consultant [la carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html) (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
+1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes. Jusqu’au résultat du test RT-PCR :
     * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
 5. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
@@ -493,7 +493,7 @@ Nous vous conseillons de :
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date du test. Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 3. Si vous constatez l’apparition de **symptômes**, vous pouvez suivre leur évolution avec le [questionnaire de suivi](#suivisymptomes).
 4. Contacter vos proches et les personnes que vous avez croisés dernièrement pour **limiter la chaîne de transmission**. Des outils, comme par exemple l’outil [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées et des lieux que vous avez fréquentés depuis le début de votre période contagieuse.
 5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
@@ -506,7 +506,7 @@ Nous vous conseillons de :
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date d’apparition des symptômes, et de contacter votre médecin au moindre doute. Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 3. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
 4. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
@@ -546,7 +546,7 @@ Nous vous conseillons de **préciser au 15** :
 Même si vous avez été vacciné‚ nous vous conseillons de :
 
 1. **Contacter votre médecin généraliste**.
-2. **Réaliser un test** en consultant [la carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html) (vous serez prioritaire). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
+2. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
 3. Vous maintenir **en isolement** jusqu’au résultat du test :
     * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
@@ -586,7 +586,7 @@ Retrouvez tous les conseils en [vidéo](https://www.youtube.com/watch?v=sckUau7q
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement** au moins 10 jours à partir de la date d’apparition des symptômes.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 3. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 4. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
 5. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
@@ -599,9 +599,9 @@ Retrouvez tous les conseils en [vidéo](https://www.youtube.com/watch?v=sckUau7q
 
 Nous vous conseillons de :
 
-1. **Réaliser un test RT-PCR en laboratoire** en consultant [la carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html) (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
+1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
 6. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
@@ -613,7 +613,7 @@ Nous vous conseillons de :
 
 Nous vous conseillons de :
 
-1. **Réaliser un test** en consultant [la carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
+1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>. Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
 2. Vous maintenir **en isolement** jusqu’au résultat du test. Si le résultat est négatif, vous pourrez mettre fin à votre isolement.
 3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 4. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
@@ -683,7 +683,7 @@ Le **chômage partiel** peut être réactivé pour les parents dans l’obligati
 
 <div class="conseil">
 
-Retrouvez le [lieu de test le plus proche](https://www.sante.fr/cf/centres-depistage-covid.html).
+Retrouvez le <a href="#conseils-depistage" class="lien-depistage">lieu de test le plus proche</a>.
 
 </div>
 
@@ -703,7 +703,7 @@ Retrouvez le [lieu de test le plus proche](https://www.sante.fr/cf/centres-depis
 
 <div class="conseil">
 
-Retrouvez le [lieu de test le plus proche](https://www.sante.fr/cf/centres-depistage-covid.html).
+Retrouvez le <a href="#conseils-depistage" class="lien-depistage">lieu de test le plus proche</a>.
 
 </div>
 
@@ -743,11 +743,11 @@ Vous avez plus de 50 ans, et vous êtes considéré·e comme une personne ayant
 
 <div class="conseil">
 
-Vous avez plus de 75 ans, **vous pouvez vous faire vacciner dès maintenant**. Nous vous invitons à <a href="#conseils-vaccins" id="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
+Vous avez plus de 75 ans, **vous pouvez vous faire vacciner dès maintenant**. Nous vous invitons à <a href="#conseils-vaccins" class="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
 
 Les plages de rendez-vous sont ouvertes au fur et à mesure par les centres de vaccination.
 
-Si vous n’arrivez à trouver un rendez-vous en ligne, vous pouvez appeler le centre de vaccination au numéro indiqué sur <a href="#conseils-vaccins" id="lien-vaccination">la liste des lieux de vaccination</a> et leur demander de vous inscrire sur **liste d’attente**. N’hésitez pas à vous rapprocher de votre mairie, certaines gérent également des listes d’attentes.
+Si vous n’arrivez à trouver un rendez-vous en ligne, vous pouvez appeler le centre de vaccination au numéro indiqué sur <a href="#conseils-vaccins" class="lien-vaccination">la liste des lieux de vaccination</a> et leur demander de vous inscrire sur **liste d’attente**. N’hésitez pas à vous rapprocher de votre mairie, certaines gérent également des listes d’attentes.
 
 </div>
 
@@ -757,7 +757,7 @@ Si vous n’arrivez à trouver un rendez-vous en ligne, vous pouvez appeler le c
 
 <div class="conseil">
 
-Tou·tes les professionnel·les de santé, **peuvent se faire vacciner dès maintenant**. Nous vous invitons à <a href="#conseils-vaccins" id="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
+Tou·tes les professionnel·les de santé, **peuvent se faire vacciner dès maintenant**. Nous vous invitons à <a href="#conseils-vaccins" class="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
 
 </div>
 
@@ -851,7 +851,7 @@ Pour en savoir plus :
 
 <div class="conseil">
 
-Vous présentez un risque de développement d’une forme grave de Covid, **vous pouvez vous faire vacciner dès maintenant**. Nous vous invitons à consulter votre médecin pour obtenir une **ordonnance**, avant de <a href="#conseils-vaccins" id="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
+Vous présentez un risque de développement d’une forme grave de Covid, **vous pouvez vous faire vacciner dès maintenant**. Nous vous invitons à consulter votre médecin pour obtenir une **ordonnance**, avant de <a href="#conseils-vaccins" class="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
 
 </div>
 

--- a/contenus/conseils/conseils_personnels_contact_à_risque_avec_test.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_avec_test.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement**.
-2. **Refaire un test antigénique immédiatement**, si votre dernier test date d’avant votre dernier contact à risque (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+2. **Refaire un test antigénique immédiatement**, si votre dernier test date d’avant votre dernier contact à risque (voir la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>.
     * Si le test est **positif**, restez **en isolement au moins 10 jours** à partir de la date du test, et renseignez le [résultat du test](#depistage) pour mettre à jour ces conseils.
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après le dernier contact à risque** ;
         * s’il est **négatif**, vous pourrez lever votre isolement ;

--- a/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_sans_depistage.md
@@ -1,7 +1,7 @@
 Même si vous avez été vacciné‚ nous vous conseillons de :
 
 1. Vous maintenir **en isolement**.
-2. Faire un **test antigénique immédiatement** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+2. Faire un **test antigénique immédiatement** (voir la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>).
     * Si le test est **positif**, restez **en isolement au moins 10 jours** à partir de la date du test, et renseignez le [résultat du test](#depistage) pour mettre à jour ces conseils.
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après la guérison** de la personne malade ;
         * s’il est **négatif**, vous pourrez lever votre isolement ;

--- a/contenus/conseils/conseils_personnels_contact_à_risque_sans_test.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_sans_test.md
@@ -1,7 +1,7 @@
 Même si vous avez été vacciné‚ nous vous conseillons de :
 
 1. Vous maintenir **en isolement**.
-2. Faire un **test antigénique immédiatement** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+2. Faire un **test antigénique immédiatement** (voir la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>).
     * Si le test est **positif**, restez **en isolement au moins 10 jours** à partir de la date du test, et renseignez le [résultat du test](#depistage) pour mettre à jour ces conseils.
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après le dernier contact à risque** ;
         * s’il est **négatif**, vous pourrez lever votre isolement ;

--- a/contenus/conseils/conseils_personnels_depistage_positif_antigenique_asymptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_antigenique_asymptomatique.md
@@ -1,10 +1,10 @@
 Nous vous conseillons de :
 
-1. **Réaliser un test RT-PCR en laboratoire** en consultant [la carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html) (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
+1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes. Jusqu’au résultat du test RT-PCR :
     * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Si vous constatez l’apparition de **symptômes**, vous pouvez suivre leur évolution avec le [questionnaire de suivi](#suivisymptomes).
 5. Contacter vos proches et les personnes que vous avez croisés dernièrement pour **limiter la chaîne de transmission**. Des outils, comme par exemple l’outil [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées et des lieux que vous avez fréquentés depuis le début de votre période contagieuse.
 6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».

--- a/contenus/conseils/conseils_personnels_depistage_positif_antigenique_symptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_antigenique_symptomatique.md
@@ -1,10 +1,10 @@
 Nous vous conseillons de :
 
-1. **Réaliser un test RT-PCR en laboratoire** en consultant [la carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html) (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
+1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes. Jusqu’au résultat du test RT-PCR :
     * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
 5. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».

--- a/contenus/conseils/conseils_personnels_depistage_positif_asymptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_asymptomatique.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date du test. Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 3. Si vous constatez l’apparition de **symptômes**, vous pouvez suivre leur évolution avec le [questionnaire de suivi](#suivisymptomes).
 4. Contacter vos proches et les personnes que vous avez croisés dernièrement pour **limiter la chaîne de transmission**. Des outils, comme par exemple l’outil [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées et des lieux que vous avez fréquentés depuis le début de votre période contagieuse.
 5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».

--- a/contenus/conseils/conseils_personnels_depistage_positif_symptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_symptomatique.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date d’apparition des symptômes, et de contacter votre médecin au moindre doute. Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 3. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
 4. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».

--- a/contenus/conseils/conseils_personnels_symptômes_actuels_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_symptômes_actuels_sans_depistage.md
@@ -1,7 +1,7 @@
 Même si vous avez été vacciné‚ nous vous conseillons de :
 
 1. **Contacter votre médecin généraliste**.
-2. **Réaliser un test** en consultant [la carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html) (vous serez prioritaire). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
+2. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
 3. Vous maintenir **en isolement** jusqu’au résultat du test :
     * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.

--- a/contenus/conseils/conseils_personnels_symptômes_passés_positif.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_positif.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement** au moins 10 jours à partir de la date d’apparition des symptômes.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 3. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 4. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
 5. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !

--- a/contenus/conseils/conseils_personnels_symptômes_passés_positif_antigenique.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_positif_antigenique.md
@@ -1,8 +1,8 @@
 Nous vous conseillons de :
 
-1. **Réaliser un test RT-PCR en laboratoire** en consultant [la carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html) (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
+1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à [réaliser un test](https://www.sante.fr/cf/centres-depistage-covid.html).
+3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
 6. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !

--- a/contenus/conseils/conseils_personnels_symptômes_passés_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_sans_depistage.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. **Réaliser un test** en consultant [la carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
+1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>. Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
 2. Vous maintenir **en isolement** jusqu’au résultat du test. Si le résultat est négatif, vous pourrez mettre fin à votre isolement.
 3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 4. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.

--- a/contenus/conseils/conseils_tests.md
+++ b/contenus/conseils/conseils_tests.md
@@ -1,6 +1,6 @@
 <div class="conseil">
 
-Retrouvez le [lieu de test le plus proche](https://www.sante.fr/cf/centres-depistage-covid.html).
+Retrouvez le <a href="#conseils-depistage" class="lien-depistage">lieu de test le plus proche</a>.
 
 </div>
 

--- a/contenus/conseils/conseils_tests_rt_pcr.md
+++ b/contenus/conseils/conseils_tests_rt_pcr.md
@@ -1,6 +1,6 @@
 <div class="conseil">
 
-Retrouvez le [lieu de test le plus proche](https://www.sante.fr/cf/centres-depistage-covid.html).
+Retrouvez le <a href="#conseils-depistage" class="lien-depistage">lieu de test le plus proche</a>.
 
 </div>
 

--- a/contenus/conseils/conseils_vaccins_75_ans.md
+++ b/contenus/conseils/conseils_vaccins_75_ans.md
@@ -1,9 +1,9 @@
 <div class="conseil">
 
-Vous avez plus de 75 ans, **vous pouvez vous faire vacciner dès maintenant**. Nous vous invitons à <a href="#conseils-vaccins" id="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
+Vous avez plus de 75 ans, **vous pouvez vous faire vacciner dès maintenant**. Nous vous invitons à <a href="#conseils-vaccins" class="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
 
 Les plages de rendez-vous sont ouvertes au fur et à mesure par les centres de vaccination.
 
-Si vous n’arrivez à trouver un rendez-vous en ligne, vous pouvez appeler le centre de vaccination au numéro indiqué sur <a href="#conseils-vaccins" id="lien-vaccination">la liste des lieux de vaccination</a> et leur demander de vous inscrire sur **liste d’attente**. N’hésitez pas à vous rapprocher de votre mairie, certaines gérent également des listes d’attentes.
+Si vous n’arrivez à trouver un rendez-vous en ligne, vous pouvez appeler le centre de vaccination au numéro indiqué sur <a href="#conseils-vaccins" class="lien-vaccination">la liste des lieux de vaccination</a> et leur demander de vous inscrire sur **liste d’attente**. N’hésitez pas à vous rapprocher de votre mairie, certaines gérent également des listes d’attentes.
 
 </div>

--- a/contenus/conseils/conseils_vaccins_activite_pro_sante.md
+++ b/contenus/conseils/conseils_vaccins_activite_pro_sante.md
@@ -1,5 +1,5 @@
 <div class="conseil">
 
-Tou·tes les professionnel·les de santé, **peuvent se faire vacciner dès maintenant**. Nous vous invitons à <a href="#conseils-vaccins" id="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
+Tou·tes les professionnel·les de santé, **peuvent se faire vacciner dès maintenant**. Nous vous invitons à <a href="#conseils-vaccins" class="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
 
 </div>

--- a/contenus/conseils/conseils_vaccins_tres_haut_risque.md
+++ b/contenus/conseils/conseils_vaccins_tres_haut_risque.md
@@ -1,5 +1,5 @@
 <div class="conseil">
 
-Vous présentez un risque de développement d’une forme grave de Covid, **vous pouvez vous faire vacciner dès maintenant**. Nous vous invitons à consulter votre médecin pour obtenir une **ordonnance**, avant de <a href="#conseils-vaccins" id="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
+Vous présentez un risque de développement d’une forme grave de Covid, **vous pouvez vous faire vacciner dès maintenant**. Nous vous invitons à consulter votre médecin pour obtenir une **ordonnance**, avant de <a href="#conseils-vaccins" class="lien-vaccination">prendre rendez-vous dans le centre de vaccination le plus proche</a>.
 
 </div>

--- a/src/scripts/injection.js
+++ b/src/scripts/injection.js
@@ -5,6 +5,8 @@ import ctaiTelephones from './data/ctaiTelephones'
 import ctaiCourriels from './data/ctaiCourriels'
 import departements from './data/departements'
 
+import { slugify } from './utils'
+
 export function nomProfil(element, app) {
     if (!element) return
     element.textContent = app.profil.affichageNom()
@@ -52,14 +54,41 @@ export function CTAIContact(element, departement) {
     element.innerHTML = contactHTML.join(' ou ')
 }
 
-export function lienVaccination(element, departement) {
-    // Pas de distinction pour la Corse sur le site de sante.fr.
-    if (departement === '2A' || departement == '2B') {
-        departement = '20'
+export function lienDepistage(element, departement) {
+    if (departement === '00' /* Autre. */) {
+        element.setAttribute(
+            'href',
+            'https://www.sante.fr/cf/centres-depistage-covid.html'
+        )
+        return
     }
     element.setAttribute(
         'href',
-        `https://www.sante.fr/centres-vaccination-covid.html#dep-${departement}`
+        `https://www.sante.fr/cf/centres-depistage-covid/departement-${departement}.html`
+    )
+}
+
+export function lienVaccination(element, departement) {
+    if (departement === '00' /* Autre. */) {
+        element.setAttribute(
+            'href',
+            'https://www.sante.fr/cf/centres-vaccination-covid.html'
+        )
+        return
+    }
+    const departementName = departements[departement]
+    const departementSlug = slugify(departementName)
+    // Subtile façon de nommer les codes des départements de la Corse
+    // sur le site de sante.fr.
+    if (departement === '2A') {
+        departement = '20A'
+    }
+    if (departement == '2B') {
+        departement = '20B'
+    }
+    element.setAttribute(
+        'href',
+        `https://www.sante.fr/cf/centres-vaccination-covid/departement-${departement}-${departementSlug}.html`
     )
 }
 

--- a/src/scripts/page/conseils.js
+++ b/src/scripts/page/conseils.js
@@ -145,8 +145,11 @@ export function dynamicDataInjection(element, profil, algoOrientation) {
     injection.dateConseils(element.querySelector('#conseils-block-date'))
 
     injection.departement(element.querySelector('#nom-departement'), profil.departement)
-    Array.from(element.querySelectorAll('#lien-vaccination')).forEach((link) => {
+    Array.from(element.querySelectorAll('.lien-vaccination')).forEach((link) => {
         injection.lienVaccination(link, profil.departement)
+    })
+    Array.from(element.querySelectorAll('.lien-depistage')).forEach((link) => {
+        injection.lienDepistage(link, profil.departement)
     })
     const lienPrefecture = element.querySelector('#lien-prefecture')
     if (lienPrefecture) {

--- a/src/scripts/tests/test.injection.js
+++ b/src/scripts/tests/test.injection.js
@@ -82,12 +82,25 @@ describe('Injection', function () {
         var dom = new JSDOM(`<!DOCTYPE html><div></div>`)
         var element = dom.window.document.querySelector('div')
         element.innerHTML =
-            '<a href="#conseils-departement" id="lien-vaccination">Site</a>'
-        injection.lienVaccination(element.querySelector('#lien-vaccination'), '01')
+            '<a href="#conseils-departement" class="lien-vaccination">Site</a>'
+        injection.lienVaccination(element.querySelector('.lien-vaccination'), '01')
 
         assert.strictEqual(
             element.innerHTML,
-            '<a href="https://www.sante.fr/centres-vaccination-covid.html#dep-01" id="lien-vaccination">Site</a>'
+            '<a href="https://www.sante.fr/cf/centres-vaccination-covid/departement-01-ain.html" class="lien-vaccination">Site</a>'
+        )
+    })
+
+    it("Lien vaccination Côtes-d'Armor", function () {
+        var dom = new JSDOM(`<!DOCTYPE html><div></div>`)
+        var element = dom.window.document.querySelector('div')
+        element.innerHTML =
+            '<a href="#conseils-departement" class="lien-vaccination">Site</a>'
+        injection.lienVaccination(element.querySelector('.lien-vaccination'), '22')
+
+        assert.strictEqual(
+            element.innerHTML,
+            `<a href="https://www.sante.fr/cf/centres-vaccination-covid/departement-22-cotes-d'armor.html" class="lien-vaccination">Site</a>`
         )
     })
 
@@ -95,12 +108,64 @@ describe('Injection', function () {
         var dom = new JSDOM(`<!DOCTYPE html><div></div>`)
         var element = dom.window.document.querySelector('div')
         element.innerHTML =
-            '<a href="#conseils-departement" id="lien-vaccination">Site</a>'
-        injection.lienVaccination(element.querySelector('#lien-vaccination'), '2A')
+            '<a href="#conseils-departement" class="lien-vaccination">Site</a>'
+        injection.lienVaccination(element.querySelector('.lien-vaccination'), '2A')
 
         assert.strictEqual(
             element.innerHTML,
-            '<a href="https://www.sante.fr/centres-vaccination-covid.html#dep-20" id="lien-vaccination">Site</a>'
+            '<a href="https://www.sante.fr/cf/centres-vaccination-covid/departement-20A-corse-du-sud.html" class="lien-vaccination">Site</a>'
+        )
+    })
+
+    it('Lien vaccination Autre', function () {
+        var dom = new JSDOM(`<!DOCTYPE html><div></div>`)
+        var element = dom.window.document.querySelector('div')
+        element.innerHTML =
+            '<a href="#conseils-departement" class="lien-vaccination">Site</a>'
+        injection.lienVaccination(element.querySelector('.lien-vaccination'), '00')
+
+        assert.strictEqual(
+            element.innerHTML,
+            '<a href="https://www.sante.fr/cf/centres-vaccination-covid.html" class="lien-vaccination">Site</a>'
+        )
+    })
+
+    it('Lien depistage', function () {
+        var dom = new JSDOM(`<!DOCTYPE html><div></div>`)
+        var element = dom.window.document.querySelector('div')
+        element.innerHTML =
+            '<a href="#conseils-departement" class="lien-depistage">Site</a>'
+        injection.lienDepistage(element.querySelector('.lien-depistage'), '01')
+
+        assert.strictEqual(
+            element.innerHTML,
+            '<a href="https://www.sante.fr/cf/centres-depistage-covid/departement-01.html" class="lien-depistage">Site</a>'
+        )
+    })
+
+    it('Lien depistage Corse', function () {
+        var dom = new JSDOM(`<!DOCTYPE html><div></div>`)
+        var element = dom.window.document.querySelector('div')
+        element.innerHTML =
+            '<a href="#conseils-departement" class="lien-depistage">Site</a>'
+        injection.lienDepistage(element.querySelector('.lien-depistage'), '2A')
+
+        assert.strictEqual(
+            element.innerHTML,
+            '<a href="https://www.sante.fr/cf/centres-depistage-covid/departement-2A.html" class="lien-depistage">Site</a>'
+        )
+    })
+
+    it('Lien depistage Autre', function () {
+        var dom = new JSDOM(`<!DOCTYPE html><div></div>`)
+        var element = dom.window.document.querySelector('div')
+        element.innerHTML =
+            '<a href="#conseils-departement" class="lien-depistage">Site</a>'
+        injection.lienDepistage(element.querySelector('.lien-depistage'), '00')
+
+        assert.strictEqual(
+            element.innerHTML,
+            '<a href="https://www.sante.fr/cf/centres-depistage-covid.html" class="lien-depistage">Site</a>'
         )
     })
 

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -21,3 +21,24 @@ export function differenceEnJours(d1, d2) {
 
     return Math.floor((utc2 - utc1) / _MS_PAR_JOUR)
 }
+
+export function slugify(string) {
+    /* Adapted from
+    https://mhagemann.medium.com/the-ultimate-way-to-slugify-a-url-string-in-javascript-b8e4a0d849e1 */
+    const a =
+        'àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/_,:;'
+    const b =
+        'aaaaaaaaaacccddeeeeeeeegghiiiiiilmnnnnoooooooooprrsssssttuuuuuuuuuwxyyzzz------'
+    const p = new RegExp(a.split('').join('|'), 'g')
+
+    return string
+        .toString()
+        .toLowerCase()
+        .replace(/\s+/g, '-') // Replace spaces with -
+        .replace(p, (c) => b.charAt(a.indexOf(c))) // Replace special characters
+        .replace(/’/g, "'") // Turn apostrophes to single quotes
+        .replace(/[^a-zA-Z0-9-']+/g, '') // Remove all non-word characters except single quotes
+        .replace(/--+/g, '-') // Replace multiple - with single -
+        .replace(/^-+/, '') // Trim - from start of text
+        .replace(/-+$/, '') // Trim - from end of text
+}


### PR DESCRIPTION
Suite au lien cassé sur https://www.sante.fr/centres-vaccination-covid.html je me suis rendu compte que l’on pouvait aussi rendre dynamiques les liens vers les lieux de dépistage.