### PR TITLE
Fin du couvre-feu en métropole

### DIFF
--- a/contenus/conseils/conseils_couvre_feu.md
+++ b/contenus/conseils/conseils_couvre_feu.md
@@ -1,4 +1,1 @@
-Pour plus d’informations, vous pouvez consulter :
-
-* [la page dédiée au couvre-feu sur le site du gouvernement](https://www.gouvernement.fr/info-coronavirus/couvre-feu) ;
-* les règles spécifiques de votre **département** sur <a href="#conseils-departement" id="lien-prefecture">le site de votre préfecture</a>.
+Pour plus d’informations, vous pouvez consulter les règles spécifiques de votre **département** sur <a href="#conseils-departement" id="lien-prefecture">le site de votre préfecture</a>.

--- a/contenus/conseils/conseils_couvre_feu_21h.md
+++ b/contenus/conseils/conseils_couvre_feu_21h.md
@@ -1,7 +1,0 @@
-<div class="conseil conseil-jaune">
-
-<span class="nouveau">nouveau</span> Un **couvre-feu** s’applique dans votre département de **23 h** à **6 h** du matin jusqu’au dimanche 20 juin.
-
-</div>
-
-Pour tout déplacement pendant le couvre-feu, une [attestation dérogatoire](https://media.interieur.gouv.fr/attestation-deplacement-derogatoire-covid-19/) et la justification du motif du déplacement sont obligatoires.

--- a/contenus/conseils/conseils_couvre_feu_976.md
+++ b/contenus/conseils/conseils_couvre_feu_976.md
@@ -1,1 +1,0 @@
-Les rassemblements, réunions ou activités à un titre autre que professionnel sur la voie publique ou dans un lieu public, mettant en présence de manière simultanée plus de 10 personnes, sont interdits.

--- a/src/scripts/algorithme/orientation.js
+++ b/src/scripts/algorithme/orientation.js
@@ -539,17 +539,17 @@ export default class AlgorithmeOrientation {
     vieQuotidienneBlockNamesToDisplay() {
         const blockNames = ['conseils-vie-quotidienne']
         if (this.profil.departement === '971') {
+            blockNames.push('conseils-couvre-feu')
             blockNames.push('conseils-couvre-feu-971')
         } else if (this.profil.departement === '972') {
+            blockNames.push('conseils-couvre-feu')
             blockNames.push('conseils-couvre-feu-972')
         } else if (this.profil.departement === '973') {
+            blockNames.push('conseils-couvre-feu')
             blockNames.push('conseils-couvre-feu-973')
         } else if (this.profil.departement === '974') {
+            blockNames.push('conseils-couvre-feu')
             blockNames.push('conseils-couvre-feu-974')
-        } else if (this.profil.departement === '976') {
-            blockNames.push('conseils-couvre-feu-976')
-        } else {
-            blockNames.push('conseils-couvre-feu-21h')
         }
         blockNames.push('conseils-deplacements')
         blockNames.push('conseils-pass-sanitaire')

--- a/src/scripts/tests/integration/test.parcours.js
+++ b/src/scripts/tests/integration/test.parcours.js
@@ -42,13 +42,6 @@ describe('Parcours', function () {
 
         // Conseils.
         {
-            // On rend la localisation visible.
-            await page.click('#page.ready #conseils-deplacements h3')
-
-            // On retrouve le département de résidence.
-            let residence = await page.waitForSelector('#page.ready #nom-departement')
-            assert.equal(await residence.innerText(), 'Somme')
-
             // On rend l’activité visible.
             await page.click('#page.ready #conseils-activite h3')
 
@@ -125,17 +118,7 @@ describe('Parcours', function () {
 
         await waitForPlausibleTrackingEvent(page, 'Questionnaire commencé:vaccins')
 
-        // Conseils.
-        {
-            // On rend la localisation visible.
-            await page.click('#page.ready #conseils-deplacements h3')
-
-            // On retrouve le département de résidence.
-            let residence = await page.waitForSelector('#page.ready #nom-departement')
-            assert.equal(await residence.innerText(), 'Somme')
-
-            await waitForPlausibleTrackingEvent(page, 'Questionnaire terminé:conseils')
-        }
+        await waitForPlausibleTrackingEvent(page, 'Questionnaire terminé:conseils')
     })
 
     it('remplir le questionnaire avec symptômes (gravité majeure)', async function () {

--- a/src/scripts/tests/integration/test.profils.js
+++ b/src/scripts/tests/integration/test.profils.js
@@ -65,13 +65,6 @@ describe('Profils', function () {
             let titre = await page.waitForSelector('#page.ready #conseils-block-titre')
             assert.equal(await titre.innerText(), 'Conseils pour « Mamie »') // &nbsp; autour du nom
 
-            // On rend la localisation visible.
-            await page.click('#page.ready #conseils-deplacements h3')
-
-            // On retrouve le département de résidence.
-            let residence = await page.waitForSelector('#page.ready #nom-departement')
-            assert.equal(await residence.innerText(), 'Somme')
-
             // On rend l’activité visible.
             await page.click('#page.ready #conseils-activite h3')
 

--- a/src/scripts/tests/test.algorithme.orientation.js
+++ b/src/scripts/tests/test.algorithme.orientation.js
@@ -878,26 +878,24 @@ describe('Blocs d’informations additionnels', function () {
     })
 
     describe('Bloc vie quotidienne', function () {
-        it('Le couvre-feu 21h est affiché par défaut', function () {
+        it('Pas de couvre-feu en métropole', function () {
             var profil = new Profil('mes_infos', {
                 departement: '01',
             })
             var algoOrientation = new AlgorithmeOrientation(profil)
             assert.deepEqual(algoOrientation.vieQuotidienneBlockNamesToDisplay(), [
                 'conseils-vie-quotidienne',
-                'conseils-couvre-feu-21h',
                 'conseils-deplacements',
                 'conseils-pass-sanitaire',
             ])
         })
-        it('À Mayotte, c’est un couvre-feu adapté', function () {
+        it('Pas de couvre-feu à Mayotte', function () {
             var profil = new Profil('mes_infos', {
                 departement: '976',
             })
             var algoOrientation = new AlgorithmeOrientation(profil)
             assert.deepEqual(algoOrientation.vieQuotidienneBlockNamesToDisplay(), [
                 'conseils-vie-quotidienne',
-                'conseils-couvre-feu-976',
                 'conseils-deplacements',
                 'conseils-pass-sanitaire',
             ])
@@ -909,6 +907,7 @@ describe('Blocs d’informations additionnels', function () {
             var algoOrientation = new AlgorithmeOrientation(profil)
             assert.deepEqual(algoOrientation.vieQuotidienneBlockNamesToDisplay(), [
                 'conseils-vie-quotidienne',
+                'conseils-couvre-feu',
                 'conseils-couvre-feu-974',
                 'conseils-deplacements',
                 'conseils-pass-sanitaire',
@@ -921,6 +920,7 @@ describe('Blocs d’informations additionnels', function () {
             var algoOrientation = new AlgorithmeOrientation(profil)
             assert.deepEqual(algoOrientation.vieQuotidienneBlockNamesToDisplay(), [
                 'conseils-vie-quotidienne',
+                'conseils-couvre-feu',
                 'conseils-couvre-feu-971',
                 'conseils-deplacements',
                 'conseils-pass-sanitaire',
@@ -933,6 +933,7 @@ describe('Blocs d’informations additionnels', function () {
             var algoOrientation = new AlgorithmeOrientation(profil)
             assert.deepEqual(algoOrientation.vieQuotidienneBlockNamesToDisplay(), [
                 'conseils-vie-quotidienne',
+                'conseils-couvre-feu',
                 'conseils-couvre-feu-972',
                 'conseils-deplacements',
                 'conseils-pass-sanitaire',
@@ -945,19 +946,8 @@ describe('Blocs d’informations additionnels', function () {
             var algoOrientation = new AlgorithmeOrientation(profil)
             assert.deepEqual(algoOrientation.vieQuotidienneBlockNamesToDisplay(), [
                 'conseils-vie-quotidienne',
+                'conseils-couvre-feu',
                 'conseils-couvre-feu-973',
-                'conseils-deplacements',
-                'conseils-pass-sanitaire',
-            ])
-        })
-        it('À département inconnu, c’est le couvre-feu 21h', function () {
-            var profil = new Profil('mes_infos', {
-                departement: '00',
-            })
-            var algoOrientation = new AlgorithmeOrientation(profil)
-            assert.deepEqual(algoOrientation.vieQuotidienneBlockNamesToDisplay(), [
-                'conseils-vie-quotidienne',
-                'conseils-couvre-feu-21h',
                 'conseils-deplacements',
                 'conseils-pass-sanitaire',
             ])

--- a/templates/index.html
+++ b/templates/index.html
@@ -1372,29 +1372,25 @@
                                 <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path d="M12.95 10.707l.707-.707L8 4.343 6.586 5.757 10.828 10l-4.242 4.243L8 15.657l4.95-4.95z"/></svg>
                             </h3>
                         </summary>
-                        <h4>Couvre-feu</h4>
-                        <div class="reponse">
-                            {{ réponse_département }}
+                        <div id="conseils-couvre-feu" hidden>
+                            <h4>Couvre-feu</h4>
+                            <div class="reponse">
+                                {{ réponse_département }}
+                            </div>
+                            <div id="conseils-couvre-feu-971" hidden>
+                                {{ conseils_couvre_feu_971 }}
+                            </div>
+                            <div id="conseils-couvre-feu-972" hidden>
+                                {{ conseils_couvre_feu_972 }}
+                            </div>
+                            <div id="conseils-couvre-feu-973" hidden>
+                                {{ conseils_couvre_feu_973 }}
+                            </div>
+                            <div id="conseils-couvre-feu-974" hidden>
+                                {{ conseils_couvre_feu_974 }}
+                            </div>
+                            {{ conseils_couvre_feu }}
                         </div>
-                        <div id="conseils-couvre-feu-21h" hidden>
-                            {{ conseils_couvre_feu_21h }}
-                        </div>
-                        <div id="conseils-couvre-feu-971" hidden>
-                            {{ conseils_couvre_feu_971 }}
-                        </div>
-                        <div id="conseils-couvre-feu-972" hidden>
-                            {{ conseils_couvre_feu_972 }}
-                        </div>
-                        <div id="conseils-couvre-feu-973" hidden>
-                            {{ conseils_couvre_feu_973 }}
-                        </div>
-                        <div id="conseils-couvre-feu-974" hidden>
-                            {{ conseils_couvre_feu_974 }}
-                        </div>
-                        <div id="conseils-couvre-feu-976" hidden>
-                            {{ conseils_couvre_feu_976 }}
-                        </div>
-                        {{ conseils_couvre_feu }}
                         {{ conseils_deplacements }}
                     </details>
                 </div>


### PR DESCRIPTION
Le couvre-feu était déjà levé à Mayotte depuis le 19/5, mais on affichait toujours un message sur les restrictions relatives aux rassemblements. On le supprime par souci de simplification.