### PR TITLE
Mise à jour de la liste des pays rouges

### DIFF
--- a/contenus/thematiques/1-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/1-pass-sanitaire-qr-code-voyages.md
@@ -79,7 +79,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 
     * d’un [pays classé **vert**](https://www.gouvernement.fr/info-coronavirus/deplacements) (pays de l’espace européen, auxquels s’ajoutent l’Albanie, l’Arabie Saoudite, l’Australie, la Bosnie, le Canada, la Corée du Sud, les États-Unis, Hong-Kong, Israël, le Japon, le Kosovo, le Liban, la Macédoine du Nord, le Monténégro, la Nouvelle-Zélande, la Serbie, Singapour, Taïwan, Vanuatu) : vous n’aurez pas à respecter une quarantaine à votre retour mais vous devez présenter un test antigénique ou PCR négatif de moins de 72 h.
 
-    * d’un [pays classé **rouge**](https://www.gouvernement.fr/info-coronavirus/deplacements) (Afghanistan, Afrique du Sud, Argentine, Bahreïn, Bangladesh, Bolivie, Brésil, Chili, Colombie, Costa-Rica, Inde, Maldives, Namibie, Népal, Pakistan, Paraguay, Russie, Seychelles, Sri Lanka, Suriname et Uruguay), vous devez :
+    * d’un [pays classé **rouge**](https://www.gouvernement.fr/info-coronavirus/deplacements) (Afghanistan, Afrique du Sud, Argentine, Bahreïn, Bangladesh, Bolivie, Brésil, Chili, Colombie, Costa-Rica, Inde, Maldives, Namibie, Népal, Oman, Pakistan, Paraguay, République Démocratique du Congo, Russie, Seychelles, Sri Lanka, Suriname, Uruguay et la Zambie), vous devez :
 
         - à l’embarquement, présenter un test PCR ou antigénique négatif réalisé il y a moins de 48 h ;
         - à l’arrivée, vous soumettre à un test antigénique ;


### PR DESCRIPTION
⚠️ la date en entête de https://www.interieur.gouv.fr/Actualites/Infos-pratiques/Attestation-de-deplacement-et-de-voyage ne tient pas compte des mises à jour des listes de cette page…