### PR TITLE
MAJ pays à risque

### DIFF
--- a/contenus/conseils/README.md
+++ b/contenus/conseils/README.md
@@ -220,15 +220,19 @@ Pour plus d’informations sur [vos déplacements ou voyages](https://www.interi
 
 #### Pays à risque
 
-Les conditions d’entrée sur le territoire pour les **voyageurs en provenance des pays les plus à risque** (Afrique du Sud, Argentine, Bahreïn, Bangladesh, Brésil, Chili, Colombie, Costa Rica, Émirats arabes unis, Inde, Népal, Pakistan, Qatar, Sri Lanka, Turquie, Uruguay) sont les suivantes :
+Les conditions d’entrée sur le territoire pour les **voyageurs en provenance des pays les plus à risque** (Afrique du Sud, Argentine, Bahreïn, Bangladesh, Brésil, Chili, Colombie, Costa Rica, Émirats arabes unis, Inde, Népal, Pakistan, Qatar, Sri Lanka, Turquie, Uruguay) et du **Royaume-Uni** ont été renforcées.   
+  
+Nous vous conseillons de consulter [le site du ministère de l’Intérieur](https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestation-de-deplacement-et-de-voyage) et séléctionner la rubrique correspondant à votre situation pour connaître les mesures qui s’appliquent.
 
-  * Tous les vols depuis le Brésil sont suspendus.
-  * Des **restrictions renforcées** ont été mises en place pour ces pays :
-    * Restriction des motifs impérieux.
-    * Avant embarquement, renforcement du dispositif de test avec présentation d’un test PCR négatif de moins de 36 h.
-    * À l’arrivée en France, réalisation d’un test antigénique systématique.
-    * Mise en quarantaine stricte pendant 10 jours à l’arrivée sur arrêté préfectoral, avec restrictions des horaires de sortie (10 h-12 h).
-  * Plus d’informations sont disponibles [sur diplomatie.gouv.fr](https://www.diplomatie.gouv.fr/fr/conseils-aux-voyageurs/informations-pratiques/article/coronavirus-covid-19).
+Les mesures peuvent notamment impliquer : 
+
+* Restriction des motifs impérieux.
+* Avant embarquement, renforcement du dispositif de test avec présentation d’un test PCR négatif de moins de 36 h. 
+* À l’arrivée en France, réalisation d’un test antigénique systématique.
+* Mise en quarantaine stricte pendant 10 jours à l’arrivée sur arrêté préfectoral, avec restrictions des horaires de sortie (10 h-12 h).
+* Plus d’informations sont disponibles : 
+  * [sur diplomatie.gouv.fr](https://www.diplomatie.gouv.fr/fr/conseils-aux-voyageurs/informations-pratiques/article/coronavirus-covid-19).
+  * sur notre page thématique : [Pass sanitaire, QR code, voyages, que faut-il retenir ?](https://mesconseilscovid.sante.gouv.fr/pass-sanitaire-qr-code-voyages.html).
 
 
 

--- a/contenus/conseils/conseils_deplacements.md
+++ b/contenus/conseils/conseils_deplacements.md
@@ -8,12 +8,14 @@ Pour plus d’informations sur [vos déplacements ou voyages](https://www.interi
 
 #### Pays à risque
 
-Les conditions d’entrée sur le territoire pour les **voyageurs en provenance des pays les plus à risque** (Afrique du Sud, Argentine, Bahreïn, Bangladesh, Brésil, Chili, Colombie, Costa Rica, Émirats arabes unis, Inde, Népal, Pakistan, Qatar, Sri Lanka, Turquie, Uruguay) sont les suivantes :
+Les conditions d’entrée sur le territoire pour les **voyageurs en provenance des pays les plus à risque** (Afrique du Sud, Argentine, Bahreïn, Bangladesh, Brésil, Chili, Colombie, Costa Rica, Émirats arabes unis, Inde, Népal, Pakistan, Qatar, Sri Lanka, Turquie, Uruguay) et du **Royaume-Uni** ont été renforcées.   
+  
+Nous vous conseillons de consulter [le site du ministère de l'Intérieur](https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestation-de-deplacement-et-de-voyage) et séléctionner la rubrique correspondant à votre situation pour connaître les mesures qui s'appliquent.
 
-  * Tous les vols depuis le Brésil sont suspendus.
-  * Des **restrictions renforcées** ont été mises en place pour ces pays :
+Les mesures peuvent notamment impliquer : 
+
     * Restriction des motifs impérieux.
-    * Avant embarquement, renforcement du dispositif de test avec présentation d’un test PCR négatif de moins de 36 h.
+    * Avant embarquement, renforcement du dispositif de test avec présentation d’un test PCR négatif de moins de 36 h. 
     * À l’arrivée en France, réalisation d’un test antigénique systématique.
     * Mise en quarantaine stricte pendant 10 jours à l’arrivée sur arrêté préfectoral, avec restrictions des horaires de sortie (10 h-12 h).
   * Plus d’informations sont disponibles : 

--- a/contenus/conseils/conseils_deplacements.md
+++ b/contenus/conseils/conseils_deplacements.md
@@ -10,14 +10,14 @@ Pour plus d’informations sur [vos déplacements ou voyages](https://www.interi
 
 Les conditions d’entrée sur le territoire pour les **voyageurs en provenance des pays les plus à risque** (Afrique du Sud, Argentine, Bahreïn, Bangladesh, Brésil, Chili, Colombie, Costa Rica, Émirats arabes unis, Inde, Népal, Pakistan, Qatar, Sri Lanka, Turquie, Uruguay) et du **Royaume-Uni** ont été renforcées.   
   
-Nous vous conseillons de consulter [le site du ministère de l'Intérieur](https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestation-de-deplacement-et-de-voyage) et séléctionner la rubrique correspondant à votre situation pour connaître les mesures qui s'appliquent.
+Nous vous conseillons de consulter [le site du ministère de l’Intérieur](https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestation-de-deplacement-et-de-voyage) et séléctionner la rubrique correspondant à votre situation pour connaître les mesures qui s’appliquent.
 
-Les mesures peuvent notamment impliquer : 
+Les mesures peuvent notamment impliquer : 
 
-    * Restriction des motifs impérieux.
-    * Avant embarquement, renforcement du dispositif de test avec présentation d’un test PCR négatif de moins de 36 h. 
-    * À l’arrivée en France, réalisation d’un test antigénique systématique.
-    * Mise en quarantaine stricte pendant 10 jours à l’arrivée sur arrêté préfectoral, avec restrictions des horaires de sortie (10 h-12 h).
-  * Plus d’informations sont disponibles : 
-    * [sur diplomatie.gouv.fr](https://www.diplomatie.gouv.fr/fr/conseils-aux-voyageurs/informations-pratiques/article/coronavirus-covid-19).
-    * sur notre page thématique : [Pass sanitaire, QR code, voyages, que faut-il retenir ?](https://mesconseilscovid.sante.gouv.fr/pass-sanitaire-qr-code-voyages.html).
+* Restriction des motifs impérieux.
+* Avant embarquement, renforcement du dispositif de test avec présentation d’un test PCR négatif de moins de 36 h. 
+* À l’arrivée en France, réalisation d’un test antigénique systématique.
+* Mise en quarantaine stricte pendant 10 jours à l’arrivée sur arrêté préfectoral, avec restrictions des horaires de sortie (10 h-12 h).
+* Plus d’informations sont disponibles : 
+  * [sur diplomatie.gouv.fr](https://www.diplomatie.gouv.fr/fr/conseils-aux-voyageurs/informations-pratiques/article/coronavirus-covid-19).
+  * sur notre page thématique : [Pass sanitaire, QR code, voyages, que faut-il retenir ?](https://mesconseilscovid.sante.gouv.fr/pass-sanitaire-qr-code-voyages.html).


### PR DESCRIPTION
Ajout Royaume-Uni et lien vers ministère de l'Intérieur pour cas par cas. 

Suggestion : renvoyer simplement vers le site du ministère de l'Intérieur, au lieu d'énumerer les mesures. Par exemple, le Royaume-Uni n'a pas les mêmes mesures de restriction que les autres pays à risque. 