### PR TITLE
Suppression du lien vers la page Tester-Alerter-Protéger

### DIFF
--- a/contenus/conseils/README.md
+++ b/contenus/conseils/README.md
@@ -698,7 +698,6 @@ Retrouvez le <a href="#conseils-depistage" class="lien-depistage">lieu de test l
     * Les prochaines étapes du parcours : [Isolement, test : que faire ?](https://www.gouvernement.fr/sites/default/files/arbre_decisionnel_covid_-_nouveau.pdf)
     * [Les tests RT-PCR, antigéniques et salivaires](https://solidarites-sante.gouv.fr/soins-et-maladies/maladies/maladies-infectieuses/coronavirus/tout-savoir-sur-la-covid-19/article/le-depistage)
     * [Tout ce qu’il faut savoir sur les tests antigéniques](https://www.ameli.fr/paris/assure/covid-19/les-tests-de-depistage-de-la-covid-19/tout-ce-quil-faut-savoir-sur-les-tests-antigeniques-du-sras-cov-2)
-    * [La stratégie de dépistage](https://www.gouvernement.fr/info-coronavirus/tests-et-depistage)
 
 
 

--- a/contenus/conseils/conseils_tests.md
+++ b/contenus/conseils/conseils_tests.md
@@ -14,4 +14,3 @@ Retrouvez le <a href="#conseils-depistage" class="lien-depistage">lieu de test l
     * Les prochaines étapes du parcours : [Isolement, test : que faire ?](https://www.gouvernement.fr/sites/default/files/arbre_decisionnel_covid_-_nouveau.pdf)
     * [Les tests RT-PCR, antigéniques et salivaires](https://solidarites-sante.gouv.fr/soins-et-maladies/maladies/maladies-infectieuses/coronavirus/tout-savoir-sur-la-covid-19/article/le-depistage)
     * [Tout ce qu’il faut savoir sur les tests antigéniques](https://www.ameli.fr/paris/assure/covid-19/les-tests-de-depistage-de-la-covid-19/tout-ce-quil-faut-savoir-sur-les-tests-antigeniques-du-sras-cov-2)
-    * [La stratégie de dépistage](https://www.gouvernement.fr/info-coronavirus/tests-et-depistage)


### PR DESCRIPTION
Le contenu n’apporte pas vraiment d’informations pratiques supplémentaires.

https://www.gouvernement.fr/info-coronavirus/tests-et-depistage