### PR TITLE
Met à un jour le lien vers la page couvre-feu

### DIFF
--- a/contenus/conseils/README.md
+++ b/contenus/conseils/README.md
@@ -961,7 +961,7 @@ Vous présentez un risque de développement d’une forme grave de Covid, **vous
 
 Pour plus d’informations, vous pouvez consulter :
 
-* [la page dédiée du site du gouvernement](https://www.gouvernement.fr/info-coronavirus/confinement) ;
+* [la page dédiée au couvre-feu sur le site du gouvernement](https://www.gouvernement.fr/info-coronavirus/couvre-feu) ;
 * les règles spécifiques de votre **département** sur <a href="#conseils-departement" id="lien-prefecture">le site de votre préfecture</a>.
 
 Pour vos **courses**, nous vous conseillons de :

--- a/contenus/conseils/conseils_vie_quotidienne.md
+++ b/contenus/conseils/conseils_vie_quotidienne.md
@@ -1,6 +1,6 @@
 Pour plus d’informations, vous pouvez consulter :
 
-* [la page dédiée du site du gouvernement](https://www.gouvernement.fr/info-coronavirus/confinement) ;
+* [la page dédiée au couvre-feu sur le site du gouvernement](https://www.gouvernement.fr/info-coronavirus/couvre-feu) ;
 * les règles spécifiques de votre **département** sur <a href="#conseils-departement" id="lien-prefecture">le site de votre préfecture</a>.
 
 Pour vos **courses**, nous vous conseillons de :


### PR DESCRIPTION
L’ancienne URL redirige maintenant vers celle-ci.