### PR TITLE
Tech: ajout des tailles d’images des thématiques

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -99,7 +99,8 @@
                 {% for thematique in thematiques %}
                 <li>
                     <a class="card" href="{{ thematique.name }}.html">
-                        <img src="{{ thematique.imgsrc }}" loading="lazy" alt="">
+                        <img src="{{ thematique.imgsrc }}" loading="lazy" alt=""
+                             width="96px" height="76.8px">
                         <span class="card-title">{{ thematique.title }}</span>
                     </a>
                 </li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -100,7 +100,7 @@
                 <li>
                     <a class="card" href="{{ thematique.name }}.html">
                         <img src="{{ thematique.imgsrc }}" loading="lazy" alt=""
-                             width="96px" height="76.8px">
+                             width="96" height="76.8">
                         <span class="card-title">{{ thematique.title }}</span>
                     </a>
                 </li>


### PR DESCRIPTION
Sur la page d’accueil pour réserver cet espace avant le chargement et éviter un mouvement sur la page.