### PR TITLE
Tech: passage à DayJS pour gérer les dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4679,6 +4679,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
+    },
     "deasync": {
       "version": "0.1.21",
       "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.21.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "core-js": "3.11.2",
+    "dayjs": "^1.10.4",
     "localforage": "1.7.3",
     "navigo": "7.1.2",
     "pikaday": "^1.8.2",


### PR DESCRIPTION
Pour l’instant restreint à la page d’historique car il y avait des bugs en fin de mois.

Étonnamment, la différence de poids est négligeable sur notre build _non compressé_ 😮 
