### PR TITLE
A11Y: libellé explicite pour le titre

### DIFF
--- a/contenus/questions/README.md
+++ b/contenus/questions/README.md
@@ -873,16 +873,6 @@ Cette personne est **en cours de vaccination**
 
 
 
-## [question_vaccins_libellé.md](question_vaccins_libellé.md)
-
-Mon statut actuel de vaccination contre la Covid :
-
----
-
-Son statut actuel de vaccination contre la Covid :
-
-
-
 ## [question_vaccins_pas_encore_libellé.md](question_vaccins_pas_encore_libellé.md)
 
 Je n’ai **pas encore été vacciné·e**
@@ -895,10 +885,10 @@ Cette personne n’a **pas encore été vaccinée**
 
 ## [question_vaccins_titre.md](question_vaccins_titre.md)
 
-Ma vaccination
+Mon statut actuel de vaccination contre la Covid
 
 ---
 
-Sa vaccination
+Son statut actuel de vaccination contre la Covid
 
 

--- a/contenus/questions/question_vaccins_libellé.md
+++ b/contenus/questions/question_vaccins_libellé.md
@@ -1,5 +1,0 @@
-Mon statut actuel de vaccination contre la Covid :
-
----
-
-Son statut actuel de vaccination contre la Covid :

--- a/contenus/questions/question_vaccins_titre.md
+++ b/contenus/questions/question_vaccins_titre.md
@@ -1,5 +1,5 @@
-Ma vaccination
+Mon statut actuel de vaccination contre la Covid
 
 ---
 
-Sa vaccination
+Son statut actuel de vaccination contre la Covid

--- a/src/scripts/tests/integration/test.pages.js
+++ b/src/scripts/tests/integration/test.pages.js
@@ -37,7 +37,7 @@ describe('Pages', function () {
             ])
             assert.equal(
                 await page.title(),
-                'Ma vaccination (étape 1) — Mes Conseils Covid — Isolement, tests, vaccins… tout savoir pour prendre soin de votre santé'
+                'Mon statut actuel de vaccination contre la Covid (étape 1) — Mes Conseils Covid — Isolement, tests, vaccins… tout savoir pour prendre soin de votre santé'
             )
         }
 

--- a/src/scripts/tests/integration/test.profils.js
+++ b/src/scripts/tests/integration/test.profils.js
@@ -37,7 +37,10 @@ describe('Profils', function () {
             let legend = await page.waitForSelector(
                 '#page.ready #vaccins-form legend h1'
             )
-            assert.equal(await legend.innerText(), 'Sa vaccination')
+            assert.equal(
+                await legend.innerText(),
+                'Son statut actuel de vaccination contre la Covid'
+            )
         }
 
         // Remplir le questionnaire.

--- a/templates/index.html
+++ b/templates/index.html
@@ -151,10 +151,7 @@
 <section id="vaccins" hidden>
     <form id="vaccins-form" class="block">
         <fieldset>
-            <legend><h1>{{ question_vaccins_titre|inline|me_or_them }}</h1></legend>
-            <div id="vaccins-label" class="secondary-title">
-                {{ question_vaccins_libellé|me_or_them }}
-            </div>
+            <legend><h1 id="vaccins-label">{{ question_vaccins_titre|inline|me_or_them }}</h1></legend>
             <div role="radiogroup" aria-labelledby="vaccins-label">
                 <input id="vaccins_radio_pas_encore" type="radio" required name="vaccins_radio" value="pas_encore">
                 <label for="vaccins_radio_pas_encore">{{ question_vaccins_pas_encore_libellé|inline|me_or_them }}</label>


### PR DESCRIPTION
Cela permet de retirer le sous-titre actuel.