### PR TITLE
Filtre les conseils personnels selon la situation

### DIFF
--- a/build.py
+++ b/build.py
@@ -31,13 +31,20 @@ class FrenchTypographyMixin:
 
 
 class CSSMixin:
+    """Possibilité d’ajouter une classe CSS sur une ligne de liste.
+
+    Par exemple :
+
+    * {.maClasse} item classique de la liste en markdown
+    """
+
     RE_CLASS = re.compile(
         r"""^
-                (?P<before>.*?)
-                (?:\s*\{\.(?P<class>[\w\-]+?)\}\s*)
-                (?P<after>.*)
-                $
-            """,
+            (?P<before>.*?)
+            (?:\s*\{\.(?P<class>[\w\-]+?)\}\s*)
+            (?P<after>.*)
+            $
+        """,
         re.MULTILINE | re.VERBOSE,
     )
 

--- a/contenus/conseils/README.md
+++ b/contenus/conseils/README.md
@@ -409,7 +409,7 @@ Nous vous conseillons de :
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après le dernier contact à risque** ;
         * s’il est **négatif**, vous pourrez lever votre isolement ;
         * s’il est **positif**, restez en isolement **au moins 10 jours** à partir de la date du test, et surveillez l’apparition de symptômes.
-5. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+5. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 6. Si vous constatez l’apparition de **symptômes**, contactez votre médecin et faites vous tester. Vous pouvez suivre l’évolution de vos symptômes avec le [questionnaire de suivi](#suivisymptomes).
 7. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
 
@@ -455,7 +455,7 @@ Même si vous avez été vacciné‚ nous vous conseillons de :
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après le dernier contact à risque** ;
         * s’il est **négatif**, vous pourrez lever votre isolement ;
         * s’il est **positif**, restez en isolement **au moins 10 jours** à partir de la date du test, et surveillez l’apparition de symptômes.
-5. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+5. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 6. Si vous constatez l’apparition de **symptômes**, contactez votre médecin et faites vous tester. Vous pouvez suivre l’évolution de vos symptômes avec le [questionnaire de suivi](#suivisymptomes).
 7. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
 
@@ -467,9 +467,9 @@ Nous vous conseillons de :
 
 1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes. Jusqu’au résultat du test RT-PCR :
-    * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
+    * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Si vous constatez l’apparition de **symptômes**, vous pouvez suivre leur évolution avec le [questionnaire de suivi](#suivisymptomes).
 5. Contacter vos proches et les personnes que vous avez croisés dernièrement pour **limiter la chaîne de transmission**. Des outils, comme par exemple l’outil [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées et des lieux que vous avez fréquentés depuis le début de votre période contagieuse.
 6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
@@ -483,9 +483,9 @@ Nous vous conseillons de :
 
 1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes. Jusqu’au résultat du test RT-PCR :
-    * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
+    * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
 5. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
@@ -497,12 +497,13 @@ Nous vous conseillons de :
 
 Nous vous conseillons de :
 
-1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date du test. Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
-3. Si vous constatez l’apparition de **symptômes**, vous pouvez suivre leur évolution avec le [questionnaire de suivi](#suivisymptomes).
-4. Contacter vos proches et les personnes que vous avez croisés dernièrement pour **limiter la chaîne de transmission**. Des outils, comme par exemple l’outil [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées et des lieux que vous avez fréquentés depuis le début de votre période contagieuse.
-5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
-6. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
+1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date du test.
+2. {.seulement-si-activite-pro} Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+4. Si vous constatez l’apparition de **symptômes**, vous pouvez suivre leur évolution avec le [questionnaire de suivi](#suivisymptomes).
+5. Contacter vos proches et les personnes que vous avez croisés dernièrement pour **limiter la chaîne de transmission**. Des outils, comme par exemple l’outil [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées et des lieux que vous avez fréquentés depuis le début de votre période contagieuse.
+6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
+7. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
 
 
 
@@ -510,12 +511,13 @@ Nous vous conseillons de :
 
 Nous vous conseillons de :
 
-1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date d’apparition des symptômes, et de contacter votre médecin au moindre doute. Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
-3. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
-4. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
-5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
-6. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
+1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date d’apparition des symptômes, et de contacter votre médecin au moindre doute.
+2. {.seulement-si-activite-pro} Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+4. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
+5. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
+6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
+7. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
 
 
 
@@ -525,9 +527,9 @@ Nous vous conseillons de :
 
 1. **Contacter votre médecin généraliste** pour lui parler de vos symptômes.
 2. Vous maintenir **en isolement** jusqu’au résultat du test :
-    * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
+    * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 4. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
 5. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 6. Revenir sur Mes Conseils Covid **quand vous aurez reçu vos résultats** afin d’avoir les conseils adaptés à votre nouvelle situation !
@@ -553,9 +555,9 @@ Même si vous avez été vacciné‚ nous vous conseillons de :
 1. **Contacter votre médecin généraliste**.
 2. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
 3. Vous maintenir **en isolement** jusqu’au résultat du test :
-    * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
+    * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-4. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+4. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 5. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
 6. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 7. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
@@ -578,7 +580,7 @@ Nous vous conseillons de **préciser au 15** :
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement** jusqu’au résultat du test.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+2. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 3. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 4. Revenir sur Mes Conseils Covid **quand vous aurez reçu vos résultats** afin d’avoir les conseils adaptés à votre nouvelle situation !
 
@@ -591,7 +593,7 @@ Retrouvez tous les conseils en [vidéo](https://www.youtube.com/watch?v=sckUau7q
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement** au moins 10 jours à partir de la date d’apparition des symptômes.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+2. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 3. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 4. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
 5. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
@@ -606,7 +608,7 @@ Nous vous conseillons de :
 
 1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
 6. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
@@ -620,7 +622,7 @@ Nous vous conseillons de :
 
 1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>. Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
 2. Vous maintenir **en isolement** jusqu’au résultat du test. Si le résultat est négatif, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 4. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 5. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
 

--- a/contenus/conseils/conseils_personnels_contact_à_risque_avec_test.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_avec_test.md
@@ -6,6 +6,6 @@ Nous vous conseillons de :
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après le dernier contact à risque** ;
         * s’il est **négatif**, vous pourrez lever votre isolement ;
         * s’il est **positif**, restez en isolement **au moins 10 jours** à partir de la date du test, et surveillez l’apparition de symptômes.
-5. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+5. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 6. Si vous constatez l’apparition de **symptômes**, contactez votre médecin et faites vous tester. Vous pouvez suivre l’évolution de vos symptômes avec le [questionnaire de suivi](#suivisymptomes).
 7. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !

--- a/contenus/conseils/conseils_personnels_contact_à_risque_sans_test.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_sans_test.md
@@ -6,6 +6,6 @@ Même si vous avez été vacciné‚ nous vous conseillons de :
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après le dernier contact à risque** ;
         * s’il est **négatif**, vous pourrez lever votre isolement ;
         * s’il est **positif**, restez en isolement **au moins 10 jours** à partir de la date du test, et surveillez l’apparition de symptômes.
-5. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+5. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 6. Si vous constatez l’apparition de **symptômes**, contactez votre médecin et faites vous tester. Vous pouvez suivre l’évolution de vos symptômes avec le [questionnaire de suivi](#suivisymptomes).
 7. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !

--- a/contenus/conseils/conseils_personnels_depistage_positif_antigenique_asymptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_antigenique_asymptomatique.md
@@ -2,9 +2,9 @@ Nous vous conseillons de :
 
 1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes. Jusqu’au résultat du test RT-PCR :
-    * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
+    * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Si vous constatez l’apparition de **symptômes**, vous pouvez suivre leur évolution avec le [questionnaire de suivi](#suivisymptomes).
 5. Contacter vos proches et les personnes que vous avez croisés dernièrement pour **limiter la chaîne de transmission**. Des outils, comme par exemple l’outil [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées et des lieux que vous avez fréquentés depuis le début de votre période contagieuse.
 6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».

--- a/contenus/conseils/conseils_personnels_depistage_positif_antigenique_symptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_antigenique_symptomatique.md
@@ -2,9 +2,9 @@ Nous vous conseillons de :
 
 1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes. Jusqu’au résultat du test RT-PCR :
-    * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
+    * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
 5. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».

--- a/contenus/conseils/conseils_personnels_depistage_positif_asymptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_asymptomatique.md
@@ -1,8 +1,9 @@
 Nous vous conseillons de :
 
-1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date du test. Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
-3. Si vous constatez l’apparition de **symptômes**, vous pouvez suivre leur évolution avec le [questionnaire de suivi](#suivisymptomes).
-4. Contacter vos proches et les personnes que vous avez croisés dernièrement pour **limiter la chaîne de transmission**. Des outils, comme par exemple l’outil [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées et des lieux que vous avez fréquentés depuis le début de votre période contagieuse.
-5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
-6. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
+1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date du test.
+2. {.seulement-si-activite-pro} Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+4. Si vous constatez l’apparition de **symptômes**, vous pouvez suivre leur évolution avec le [questionnaire de suivi](#suivisymptomes).
+5. Contacter vos proches et les personnes que vous avez croisés dernièrement pour **limiter la chaîne de transmission**. Des outils, comme par exemple l’outil [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées et des lieux que vous avez fréquentés depuis le début de votre période contagieuse.
+6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
+7. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !

--- a/contenus/conseils/conseils_personnels_depistage_positif_symptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_symptomatique.md
@@ -1,8 +1,9 @@
 Nous vous conseillons de :
 
-1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date d’apparition des symptômes, et de contacter votre médecin au moindre doute. Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
-3. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
-4. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
-5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
-6. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
+1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date d’apparition des symptômes, et de contacter votre médecin au moindre doute.
+2. {.seulement-si-activite-pro} Vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+4. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
+5. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
+6. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
+7. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !

--- a/contenus/conseils/conseils_personnels_symptômes_actuels_en_attente.md
+++ b/contenus/conseils/conseils_personnels_symptômes_actuels_en_attente.md
@@ -2,9 +2,9 @@ Nous vous conseillons de :
 
 1. **Contacter votre médecin généraliste** pour lui parler de vos symptômes.
 2. Vous maintenir **en isolement** jusqu’au résultat du test :
-    * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
+    * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 4. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
 5. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 6. Revenir sur Mes Conseils Covid **quand vous aurez reçu vos résultats** afin d’avoir les conseils adaptés à votre nouvelle situation !

--- a/contenus/conseils/conseils_personnels_symptômes_actuels_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_symptômes_actuels_sans_depistage.md
@@ -3,9 +3,9 @@ Même si vous avez été vacciné‚ nous vous conseillons de :
 1. **Contacter votre médecin généraliste**.
 2. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
 3. Vous maintenir **en isolement** jusqu’au résultat du test :
-    * Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
+    * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
-4. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+4. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 5. Suivre vos **symptômes** 1 à 2 fois par jour avec le [questionnaire de suivi](#suivisymptomes) (pour y penser, ajoutez un rappel sur votre téléphone ou dans <a href="" class="js-calendar" download="rappel-covid19.ics">votre calendrier</a>).
 6. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 7. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !

--- a/contenus/conseils/conseils_personnels_symptômes_passés_en_attente.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_en_attente.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement** jusqu’au résultat du test.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+2. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 3. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 4. Revenir sur Mes Conseils Covid **quand vous aurez reçu vos résultats** afin d’avoir les conseils adaptés à votre nouvelle situation !
 

--- a/contenus/conseils/conseils_personnels_symptômes_passés_positif.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_positif.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. Vous maintenir **en isolement** au moins 10 jours à partir de la date d’apparition des symptômes.
-2. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+2. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 3. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 4. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
 5. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !

--- a/contenus/conseils/conseils_personnels_symptômes_passés_positif_antigenique.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_positif_antigenique.md
@@ -2,7 +2,7 @@ Nous vous conseillons de :
 
 1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour identifier un éventuel **variant** du virus.
 2. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer, et les inviter à <a href="#conseils-depistage" class="lien-depistage">réaliser un test</a>.
 4. Pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 5. Si vous avez installé l’application TousAntiCovid sur votre smartphone, vous pouvez y scanner le **QR code** présent sur vos résultats dans la section « Me déclarer ».
 6. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !

--- a/contenus/conseils/conseils_personnels_symptômes_passés_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_sans_depistage.md
@@ -2,7 +2,7 @@ Nous vous conseillons de :
 
 1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>. Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
 2. Vous maintenir **en isolement** jusqu’au résultat du test. Si le résultat est négatif, vous pourrez mettre fin à votre isolement.
-3. Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
+3. {.seulement-si-foyer} Appliquer **les mesures barrières renforcées** avec les autres membres de votre foyer.
 4. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 5. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !
 

--- a/src/scripts/page/conseils.js
+++ b/src/scripts/page/conseils.js
@@ -68,6 +68,17 @@ export default function conseils(element, app) {
         hideSelector(element, '#conseils-statut')
     }
 
+    // Éléments conditionnés à une activité professionnelle.
+    const activitePro = app.profil.activite_pro || app.profil.activite_pro_sante
+    if (!activitePro) {
+        hideSelector(element, '.seulement-si-activite-pro')
+    }
+
+    // Éléments conditionnés à un foyer partagé.
+    if (!app.profil.foyer_autres_personnes) {
+        hideSelector(element, '.seulement-si-foyer')
+    }
+
     // Dynamic data injections.
     dynamicDataInjection(element, app.profil, algoOrientation)
 

--- a/src/scripts/page/conseils.js
+++ b/src/scripts/page/conseils.js
@@ -68,16 +68,7 @@ export default function conseils(element, app) {
         hideSelector(element, '#conseils-statut')
     }
 
-    // Éléments conditionnés à une activité professionnelle.
-    const activitePro = app.profil.activite_pro || app.profil.activite_pro_sante
-    if (!activitePro) {
-        hideSelector(element, '.seulement-si-activite-pro')
-    }
-
-    // Éléments conditionnés à un foyer partagé.
-    if (!app.profil.foyer_autres_personnes) {
-        hideSelector(element, '.seulement-si-foyer')
-    }
+    cacherElementsConditionnels(element, app.profil)
 
     // Dynamic data injections.
     dynamicDataInjection(element, app.profil, algoOrientation)
@@ -99,6 +90,19 @@ export default function conseils(element, app) {
         bindCalendar(element, app.profil)
     }
     bindSuppressionTotale(element.querySelector('.js-suppression'), app)
+}
+
+export function cacherElementsConditionnels(element, profil) {
+    // Éléments conditionnés à une activité professionnelle.
+    const activitePro = profil.activite_pro || profil.activite_pro_sante
+    if (!activitePro) {
+        hideSelector(element, '.seulement-si-activite-pro')
+    }
+
+    // Éléments conditionnés à un foyer partagé.
+    if (!profil.foyer_autres_personnes) {
+        hideSelector(element, '.seulement-si-foyer')
+    }
 }
 
 function showRelevantSuiviBlocks(element, algoSuivi) {

--- a/src/scripts/tests/test.conseils.js
+++ b/src/scripts/tests/test.conseils.js
@@ -1,0 +1,83 @@
+import { assert } from 'chai'
+import { JSDOM } from 'jsdom'
+
+import { cacherElementsConditionnels } from '../page/conseils'
+import Profil from '../profil'
+
+describe('Conseils personnels', function () {
+    it('Je n’ai pas d’activité pro', function () {
+        let dom = new JSDOM(`<!DOCTYPE html>
+            <section id="conseils">
+                <div id="conseils-personnels" class="conseils">
+                    <ol>
+                        <li id="isolement">Rester isolé</li>
+                        <li id="arret-de-travail" class="seulement-si-activite-pro">Obtenir un arrêt de travail</li>
+                    </ol>
+                </div>
+            </section>
+        `)
+        let element = dom.window.document.querySelector('#conseils')
+        let profil = new Profil('mes_infos', {
+            activite_pro: false,
+        })
+        cacherElementsConditionnels(element, profil)
+        assert.isTrue(element.querySelector('#arret-de-travail').hidden)
+    })
+
+    it('J’ai une activité pro', function () {
+        let dom = new JSDOM(`<!DOCTYPE html>
+            <section id="conseils">
+                <div id="conseils-personnels" class="conseils">
+                    <ol>
+                        <li id="isolement">Rester isolé</li>
+                        <li id="arret-de-travail" class="seulement-si-activite-pro">Obtenir un arrêt de travail</li>
+                    </ol>
+                </div>
+            </section>
+        `)
+        let element = dom.window.document.querySelector('#conseils')
+        let profil = new Profil('mes_infos', {
+            activite_pro: true,
+        })
+        cacherElementsConditionnels(element, profil)
+        assert.isFalse(element.querySelector('#arret-de-travail').hidden)
+    })
+
+    it('Je vis seul', function () {
+        let dom = new JSDOM(`<!DOCTYPE html>
+            <section id="conseils">
+                <div id="conseils-personnels" class="conseils">
+                    <ol>
+                        <li id="isolement">Rester isolé</li>
+                        <li id="foyer" class="seulement-si-foyer">Manger tout seul</li>
+                    </ol>
+                </div>
+            </section>
+        `)
+        let element = dom.window.document.querySelector('#conseils')
+        let profil = new Profil('mes_infos', {
+            foyer_autres_personnes: false,
+        })
+        cacherElementsConditionnels(element, profil)
+        assert.isTrue(element.querySelector('#foyer').hidden)
+    })
+
+    it('Je partage mon foyer avec d’autres personnes', function () {
+        let dom = new JSDOM(`<!DOCTYPE html>
+            <section id="conseils">
+                <div id="conseils-personnels" class="conseils">
+                    <ol>
+                        <li id="isolement">Rester isolé</li>
+                        <li id="foyer" class="seulement-si-foyer">Manger tout seul</li>
+                    </ol>
+                </div>
+            </section>
+        `)
+        let element = dom.window.document.querySelector('#conseils')
+        let profil = new Profil('mes_infos', {
+            foyer_autres_personnes: true,
+        })
+        cacherElementsConditionnels(element, profil)
+        assert.isFalse(element.querySelector('#foyer').hidden)
+    })
+})

--- a/test_markdown.py
+++ b/test_markdown.py
@@ -50,6 +50,31 @@ def test_liste_avec_saut_de_ligne():
     )
 
 
+def test_liste_avec_classes():
+    from build import markdown
+
+    assert (
+        markdown(
+            dedent(
+                """\
+                - {.classe-au-debut} a
+                - b {.classe-a-la-fin}
+                - foo {.classe-au-milieu} bar
+                """
+            )
+        )
+        == dedent(
+            """\
+            <ul>
+            <li class="classe-au-debut">a</li>
+            <li class="classe-a-la-fin">b</li>
+            <li class="classe-au-milieu">foo bar</li>
+            </ul>
+            """
+        )
+    )
+
+
 def test_block_html():
     from build import markdown
 


### PR DESCRIPTION
- N’affiche les _bullet points_ relatifs aux arrêts de travail que si la personne a une activité pro
- N’affiche les _bullet points_ relatifs aux mesures barrières renforcées avec les personnes du foyer que si la personne partage effectivement son foyer avec d’autres personnes