### PR TITLE
Tech: rend les URLs tel: conformes à la RFC3966

### DIFF
--- a/contenus/conseils/README.md
+++ b/contenus/conseils/README.md
@@ -94,7 +94,7 @@ Nous vous conseillons de <a href="#suiviintroduction">renseigner son questionnai
 
 ## [conseils_contacts_utiles.md](conseils_contacts_utiles.md)
 
-La situation actuelle peut être difficile à vivre. Si vous le souhaitez, vous pouvez contacter le <a href="tel:0800190000">0800 19 00 00</a> pour une écoute et un soutien psychologique (appel gratuit, tous les jours de 9 h à 21 h).
+La situation actuelle peut être difficile à vivre. Si vous le souhaitez, vous pouvez contacter le <a href="tel:0800190000;phone-context=+33">0800 19 00 00</a> pour une écoute et un soutien psychologique (appel gratuit, tous les jours de 9 h à 21 h).
 
 
 
@@ -202,7 +202,7 @@ Certaines personnes continuent de ressentir des symptômes au-delà de 4 semain
 * [Association de patients et de chercheurs « TousPartenairesCovid »](https://touspartenairescovid.org/)
 
 
-Pour toutes vos questions sur la Covid, vous pouvez appeler le numéro vert [0 800 130 000](tel:+33800130000) (24 h/24 et 7 j/7).
+Pour toutes vos questions sur la Covid, vous pouvez appeler le numéro vert [0 800 130 000](tel:0800130000;phone-context=+33) (24 h/24 et 7 j/7).
 
 Décrypter les fausses informations ? [Désintox : la parole à la science](https://recherchecovid.enseignementsup-recherche.gouv.fr/desintox-la-parole-la-science).
 
@@ -943,7 +943,7 @@ Vous avec un traitement de longue durée ou une maladie chronique. Nous vous inv
 
 <div class="conseil">
 
-Trouvez les <a href="#conseils-vaccins" class="lien-vaccination">lieux de vaccination proches de chez vous</a> ou appelez le numéro vert <a href="tel:0800009110">0 800 009 110</a> (7j/7, de 6h à 22h) pour un accompagnement à la prise de rendez-vous.
+Trouvez les <a href="#conseils-vaccins" class="lien-vaccination">lieux de vaccination proches de chez vous</a> ou appelez le numéro vert <a href="tel:0800009110;phone-context=+33">0 800 009 110</a> (7j/7, de 6h à 22h) pour un accompagnement à la prise de rendez-vous.
 
 </div>
 
@@ -1016,6 +1016,6 @@ Pour vos **courses**, nous vous conseillons de :
   * réaliser vos courses lors des périodes les moins fréquentées ;
   * suivre [les conseils de l’ANSES](https://www.anses.fr/fr/content/coronavirus-alimentation-courses-nettoyage-les-recommandations-de-l%E2%80%99anses).
 
-Si vous êtes victime ou témoin de **violences conjugales**, vous pouvez contacter le <a href="tel:3919">39 19</a> (appel gratuit, de 9 h à 19 h du lundi au samedi) ou le <a href="tel:17">17</a> en cas d’urgence.
+Si vous êtes victime ou témoin de **violences conjugales**, vous pouvez contacter le <a href="tel:3919;phone-context=+33">39 19</a> (appel gratuit, de 9 h à 19 h du lundi au samedi) ou le <a href="tel:17;phone-context=+33">17</a> en cas d’urgence.
 
 

--- a/contenus/conseils/conseils_contacts_utiles.md
+++ b/contenus/conseils/conseils_contacts_utiles.md
@@ -1,1 +1,1 @@
-La situation actuelle peut être difficile à vivre. Si vous le souhaitez, vous pouvez contacter le <a href="tel:0800190000">0800 19 00 00</a> pour une écoute et un soutien psychologique (appel gratuit, tous les jours de 9 h à 21 h).
+La situation actuelle peut être difficile à vivre. Si vous le souhaitez, vous pouvez contacter le <a href="tel:0800190000;phone-context=+33">0800 19 00 00</a> pour une écoute et un soutien psychologique (appel gratuit, tous les jours de 9 h à 21 h).

--- a/contenus/conseils/conseils_covid.md
+++ b/contenus/conseils/conseils_covid.md
@@ -21,6 +21,6 @@ Certaines personnes continuent de ressentir des symptômes au-delà de 4 semain
 * [Association de patients et de chercheurs « TousPartenairesCovid »](https://touspartenairescovid.org/)
 
 
-Pour toutes vos questions sur la Covid, vous pouvez appeler le numéro vert [0 800 130 000](tel:+33800130000) (24 h/24 et 7 j/7).
+Pour toutes vos questions sur la Covid, vous pouvez appeler le numéro vert [0 800 130 000](tel:0800130000;phone-context=+33) (24 h/24 et 7 j/7).
 
 Décrypter les fausses informations ? [Désintox : la parole à la science](https://recherchecovid.enseignementsup-recherche.gouv.fr/desintox-la-parole-la-science).

--- a/contenus/conseils/conseils_vaccins_pas_encore_vaccine.md
+++ b/contenus/conseils/conseils_vaccins_pas_encore_vaccine.md
@@ -6,7 +6,7 @@
 
 <div class="conseil">
 
-Trouvez les <a href="#conseils-vaccins" class="lien-vaccination">lieux de vaccination proches de chez vous</a> ou appelez le numéro vert <a href="tel:0800009110">0 800 009 110</a> (7j/7, de 6h à 22h) pour un accompagnement à la prise de rendez-vous.
+Trouvez les <a href="#conseils-vaccins" class="lien-vaccination">lieux de vaccination proches de chez vous</a> ou appelez le numéro vert <a href="tel:0800009110;phone-context=+33">0 800 009 110</a> (7j/7, de 6h à 22h) pour un accompagnement à la prise de rendez-vous.
 
 </div>
 

--- a/contenus/conseils/conseils_vie_quotidienne.md
+++ b/contenus/conseils/conseils_vie_quotidienne.md
@@ -5,4 +5,4 @@ Pour vos **courses**, nous vous conseillons de :
   * réaliser vos courses lors des périodes les moins fréquentées ;
   * suivre [les conseils de l’ANSES](https://www.anses.fr/fr/content/coronavirus-alimentation-courses-nettoyage-les-recommandations-de-l%E2%80%99anses).
 
-Si vous êtes victime ou témoin de **violences conjugales**, vous pouvez contacter le <a href="tel:3919">39 19</a> (appel gratuit, de 9 h à 19 h du lundi au samedi) ou le <a href="tel:17">17</a> en cas d’urgence.
+Si vous êtes victime ou témoin de **violences conjugales**, vous pouvez contacter le <a href="tel:3919;phone-context=+33">39 19</a> (appel gratuit, de 9 h à 19 h du lundi au samedi) ou le <a href="tel:17;phone-context=+33">17</a> en cas d’urgence.

--- a/contenus/suivi/README.md
+++ b/contenus/suivi/README.md
@@ -64,12 +64,12 @@ Contactez votre médecin généraliste ou le 15 si votre médecin généraliste 
 
 ## [suivi_psy_1.md](suivi_psy_1.md)
 
-Pour tout problème **de moral ou d’anxiété**, vous pouvez appeler le numéro vert dédié <a href="tel:+33800130000">0 800 130 000</a> (24 h/24 et 7 j/7).
+Pour tout problème **de moral ou d’anxiété**, vous pouvez appeler le numéro vert dédié <a href="tel:0800130000;phone-context=+33">0 800 130 000</a> (24 h/24 et 7 j/7).
 
 
 
 ## [suivi_psy_2.md](suivi_psy_2.md)
 
-Pour tout problème **de moral ou d’anxiété**, si vous le désirez, vous pouvez appeler votre médecin ou le numéro vert dédié <a href="tel:+33800130000">0 800 130 000</a> (24 h/24 et 7 j/7).
+Pour tout problème **de moral ou d’anxiété**, si vous le désirez, vous pouvez appeler votre médecin ou le numéro vert dédié <a href="tel:0800130000;phone-context=+33">0 800 130 000</a> (24 h/24 et 7 j/7).
 
 

--- a/contenus/suivi/suivi_psy_1.md
+++ b/contenus/suivi/suivi_psy_1.md
@@ -1,1 +1,1 @@
-Pour tout problème **de moral ou d’anxiété**, vous pouvez appeler le numéro vert dédié <a href="tel:+33800130000">0 800 130 000</a> (24 h/24 et 7 j/7).
+Pour tout problème **de moral ou d’anxiété**, vous pouvez appeler le numéro vert dédié <a href="tel:0800130000;phone-context=+33">0 800 130 000</a> (24 h/24 et 7 j/7).

--- a/contenus/suivi/suivi_psy_2.md
+++ b/contenus/suivi/suivi_psy_2.md
@@ -1,1 +1,1 @@
-Pour tout problème **de moral ou d’anxiété**, si vous le désirez, vous pouvez appeler votre médecin ou le numéro vert dédié <a href="tel:+33800130000">0 800 130 000</a> (24 h/24 et 7 j/7).
+Pour tout problème **de moral ou d’anxiété**, si vous le désirez, vous pouvez appeler votre médecin ou le numéro vert dédié <a href="tel:0800130000;phone-context=+33">0 800 130 000</a> (24 h/24 et 7 j/7).

--- a/contenus/thematiques/README.md
+++ b/contenus/thematiques/README.md
@@ -234,7 +234,7 @@ Vous pouvez vous faire vacciner **dès maintenant** :
 
 * Chez votre **médecin traitant**, en cabinet infirmier, ou en pharmacie, avec un vaccin *AstraZeneca* ou *Janssen* (si vous avez **55 ans ou plus**).
 
-Trouvez les lieux de vaccination proches de chez vous sur le site [sante.fr](https://www.sante.fr/cf/centres-vaccination-covid.html) ou en appelant le numéro vert <a href="tel:0800009110">0 800 009 110</a> (7j/7, de 6h à 22h).
+Trouvez les lieux de vaccination proches de chez vous sur le site [sante.fr](https://www.sante.fr/cf/centres-vaccination-covid.html) ou en appelant le numéro vert <a href="tel:0800009110;phone-context=+33">0 800 009 110</a> (7j/7, de 6h à 22h).
 
 </div>
 </div>
@@ -248,7 +248,7 @@ Trouvez les lieux de vaccination proches de chez vous sur le site [sante.fr](htt
 
 Les centres de vaccination proposent une prise de rendez-vous par internet (via une des trois plateformes Doctolib, Keldoc ou Maiia) ou par téléphone.
 
-Pour savoir comment prendre rendez-vous dans les lieux de vaccination proches de chez vous, consultez [sante.fr](https://www.sante.fr/cf/centres-vaccination-covid.html) ou appelez le numéro vert <a href="tel:0800009110">0 800 009 110</a> pour être accompagné dans votre prise de rendez-vous.
+Pour savoir comment prendre rendez-vous dans les lieux de vaccination proches de chez vous, consultez [sante.fr](https://www.sante.fr/cf/centres-vaccination-covid.html) ou appelez le numéro vert <a href="tel:0800009110;phone-context=+33">0 800 009 110</a> pour être accompagné dans votre prise de rendez-vous.
 
 </div>
 </div>

--- a/contenus/thematiques/je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/je-veux-me-faire-vacciner.md
@@ -35,7 +35,7 @@ Vous pouvez vous faire vacciner **dès maintenant** :
 
 * Chez votre **médecin traitant**, en cabinet infirmier, ou en pharmacie, avec un vaccin *AstraZeneca* ou *Janssen* (si vous avez **55 ans ou plus**).
 
-Trouvez les lieux de vaccination proches de chez vous sur le site [sante.fr](https://www.sante.fr/cf/centres-vaccination-covid.html) ou en appelant le numéro vert <a href="tel:0800009110">0 800 009 110</a> (7j/7, de 6h à 22h).
+Trouvez les lieux de vaccination proches de chez vous sur le site [sante.fr](https://www.sante.fr/cf/centres-vaccination-covid.html) ou en appelant le numéro vert <a href="tel:0800009110;phone-context=+33">0 800 009 110</a> (7j/7, de 6h à 22h).
 
 </div>
 </div>
@@ -49,7 +49,7 @@ Trouvez les lieux de vaccination proches de chez vous sur le site [sante.fr](htt
 
 Les centres de vaccination proposent une prise de rendez-vous par internet (via une des trois plateformes Doctolib, Keldoc ou Maiia) ou par téléphone.
 
-Pour savoir comment prendre rendez-vous dans les lieux de vaccination proches de chez vous, consultez [sante.fr](https://www.sante.fr/cf/centres-vaccination-covid.html) ou appelez le numéro vert <a href="tel:0800009110">0 800 009 110</a> pour être accompagné dans votre prise de rendez-vous.
+Pour savoir comment prendre rendez-vous dans les lieux de vaccination proches de chez vous, consultez [sante.fr](https://www.sante.fr/cf/centres-vaccination-covid.html) ou appelez le numéro vert <a href="tel:0800009110;phone-context=+33">0 800 009 110</a> pour être accompagné dans votre prise de rendez-vous.
 
 </div>
 </div>

--- a/src/scripts/injection.js
+++ b/src/scripts/injection.js
@@ -43,7 +43,7 @@ export function CTAIContact(element, departement) {
     const contactHTML = []
     if (telephone) {
         contactHTML.push(
-            ` au <a href="tel:${telephone}" style="white-space: nowrap;">${telephone
+            ` au <a href="tel:${telephone};phone-context=+33" style="white-space: nowrap;">${telephone
                 .match(/.{1,2}/g)
                 .join(' ')}</a>`
         )

--- a/src/scripts/tests/test.injection.js
+++ b/src/scripts/tests/test.injection.js
@@ -38,7 +38,7 @@ describe('Injection', function () {
 
         assert.strictEqual(
             element.innerHTML,
-            '<span id="ctai-contact-placeholder"> au <a href="tel:0470483048" style="white-space: nowrap;">04 70 48 30 48</a> ou  à l’adresse <a href="mailto:pref-ctai@allier.gouv.fr">pref-ctai@allier.gouv.fr</a></span>'
+            '<span id="ctai-contact-placeholder"> au <a href="tel:0470483048;phone-context=+33" style="white-space: nowrap;">04 70 48 30 48</a> ou  à l’adresse <a href="mailto:pref-ctai@allier.gouv.fr">pref-ctai@allier.gouv.fr</a></span>'
         )
     })
 
@@ -50,7 +50,7 @@ describe('Injection', function () {
 
         assert.strictEqual(
             element.innerHTML,
-            '<span id="ctai-contact-placeholder"> au <a href="tel:0325305252" style="white-space: nowrap;">03 25 30 52 52</a></span>'
+            '<span id="ctai-contact-placeholder"> au <a href="tel:0325305252;phone-context=+33" style="white-space: nowrap;">03 25 30 52 52</a></span>'
         )
     })
 


### PR DESCRIPTION
Indique que ce sont des numéros locaux, valides seulement en France.

cf. https://tools.ietf.org/html/rfc3966