### PR TITLE
A11Y: ajout de balises paragraphes manquantes

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -118,15 +118,17 @@
         <fieldset>
             <legend>{{ question_vaccins_titre|me_or_them }}</legend>
             <div id="vaccins-label" class="secondary-title">
-                {{ question_vaccins_libellé|me_or_them }}
+                <p>
+                    {{ question_vaccins_libellé|me_or_them }}
+                </p>
             </div>
             <div role="radiogroup" aria-labelledby="vaccins-label">
                 <input id="vaccins_radio_pas_encore" type="radio" required name="vaccins_radio" value="pas_encore">
-                <label for="vaccins_radio_pas_encore"><span>{{ question_vaccins_pas_encore_libellé|me_or_them }}</span></label>
+                <label for="vaccins_radio_pas_encore">{{ question_vaccins_pas_encore_libellé|me_or_them }}</label>
                 <input id="vaccins_radio_en_cours" type="radio" required name="vaccins_radio" value="en_cours">
-                <label for="vaccins_radio_en_cours"><span>{{ question_vaccins_en_cours_libellé|me_or_them }}</span></label>
+                <label for="vaccins_radio_en_cours">{{ question_vaccins_en_cours_libellé|me_or_them }}</label>
                 <input id="vaccins_radio_completement" type="radio" required name="vaccins_radio" value="completement">
-                <label for="vaccins_radio_completement"><span>{{ question_vaccins_completement_libellé|me_or_them }}</span></label>
+                <label for="vaccins_radio_completement">{{ question_vaccins_completement_libellé|me_or_them }}</label>
             </div>
         </fieldset>
         <div class="form-controls">
@@ -146,11 +148,13 @@
             <div>
                 <input id="covid_passee_checkbox" type="checkbox" name="covid_passee">
                 <label for="covid_passee_checkbox">
-                    <span>{{ question_historique_covid_passee_libellé|me_or_them }}</span>
+                    {{ question_historique_covid_passee_libellé|me_or_them }}
                 </label>
                 <div class="secondary disabled required">
                     <div id="covid-passee-label" class="secondary-title">
-                        {{ question_historique_covid_passee_date_libellé|me_or_them }}
+                        <p>
+                            {{ question_historique_covid_passee_date_libellé|me_or_them }}
+                        </p>
                     </div>
                     <div role="radiogroup" aria-labelledby="covid-passee-label">
                         <input id="covid_passee_date_6_mois" type="radio" required name="covid_passee_date" value="6">
@@ -310,24 +314,24 @@
             <div>
                 <input id="foyer_autres_personnes" type="checkbox" name="foyer_autres_personnes">
                 <label for="foyer_autres_personnes">
-                    <span>{{ question_foyer_autres_personnes_libellé|me_or_them }}</span>
+                    {{ question_foyer_autres_personnes_libellé|me_or_them }}
                 </label>
                 <div class="secondary disabled">
                     <input id="foyer_enfants" type="checkbox" name="foyer_enfants" disabled>
                     <label for="foyer_enfants">
-                        <span>{{ question_foyer_enfants_libellé|me_or_them }}</span>
+                        {{ question_foyer_enfants_libellé|me_or_them }}
                     </label>
                 </div>
             </div>
             <div>
                 <input id="activite_pro" type="checkbox" name="activite_pro">
                 <label for="activite_pro">
-                    <span>{{ question_activité_pro_libellé|me_or_them }}</span>
+                    {{ question_activité_pro_libellé|me_or_them }}
                 </label>
                 <div class="secondary disabled">
                     <input id="activite_pro_sante" type="checkbox" name="activite_pro_sante" disabled>
                     <label for="activite_pro_sante">
-                        <span>{{ question_activité_pro_santé_libellé|me_or_them }}</span>
+                        {{ question_activité_pro_santé_libellé|me_or_them }}
                     </label>
                     <div class="details">{{ question_activité_pro_santé_aide }}</div>
                 </div>
@@ -365,104 +369,82 @@
             <div class="field">
                 <input id="grossesse_3e_trimestre" type="checkbox" name="grossesse_3e_trimestre">
                 <label for="grossesse_3e_trimestre">
-                    <span>{{ question_caractéristiques_grossesse_libellé|me_or_them }}</span>
+                    {{ question_caractéristiques_grossesse_libellé|me_or_them }}
                 </label>
             </div>
             <div>
                 <input id="antecedent_chronique" type="checkbox" name="antecedent_chronique">
                 <label for="antecedent_chronique">
-                    <span>{{ question_antecedent_chronique|me_or_them }}</span>
+                    {{ question_antecedent_chronique|me_or_them }}
                 </label>
             </div>
             <div class="secondary disabled">
                 <input id="antecedent_cardio" type="checkbox" name="antecedent_cardio">
                 <label for="antecedent_cardio">
-                    <span>
-                        {{ question_antécédents_cardio_libellé|me_or_them }}
-                    </span>
+                    {{ question_antécédents_cardio_libellé|me_or_them }}
                 </label>
                 <div class="details">{{ question_antécédents_cardio_aide }}</div>
             </div>
             <div class="secondary disabled">
                 <input id="antecedent_diabete" type="checkbox" name="antecedent_diabete">
                 <label for="antecedent_diabete">
-                    <span>
-                        {{ question_antécédents_diabète_libellé|me_or_them }}
-                    </span>
+                    {{ question_antécédents_diabète_libellé|me_or_them }}
                 </label>
             </div>
             <div class="secondary disabled">
                 <input id="antecedent_respi" type="checkbox" name="antecedent_respi">
                 <label for="antecedent_respi">
-                    <span>
-                        {{ question_antécédents_respi_libellé|me_or_them }}
-                    </span>
+                    {{ question_antécédents_respi_libellé|me_or_them }}
                 </label>
                 <div class="details">{{ question_antécédents_respi_aide }}</div>
             </div>
             <div class="secondary disabled">
                 <input id="antecedent_dialyse" type="checkbox" name="antecedent_dialyse">
                 <label for="antecedent_dialyse">
-                    <span>
-                        {{ question_antécédents_dialyse_libellé|me_or_them }}
-                    </span>
+                    {{ question_antécédents_dialyse_libellé|me_or_them }}
                 </label>
             </div>
             <div class="secondary disabled">
                 <input id="antecedent_greffe" type="checkbox" name="antecedent_greffe">
                 <label for="antecedent_greffe">
-                    <span>
-                        {{ question_antécédents_greffe_libellé|me_or_them }}
-                    </span>
+                    {{ question_antécédents_greffe_libellé|me_or_them }}
                 </label>
             </div>
             <div class="secondary disabled">
                 <input id="antecedent_cancer" type="checkbox" name="antecedent_cancer">
                 <label for="antecedent_cancer">
-                    <span>
-                        {{ question_antécédents_cancer_libellé|me_or_them }}
-                    </span>
+                    {{ question_antécédents_cancer_libellé|me_or_them }}
                 </label>
             </div>
             <div class="secondary disabled">
                 <input id="antecedent_immunodep" type="checkbox" name="antecedent_immunodep">
                 <label for="antecedent_immunodep">
-                    <span>
-                        {{ question_antécédents_immunodépression_libellé|me_or_them }}
-                    </span>
+                    {{ question_antécédents_immunodépression_libellé|me_or_them }}
                 </label>
                 <div class="details">{{ question_antécédents_immunodépression_aide }}</div>
             </div>
             <div class="secondary disabled">
                 <input id="antecedent_cirrhose" type="checkbox" name="antecedent_cirrhose">
                 <label for="antecedent_cirrhose">
-                    <span>
-                        {{ question_antécédents_cirrhose_libellé|me_or_them }}
-                    </span>
+                    {{ question_antécédents_cirrhose_libellé|me_or_them }}
                 </label>
             </div>
             <div class="secondary disabled">
                 <input id="antecedent_drepano" type="checkbox" name="antecedent_drepano">
                 <label for="antecedent_drepano">
-                    <span>
-                        {{ question_antécédents_drépanocytose_libellé|me_or_them }}
-                    </span>
+                    {{ question_antécédents_drépanocytose_libellé|me_or_them }}
                 </label>
             </div>
             <div class="secondary disabled">
                 <input id="antecedent_trisomie" type="checkbox" name="antecedent_trisomie">
                 <label for="antecedent_trisomie">
-                    <span>
-                        {{ question_antécédents_trisomie_libellé|me_or_them }}
-                    </span>
+                    {{ question_antécédents_trisomie_libellé|me_or_them }}
                 </label>
             </div>
             <div class="secondary disabled">
                 <input id="antecedent_chronique_autre" type="checkbox" name="antecedent_chronique_autre">
                 <label for="antecedent_chronique_autre">
-                    <span>
-                        {{ question_antécédents_chronique_autre_libellé|me_or_them }}
-                    </span>
+                    {{ question_antécédents_chronique_autre_libellé|me_or_them }}
                 </label>
             </div>
         </fieldset>
@@ -485,21 +467,15 @@
             <div role="radiogroup" aria-labelledby="symptomes-label">
                 <input id="symptomes_actuels" type="radio" required name="symptomes_actuels_statuts">
                 <label for="symptomes_actuels">
-                    <span>
-                        {{ question_symptômes_libellé_oui|me_or_them }}
-                    </span>
+                    {{ question_symptômes_libellé_oui|me_or_them }}
                 </label>
                 <input id="symptomes_passes" type="radio" required name="symptomes_actuels_statuts">
                 <label for="symptomes_passes">
-                    <span>
-                        {{ question_symptômes_libellé_passés|me_or_them }}
-                    </span>
+                    {{ question_symptômes_libellé_passés|me_or_them }}
                 </label>
                 <input id="symptomes_non" type="radio" required name="symptomes_actuels_statuts">
                 <label for="symptomes_non">
-                    <span>
-                        {{ question_symptômes_libellé_non }}
-                    </span>
+                    {{ question_symptômes_libellé_non }}
                 </label>
             </div>
             <div id="symptomes-choix" class="checkboxgroup" hidden>
@@ -513,7 +489,7 @@
                 <div>
                     <input id="symptomes_actuels_temperature_inconnue" type="checkbox" name="symptomes_actuels_temperature_inconnue">
                     <label for="symptomes_actuels_temperature_inconnue">
-                        <span>{{ question_symptômes_actuels_température_inconnue_libellé|me_or_them }}</span>
+                        {{ question_symptômes_actuels_température_inconnue_libellé|me_or_them }}
                     </label>
                 </div>
                 <div>
@@ -525,13 +501,13 @@
                 <div>
                     <input id="symptomes_actuels_odorat" type="checkbox" name="symptomes_actuels_odorat">
                     <label for="symptomes_actuels_odorat">
-                        <span>{{ question_symptômes_actuels_odorat_libellé|me_or_them }}</span>
+                        {{ question_symptômes_actuels_odorat_libellé|me_or_them }}
                     </label>
                 </div>
                 <div>
                     <input id="symptomes_actuels_douleurs" type="checkbox" name="symptomes_actuels_douleurs">
                     <label for="symptomes_actuels_douleurs">
-                        <span>{{ question_symptômes_actuels_douleurs_libellé|me_or_them }}</span>
+                        {{ question_symptômes_actuels_douleurs_libellé|me_or_them }}
                     </label>
                     <div class="details">{{ question_symptômes_actuels_douleurs_aide }}</div>
                 </div>
@@ -544,19 +520,19 @@
                 <div>
                     <input id="symptomes_actuels_fatigue" type="checkbox" name="symptomes_actuels_fatigue">
                     <label for="symptomes_actuels_fatigue">
-                        <span>{{ question_symptômes_actuels_fatigue_libellé|me_or_them }}</span>
+                        {{ question_symptômes_actuels_fatigue_libellé|me_or_them }}
                     </label>
                 </div>
                 <div>
                     <input id="symptomes_actuels_alimentation" type="checkbox" name="symptomes_actuels_alimentation">
                     <label for="symptomes_actuels_alimentation">
-                        <span>{{ question_symptômes_actuels_alimentation_libellé|me_or_them }}</span>
+                        {{ question_symptômes_actuels_alimentation_libellé|me_or_them }}
                     </label>
                 </div>
                 <div>
                     <input id="symptomes_actuels_souffle" type="checkbox" name="symptomes_actuels_souffle">
                     <label for="symptomes_actuels_souffle">
-                        <span>{{ question_symptômes_actuels_souffle_libellé|me_or_them }}</span>
+                        {{ question_symptômes_actuels_souffle_libellé|me_or_them }}
                     </label>
                 </div>
             </div>
@@ -579,7 +555,7 @@
                         <input type="date" lang="fr" id="debut_symptomes_exacte" name="suivi_symptomes_date_exacte">
                     </label>
                 </div>
-                <div class="details">{{ question_debut_symptomes_aide|me_or_them }}</div>
+                <div class="details"><p>{{ question_debut_symptomes_aide|me_or_them }}</p></div>
             </div>
         </fieldset>
         <div class="form-controls">
@@ -599,7 +575,7 @@
             <div>
                 <input id="depistage_checkbox" type="checkbox" name="depistage">
                 <label for="depistage_checkbox">
-                    <span>{{ question_dépistage_libellé|me_or_them }}</span>
+                    {{ question_dépistage_libellé|me_or_them }}
                 </label>
                 <div class="details">{{ question_dépistage_aide }}</div>
             </div>
@@ -640,7 +616,7 @@
                     <input id="depistage_resultat_negatif" type="radio" required name="depistage_resultat" value="negatif">
                     <label for="depistage_resultat_negatif"><span>{{ question_dépistage_négatif_libellé }}</span></label>
                     <input id="depistage_resultat_en_attente" type="radio" required name="depistage_resultat" value="en_attente">
-                    <label for="depistage_resultat_en_attente"><span>{{ question_dépistage_attente_libellé|me_or_them }}</span></label>
+                    <label for="depistage_resultat_en_attente">{{ question_dépistage_attente_libellé|me_or_them }}</label>
                 </div>
             </div>
         </fieldset>
@@ -661,24 +637,22 @@
             <div>
                 <input id="contact_a_risque_assurance_maladie" type="checkbox" name="contact_a_risque_assurance_maladie">
                 <label for="contact_a_risque_assurance_maladie">
-                    <span>{{ question_symptômes_contact_à_risque_assurance_maladie_libellé|me_or_them }}</span>
+                    {{ question_symptômes_contact_à_risque_assurance_maladie_libellé|me_or_them }}
                 </label>
             </div>
             <div>
                 <input id="contact_a_risque_stop_covid" type="checkbox" name="contact_a_risque_stop_covid">
                 <label for="contact_a_risque_stop_covid">
-                    <span>{{ question_symptômes_contact_à_risque_stop_covid_libellé|me_or_them }}</span>
+                    {{ question_symptômes_contact_à_risque_stop_covid_libellé|me_or_them }}
                 </label>
             </div>
             <div>
                 <input id="contact_a_risque" type="checkbox" name="contact_a_risque" class="primary">
                 <label for="contact_a_risque">
-                    <span>
-                        {{ question_symptômes_contact_à_risque_libellé|me_or_them }}
-                    </span>
+                    {{ question_symptômes_contact_à_risque_libellé|me_or_them }}
                 </label>
                 <div class="details">
-                    {{ question_symptômes_contact_à_risque_aide|me_or_them }}
+                    <p>{{ question_symptômes_contact_à_risque_aide|me_or_them }}</p>
                 </div>
             </div>
             <div class="secondary disabled">
@@ -688,45 +662,45 @@
                 <div>
                     <input id="contact_a_risque_meme_lieu_de_vie" type="checkbox" name="contact_a_risque_meme_lieu_de_vie" disabled>
                     <label for="contact_a_risque_meme_lieu_de_vie">
-                        <span>{{ question_symptômes_contact_à_risque_même_lieu_de_vie_libellé|me_or_them }}</span>
+                        {{ question_symptômes_contact_à_risque_même_lieu_de_vie_libellé|me_or_them }}
                     </label>
                 </div>
                 <div>
                     <input id="contact_a_risque_contact_direct" type="checkbox" name="contact_a_risque_contact_direct" disabled>
                     <label for="contact_a_risque_contact_direct">
-                        <span>{{ question_symptômes_contact_à_risque_contact_direct_libellé|me_or_them }}</span>
+                        {{ question_symptômes_contact_à_risque_contact_direct_libellé|me_or_them }}
                     </label>
                     <div class="details">{{ question_symptômes_contact_à_risque_contact_direct_aide }}</div>
                 </div>
                 <div>
                     <input id="contact_a_risque_actes" type="checkbox" name="contact_a_risque_actes" disabled>
                     <label for="contact_a_risque_actes">
-                        <span>{{ question_symptômes_contact_à_risque_actes_libellé|me_or_them }}</span>
+                        {{ question_symptômes_contact_à_risque_actes_libellé|me_or_them }}
                     </label>
                     <div class="details">{{ question_symptômes_contact_à_risque_actes_aide }}</div>
                 </div>
                 <div>
                     <input id="contact_a_risque_espace_confine" type="checkbox" name="contact_a_risque_espace_confine" disabled>
                     <label for="contact_a_risque_espace_confine">
-                        <span>{{ question_symptômes_contact_à_risque_espace_confiné_libellé|me_or_them }}</span>
+                        {{ question_symptômes_contact_à_risque_espace_confiné_libellé|me_or_them }}
                     </label>
                 </div>
                 <div>
                     <input id="contact_a_risque_tousse_eternue" type="checkbox" name="contact_a_risque_tousse_eternue" disabled>
                     <label for="contact_a_risque_tousse_eternue">
-                        <span>{{ question_symptômes_contact_à_risque_toussé_éternué_libellé|me_or_them }}</span>
+                        {{ question_symptômes_contact_à_risque_toussé_éternué_libellé|me_or_them }}
                     </label>
                 </div>
                 <div>
                     <input id="contact_a_risque_meme_classe" type="checkbox" name="contact_a_risque_meme_classe" disabled>
                     <label for="contact_a_risque_meme_classe">
-                        <span>{{ question_symptômes_contact_à_risque_même_classe_libellé|me_or_them }}</span>
+                        {{ question_symptômes_contact_à_risque_même_classe_libellé|me_or_them }}
                     </label>
                 </div>
                 <div>
                     <input id="contact_a_risque_autre" type="checkbox" name="contact_a_risque_autre" disabled>
                     <label for="contact_a_risque_autre">
-                        <span>{{ question_symptômes_contact_à_risque_autre_libellé|me_or_them }}</span>
+                        {{ question_symptômes_contact_à_risque_autre_libellé|me_or_them }}
                     </label>
                 </div>
             </div>
@@ -1403,13 +1377,11 @@
     <form id="suivi-symptomes-form" class="block">
         <fieldset>
             <legend>{{ question_suivi_symptômes_titre|me_or_them }}</legend>
-            <div class="details">{{ question_suivi_symptômes_aide|me_or_them }}</div>
+            <div class="details"><p>{{ question_suivi_symptômes_aide|me_or_them }}</p></div>
             <div id="suivi-symptomes-aujourdhui">
                 <input id="suivi_symptomes" type="checkbox" name="suivi_symptomes">
                 <label for="suivi_symptomes">
-                    <span>
-                        {{ question_suivi_symptômes_libellé|me_or_them }}
-                    </span>
+                    {{ question_suivi_symptômes_libellé|me_or_them }}
                 </label>
             </div>
 


### PR DESCRIPTION
Et retrait des span inutiles, attention ils le sont lorsqu’il n’y a pas de filtre `me_or_them`, peut-être que l’on pourrait uniformiser et l’ajouter avec le filtre si on ne trouve pas le séparateur dans la chaîne.