### PR TITLE
Retrait de la mention `11 ans ou moins`

### DIFF
--- a/contenus/questions/README.md
+++ b/contenus/questions/README.md
@@ -350,11 +350,11 @@ Si vous avez un doute sur vos réponses, revenez plus tard sur cette page pour l
 
 ## [question_foyer_enfants_libellé.md](question_foyer_enfants_libellé.md)
 
-<!---->Je vis avec un ou des <b>enfants</b> de moins de 11 ans
+<!---->Je vis avec un ou des <b>enfants</b>
 
 ---
 
-<!---->Cette personne vit avec un ou des <b>enfants</b> de moins de 11 ans
+<!---->Cette personne vit avec un ou des <b>enfants</b>
 
 
 

--- a/contenus/questions/question_foyer_enfants_libellé.md
+++ b/contenus/questions/question_foyer_enfants_libellé.md
@@ -1,5 +1,5 @@
-<!---->Je vis avec un ou des <b>enfants</b> de moins de 11 ans
+<!---->Je vis avec un ou des <b>enfants</b>
 
 ---
 
-<!---->Cette personne vit avec un ou des <b>enfants</b> de moins de 11 ans
+<!---->Cette personne vit avec un ou des <b>enfants</b>

--- a/contenus/réponses/README.md
+++ b/contenus/réponses/README.md
@@ -96,7 +96,7 @@ Votre lieu de résidence actuel : <b id="nom-departement"></b> (<a href="#situat
 
 ## [réponse_foyer_enfants.md](réponse_foyer_enfants.md)
 
-Vous vivez avec un ou des enfants de moins de 11 ans (<a href="#situation">modifier</a>)
+Vous vivez avec un ou des enfants (<a href="#situation">modifier</a>)
 
 
 

--- a/contenus/réponses/réponse_foyer_enfants.md
+++ b/contenus/réponses/réponse_foyer_enfants.md
@@ -1,1 +1,1 @@
-Vous vivez avec un ou des enfants de moins de 11 ans (<a href="#situation">modifier</a>)
+Vous vivez avec un ou des enfants (<a href="#situation">modifier</a>)


### PR DESCRIPTION
Cela conditionne l’affichage d’un bloc Enfants (et peut-être Études et scolarité prochainement) qui n’est pas spécifique aux enfants si jeunes, il serait pertinent de l’afficher à davantage de familles.