### PR TITLE
Mise à jour des conseils sur la vaccination au 3 juin

### DIFF
--- a/contenus/conseils/README.md
+++ b/contenus/conseils/README.md
@@ -937,9 +937,11 @@ Vous avec un traitement de longue durée ou une maladie chronique. Nous vous inv
 
 #### Où se faire vacciner ?
 
-* Dans un **centre de vaccination**, avec un vaccin *Pfizer-BioNTech* ou *Moderna*.
+* Dans un **centre de vaccination**, avec un vaccin *Pfizer-BioNTech*.
 
-* Chez son **médecin traitant**, en cabinet infirmier, ou en pharmacie, avec un vaccin *AstraZeneca* ou *Janssen* (pour les personnes de **55 ans et plus**).
+* Chez son **médecin traitant**, en cabinet infirmier, ou en pharmacie :
+    * avec un vaccin *Moderna*,
+    * avec un vaccin *AstraZeneca* ou *Janssen* (si vous avez **55 ans ou plus**).
 
 <div class="conseil">
 

--- a/contenus/conseils/README.md
+++ b/contenus/conseils/README.md
@@ -950,11 +950,13 @@ Trouvez les <a href="#conseils-vaccins" class="lien-vaccination">lieux de vaccin
 
 #### Quand se faire vacciner ?
 
+<span class="nouveau">nouveau</span> Les personnes de 12 à 18 ans pourront se faire vacciner dès le 15 juin.
+
 Vous pouvez vous faire vacciner **dès maintenant** :
 
 * si vous avez **18 ans et plus**, sans conditions ;
-* si vous avez entre **16 et 17 ans** et présentez un risque de développer une **forme très grave** de Covid (cancer, dialyse, trisomie 21, etc.) ;
-* si vous êtes au **second trimestre** de votre grossesse.
+* si vous avez entre **16 et 17 ans** et présentez un risque de développer une **forme très grave** de Covid (cancer, dialyse, trisomie 21, etc.), ou si vous vivez sous le même toit qu’une personne immunodéprimée (dialysée, ayant reçu une transplantation d’organe ou de moelle osseuse, traitée par des médicaments immunosuppresseurs forts), ou que vous lui apportez une aide quotidienne ;
+* si vous êtes **enceinte**, à partir du second trimestre de votre grossesse.
 
 Pour en savoir plus :
 

--- a/contenus/conseils/conseils_vaccins_pas_encore_vaccine.md
+++ b/contenus/conseils/conseils_vaccins_pas_encore_vaccine.md
@@ -13,11 +13,13 @@ Trouvez les <a href="#conseils-vaccins" class="lien-vaccination">lieux de vaccin
 
 #### Quand se faire vacciner ?
 
+<span class="nouveau">nouveau</span> Les personnes de 12 à 18 ans pourront se faire vacciner dès le 15 juin.
+
 Vous pouvez vous faire vacciner **dès maintenant** :
 
 * si vous avez **18 ans et plus**, sans conditions ;
-* si vous avez entre **16 et 17 ans** et présentez un risque de développer une **forme très grave** de Covid (cancer, dialyse, trisomie 21, etc.) ;
-* si vous êtes au **second trimestre** de votre grossesse.
+* si vous avez entre **16 et 17 ans** et présentez un risque de développer une **forme très grave** de Covid (cancer, dialyse, trisomie 21, etc.), ou si vous vivez sous le même toit qu’une personne immunodéprimée (dialysée, ayant reçu une transplantation d’organe ou de moelle osseuse, traitée par des médicaments immunosuppresseurs forts), ou que vous lui apportez une aide quotidienne ;
+* si vous êtes **enceinte**, à partir du second trimestre de votre grossesse.
 
 Pour en savoir plus :
 

--- a/contenus/conseils/conseils_vaccins_pas_encore_vaccine.md
+++ b/contenus/conseils/conseils_vaccins_pas_encore_vaccine.md
@@ -1,8 +1,10 @@
 #### Où se faire vacciner ?
 
-* Dans un **centre de vaccination**, avec un vaccin *Pfizer-BioNTech* ou *Moderna*.
+* Dans un **centre de vaccination**, avec un vaccin *Pfizer-BioNTech*.
 
-* Chez son **médecin traitant**, en cabinet infirmier, ou en pharmacie, avec un vaccin *AstraZeneca* ou *Janssen* (pour les personnes de **55 ans et plus**).
+* Chez son **médecin traitant**, en cabinet infirmier, ou en pharmacie :
+    * avec un vaccin *Moderna*,
+    * avec un vaccin *AstraZeneca* ou *Janssen* (si vous avez **55 ans ou plus**).
 
 <div class="conseil">
 

--- a/contenus/thematiques/README.md
+++ b/contenus/thematiques/README.md
@@ -233,9 +233,11 @@ Vous pouvez vous faire vacciner **dès maintenant** :
 <div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
 <div itemprop="text">
 
-* Dans un **centre de vaccination**, avec un vaccin *Pfizer-BioNTech* ou *Moderna*.
+* Dans un **centre de vaccination**, avec un vaccin *Pfizer-BioNTech*.
 
-* Chez votre **médecin traitant**, en cabinet infirmier, ou en pharmacie, avec un vaccin *AstraZeneca* ou *Janssen* (si vous avez **55 ans ou plus**).
+* Chez votre **médecin traitant**, en cabinet infirmier, ou en pharmacie :
+    * avec un vaccin *Moderna*,
+    * avec un vaccin *AstraZeneca* ou *Janssen* (si vous avez **55 ans ou plus**).
 
 Trouvez les lieux de vaccination proches de chez vous sur le site [sante.fr](https://www.sante.fr/cf/centres-vaccination-covid.html) ou en appelant le numéro vert <a href="tel:0800009110">0 800 009 110</a> (7j/7, de 6h à 22h).
 

--- a/contenus/thematiques/README.md
+++ b/contenus/thematiques/README.md
@@ -214,11 +214,14 @@ Nous vous conseillons de vérifier directement auprès des autorités du pays de
 <div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
 <div itemprop="text">
 
+<span class="nouveau">nouveau</span> Les personnes de 12 à 18 ans pourront se faire vacciner dès le 15 juin.
+
 Vous pouvez vous faire vacciner **dès maintenant** :
 
 * si vous avez **18 ans et plus**, sans conditions ;
-* si vous avez entre **16 et 17 ans** et présentez un risque de développer une **forme très grave** de Covid (cancer, dialyse, trisomie 21, etc.) ;
-* si vous êtes au **second trimestre** de votre grossesse.
+* si vous avez entre **16 et 17 ans** et présentez un risque de développer une **forme très grave** de Covid (cancer, dialyse, trisomie 21, etc.), ou si vous vivez sous le même toit qu’une personne immunodéprimée (dialysée, ayant reçu une transplantation d’organe ou de moelle osseuse, traitée par des médicaments immunosuppresseurs forts), ou que vous lui apportez une aide quotidienne ;
+* si vous êtes **enceinte**, à partir du second trimestre de votre grossesse.
+
 
 </div>
 </div>

--- a/contenus/thematiques/je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/je-veux-me-faire-vacciner.md
@@ -15,11 +15,14 @@
 <div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
 <div itemprop="text">
 
+<span class="nouveau">nouveau</span> Les personnes de 12 à 18 ans pourront se faire vacciner dès le 15 juin.
+
 Vous pouvez vous faire vacciner **dès maintenant** :
 
 * si vous avez **18 ans et plus**, sans conditions ;
-* si vous avez entre **16 et 17 ans** et présentez un risque de développer une **forme très grave** de Covid (cancer, dialyse, trisomie 21, etc.) ;
-* si vous êtes au **second trimestre** de votre grossesse.
+* si vous avez entre **16 et 17 ans** et présentez un risque de développer une **forme très grave** de Covid (cancer, dialyse, trisomie 21, etc.), ou si vous vivez sous le même toit qu’une personne immunodéprimée (dialysée, ayant reçu une transplantation d’organe ou de moelle osseuse, traitée par des médicaments immunosuppresseurs forts), ou que vous lui apportez une aide quotidienne ;
+* si vous êtes **enceinte**, à partir du second trimestre de votre grossesse.
+
 
 </div>
 </div>

--- a/contenus/thematiques/je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/je-veux-me-faire-vacciner.md
@@ -34,9 +34,11 @@ Vous pouvez vous faire vacciner **dès maintenant** :
 <div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
 <div itemprop="text">
 
-* Dans un **centre de vaccination**, avec un vaccin *Pfizer-BioNTech* ou *Moderna*.
+* Dans un **centre de vaccination**, avec un vaccin *Pfizer-BioNTech*.
 
-* Chez votre **médecin traitant**, en cabinet infirmier, ou en pharmacie, avec un vaccin *AstraZeneca* ou *Janssen* (si vous avez **55 ans ou plus**).
+* Chez votre **médecin traitant**, en cabinet infirmier, ou en pharmacie :
+    * avec un vaccin *Moderna*,
+    * avec un vaccin *AstraZeneca* ou *Janssen* (si vous avez **55 ans ou plus**).
 
 Trouvez les lieux de vaccination proches de chez vous sur le site [sante.fr](https://www.sante.fr/cf/centres-vaccination-covid.html) ou en appelant le numéro vert <a href="tel:0800009110">0 800 009 110</a> (7j/7, de 6h à 22h).
 


### PR DESCRIPTION
- les personnes de 12 à 18 ans pourront être vaccinées dès le 15 juin
- le vaccin Moderna est maintenant utilisé exclusivement en ville
- précisions supplémentaires