### PR TITLE
Reformule la réponse « pas de symptômes »

### DIFF
--- a/contenus/questions/README.md
+++ b/contenus/questions/README.md
@@ -794,7 +794,7 @@ Des personnes croisées à l’extérieur de chez moi un court instant ne sont p
 
 ## [question_symptômes_libellé_non.md](question_symptômes_libellé_non.md)
 
-<!----><b>Pas récemment</b>
+<!----><b>Non, ou pas récemment</b>
 
 
 

--- a/contenus/questions/question_symptômes_libellé_non.md
+++ b/contenus/questions/question_symptômes_libellé_non.md
@@ -1,1 +1,1 @@
-<!----><b>Pas récemment</b>
+<!----><b>Non, ou pas récemment</b>


### PR DESCRIPTION
Plusieurs personnes ont signalé que la formulation précédente pouvait prêter à confusion.