### PR TITLE
Tech: version de "make dev" qui marche mieux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,6 @@
 key.pem:  ## Generate certificates to be able to run `https` on `localhost`.
 	openssl req -nodes -newkey rsa:2048 -x509  -days 365 -keyout key.pem -out cert.pem -subj "/C=FR/CN=localhost"
 
-serve: build  ## Local HTTP server with auto rebuild (with LiveReload).
-	python3 serve.py --watch
-
-serve-ssl: key.pem build  ## Local HTTPS server with auto rebuild (without LiveReload).
-	python3 serve.py --watch --ssl
-
 install: install-python install-js
 
 install-python:  ## Install Python dependencies.
@@ -90,15 +84,16 @@ build:  ## Build all files (markdown + statics).
 	python3 build.py all
 	npm run-script build
 
-generate:  ## Auto-regenerate the `.html` files from `templates` + contenus.
-	find . -type f \( -iname "*.md" ! -iname "README.md" ! -iname "CHANGELOG.md" -o -iname "templates/index.html" -iname "templates/cas-contact-a-risque.html" ! -iname "CHANGELOG.md" \) -not -path "./node_modules/*" -not -path "./venv/*" | entr -r python3 build.py index satellites
-
 prefectures:  ## Generate data related to prefectures.
 	python prefectures.py generate
 	make pretty
 
-dev:  ## Auto-rebuild and serve the static website with Parcel.
-	npm run-script build-dev
+dev: build  ## Local HTTP server with auto rebuild (with LiveReload).
+	python3 serve.py --watch --open
+
+dev-ssl: key.pem build  ## Local HTTPS server with auto rebuild (without LiveReload).
+	python3 serve.py --watch --open --ssl
+
 
 pre-commit: pretty lint test-unit build check-versions check-orphelins check-diagrammes check-service-worker  ## Interesting prior to commit/push.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Ce serveur reconstruit automatiquement le site en cas de modification des fichie
 Pour lancer ce serveur local sur [http://0.0.0.0:5500/](http://0.0.0.0:5500/) :
 
 ```
-$ make serve
+$ make dev
 ```
 
 ### Lancer un serveur local en HTTPS
@@ -55,22 +55,25 @@ Activer HTTPS permet de tester la géolocalisation, mais ne permet plus d’util
 Pour lancer ce serveur local sur [https://0.0.0.0:8443/](https://0.0.0.0:8443/) :
 
 ```
-$ make serve-ssl
+$ make dev-ssl
 ```
-
-### Alternative plus réactive
-
-Pour que les modifications de contenus/code soient plus rapidement prise en compte (développement actif) :
-
-1. installer [entr](http://eradman.com/entrproject/)
-2. lancer `make generate` dans un shell (re-génération de l’`index.html`)
-3. lancer `make dev` dans un autre shell (re-génération des fichiers statiques)
-
 
 ### Lancer les tests
 
-Pour lancer les tests unitaires sous Node avec [Mocha](https://mochajs.org/) :
+Pour lancer tous les tests :
 
 ```
 $ make test
+```
+
+Pour lancer seulement les tests unitaires sous Node avec [Mocha](https://mochajs.org/) :
+
+```
+$ make test-unit
+```
+
+Pour lancer seulement les tests d’intégration (exécution de scénarios avec des vrais navigateurs web) avec [Playwright](https://playwright.dev/) :
+
+```
+$ make test-integration
 ```

--- a/build.py
+++ b/build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import fnmatch
+import logging
 import os
 import re
 from html.parser import HTMLParser
@@ -14,6 +15,8 @@ from jinja2 import FileSystemLoader, StrictUndefined
 from minicli import cli, run, wrap
 
 from typographie import typographie
+
+LOGGER = logging.getLogger(__name__)
 
 HERE = Path(__file__).parent
 SRC_DIR = HERE / "src"
@@ -190,9 +193,9 @@ def url_to_filename(url: str) -> str:
 
 def download_file_if_needed(url, local_path, timeout):
     if local_path.exists():
-        print(f"SKIP: {url} exists in {local_path}")
+        LOGGER.info(f"SKIP: {url} exists in {local_path}")
     else:
-        print(f"FETCH: {url} to {local_path}")
+        LOGGER.info(f"FETCH: {url} to {local_path}")
         _download_file(url, local_path, timeout)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ packaging==20.9
 pathtools==0.1.2
 pluggy==0.13.1
 py==1.10.0
+pyinotify==0.9.6
 pyparsing==2.4.7
 pytest==6.2.3
 regex==2021.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ packaging==20.9
 pathtools==0.1.2
 pluggy==0.13.1
 py==1.10.0
-pyinotify==0.9.6
+pyinotify==0.9.6; platform_system == 'Linux'
 pyparsing==2.4.7
 pytest==6.2.3
 regex==2021.4.4

--- a/serve.py
+++ b/serve.py
@@ -11,14 +11,14 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from ssl import wrap_socket
 
-from livereload.server import LogFormatter, Server, shell
+from livereload.server import LogFormatter, Server
 from watchdog.observers import Observer
 from watchdog.tricks import ShellCommandTrick
 
 import build
 
-
-BUNDLER_COMMAND = "parcel watch src/*.html"
+PARCEL_CLI = "./node_modules/.bin/parcel"
+BUNDLER_COMMAND = f"{PARCEL_CLI} watch src/*.html"
 
 ROOT_DIR = "dist/"
 


### PR DESCRIPTION
- surveille les templates et les contenus pour
  regénérer les fichiers HTML en tâche de fond
  (pas besoin de lancer un "make generate")

- lance Parcel en mode "watch" en arrière plan
  pour regénérer les bundles incrémentalement

- utilise un serveur web Python (avec live reload
  si on n’active pas SSL) qui gère bien les
  différents chemins :
    /
    /index.html
    /cas-contact-a-risque.html

- ouvre l’index dans le navigateur au lancement