### PR TITLE
A11Y: amélioration du contraste des icônes de suivi

### DIFF
--- a/src/suivi_gravite.svg
+++ b/src/suivi_gravite.svg
@@ -6,8 +6,8 @@
     <path d="M34.7 28.2L20.8 2.7a3.2 3.2 0 00-5.6 0l-14 25.5a3.2 3.2 0 003 4.8h27.7a3.2 3.2 0 002.8-4.7zM16.7 9a1.4 1.4 0 012.8 0v12a1.4 1.4 0 11-2.8 0V9zm1.4 19.9a1.8 1.8 0 110-3.6 1.8 1.8 0 010 3.6z" id="b"/>
   </defs>
   <g fill="none" fill-rule="evenodd">
-    <g filter="url(#a)">
-      <use fill="#F69B04" xlink:href="#b" transform="translate(7 9)"/>
+    <g>
+      <use fill="#A26859" xlink:href="#b" transform="translate(7 9)"/>
     </g>
     <path d="M0 0h50v50H0z"/>
   </g>

--- a/src/suivi_gravite_superieure.svg
+++ b/src/suivi_gravite_superieure.svg
@@ -6,7 +6,7 @@
     <path d="M34.7 28.2L20.8 2.7a3.2 3.2 0 00-5.6 0l-14 25.5a3.2 3.2 0 003 4.8h27.7a3.2 3.2 0 002.8-4.7zM16.7 9a1.4 1.4 0 012.8 0v12a1.4 1.4 0 11-2.8 0V9zm1.4 19.9a1.8 1.8 0 110-3.6 1.8 1.8 0 010 3.6z" id="b"/>
   </defs>
   <g fill="none" fill-rule="evenodd">
-    <path fill="#D0021B" d="M0 0h50v50H0z"/>
+    <path fill="#E10600" d="M0 0h50v50H0z"/>
     <g filter="url(#a)">
       <use fill="#000" fill-rule="nonzero" xlink:href="#b" transform="translate(7 8)"/>
     </g>

--- a/src/suivi_interrogation.svg
+++ b/src/suivi_interrogation.svg
@@ -4,6 +4,6 @@
   </defs>
   <g fill="none" fill-rule="evenodd">
     <path d="M0 0h50v50H0z"/>
-    <use fill="#000091" xlink:href="#a" transform="translate(18 15)"/>
+    <use fill="#0762C8" xlink:href="#a" transform="translate(18 15)"/>
   </g>
 </svg>

--- a/src/suivi_ok.svg
+++ b/src/suivi_ok.svg
@@ -3,7 +3,7 @@
     <path d="M16 0a16 16 0 100 32 16 16 0 000-32zm10.4 10.6l-13 13.2L5.4 16a1.4 1.4 0 012-2l5.8 5.8L24.5 8.6a1.4 1.4 0 112 2z" id="a"/>
   </defs>
   <g fill="none" fill-rule="evenodd">
-    <use fill="#17B600" xlink:href="#a" transform="translate(9 10)"/>
+    <use fill="#008941" xlink:href="#a" transform="translate(9 10)"/>
     <path d="M0 0h50v50H0z"/>
   </g>
 </svg>

--- a/src/suivi_stable.svg
+++ b/src/suivi_stable.svg
@@ -3,7 +3,7 @@
     <path d="M29.1 5.9a2.9 2.9 0 100-5.8 2.9 2.9 0 000 5.8zM16 .1a2.9 2.9 0 110 5.8 2.9 2.9 0 010-5.8zM2.9.1a2.9 2.9 0 110 5.8 2.9 2.9 0 010-5.8z" id="a"/>
   </defs>
   <g fill="none" fill-rule="evenodd">
-    <use fill="#000091" xlink:href="#a" transform="translate(9 22)"/>
+    <use fill="#0762C8" xlink:href="#a" transform="translate(9 22)"/>
     <path d="M0 0h50v50H0z"/>
   </g>
 </svg>


### PR DESCRIPTION
En utilisant les couleurs du design système de l’État :
https://gouvfr.atlassian.net/wiki/spaces/DB/pages/217186370/Couleurs+-+palette+-+Color#Couleurs-fonctionnelles