### PR TITLE
Change l’ordre des pages du questionnaire

### DIFF
--- a/contenus/questions/question_historique_covid_passee_libellé.md
+++ b/contenus/questions/question_historique_covid_passee_libellé.md
@@ -1,5 +1,5 @@
-J’ai déjà eu la **Covid**
+J’ai déjà eu la **Covid** par le passé
 
 ---
 
-Cette personne a déjà eu la **Covid**
+Cette personne a déjà eu la **Covid** par le passé

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -251,4 +251,16 @@ export default class App {
                 encodeURIComponent(e.message)
         }
     }
+    premierDemarrageFormulaire() {
+        if (typeof this.profil.questionnaire_start_date === 'undefined') {
+            this.profil.questionnaire_start_date = new Date()
+            this.enregistrerProfilActuel()
+            this.plausible('Questionnaire commencé')
+            if (this.profil.estMonProfil()) {
+                this.plausible('Questionnaire commencé pour moi')
+            } else {
+                this.plausible('Questionnaire commencé pour un proche')
+            }
+        }
+    }
 }

--- a/src/scripts/page/questionnaire/symptomes.js
+++ b/src/scripts/page/questionnaire/symptomes.js
@@ -13,6 +13,8 @@ import AlgorithmeOrientation from '../../algorithme/orientation'
 export default function symptomes(page, app) {
     const form = page.querySelector('form')
 
+    app.premierDemarrageFormulaire()
+
     // Selon le choix radio ça affiche le choix des symptômes et/ou
     // la saisie de la date.
     const statuts = form.elements['symptomes_actuels_statuts']

--- a/src/scripts/page/questionnaire/vaccins.js
+++ b/src/scripts/page/questionnaire/vaccins.js
@@ -7,8 +7,6 @@ import {
 export default function vaccins(page, app) {
     const form = page.querySelector('form')
 
-    app.premierDemarrageFormulaire()
-
     // Remplir le formulaire avec les données du profil.
     if (typeof app.profil.vaccins !== 'undefined') {
         form.querySelector('#vaccins_radio_' + app.profil.vaccins).checked = true

--- a/src/scripts/page/questionnaire/vaccins.js
+++ b/src/scripts/page/questionnaire/vaccins.js
@@ -7,7 +7,7 @@ import {
 export default function vaccins(page, app) {
     const form = page.querySelector('form')
 
-    premierDemarrageFormulaire(app)
+    app.premierDemarrageFormulaire()
 
     // Remplir le formulaire avec les données du profil.
     if (typeof app.profil.vaccins !== 'undefined') {
@@ -32,17 +32,4 @@ export default function vaccins(page, app) {
             app.goToNextPage('vaccins')
         })
     })
-}
-
-function premierDemarrageFormulaire(app) {
-    if (typeof app.profil.questionnaire_start_date === 'undefined') {
-        app.profil.questionnaire_start_date = new Date()
-        app.enregistrerProfilActuel()
-        app.plausible('Questionnaire commencé')
-        if (app.profil.estMonProfil()) {
-            app.plausible('Questionnaire commencé pour moi')
-        } else {
-            app.plausible('Questionnaire commencé pour un proche')
-        }
-    }
 }

--- a/src/scripts/questionnaire.js
+++ b/src/scripts/questionnaire.js
@@ -16,11 +16,11 @@ export function beforeSuiviHistorique(profil, questionnaire) {
 
 // Représentation de la structure du questionnaire d’orientation.
 export const ORDRE = [
-    'vaccins',
-    'historique',
     'symptomes',
     'contactarisque',
     'depistage',
+    'historique',
+    'vaccins',
     'situation',
     'sante',
 ]
@@ -30,20 +30,8 @@ export const TRANSITIONS = {
         previous: { introduction: () => true },
         next: { symptomes: (profil) => profil.nom },
     },
-    vaccins: {
-        previous: { introduction: () => true },
-        next: {
-            historique: (profil) => profil.isVaccinsComplete(),
-        },
-    },
-    historique: {
-        previous: { vaccins: () => true },
-        next: {
-            symptomes: (profil) => profil.isHistoriqueComplete(),
-        },
-    },
     symptomes: {
-        previous: { historique: () => true },
+        previous: { introduction: () => true },
         next: {
             depistage: (profil) =>
                 profil.isSymptomesComplete() &&
@@ -70,12 +58,24 @@ export const TRANSITIONS = {
             contactarisque: (profil) => profil.isContactARisqueComplete(),
         },
         next: {
-            situation: (profil) => profil.isDepistageComplete(),
+            historique: (profil) => profil.isDepistageComplete(),
+        },
+    },
+    historique: {
+        previous: { depistage: () => true },
+        next: {
+            vaccins: (profil) => profil.isHistoriqueComplete(),
+        },
+    },
+    vaccins: {
+        previous: { historique: () => true },
+        next: {
+            situation: (profil) => profil.isVaccinsComplete(),
         },
     },
     situation: {
         previous: {
-            depistage: (profil) => profil.isDepistageComplete(),
+            vaccins: () => true,
         },
         next: {
             sante: (profil) => profil.isSituationComplete(),

--- a/src/scripts/tests/integration/helpers.js
+++ b/src/scripts/tests/integration/helpers.js
@@ -44,8 +44,6 @@ export async function remplirQuestionnaire(page, choix) {
     if (typeof choix.nom !== 'undefined') {
         await remplirNom(page, choix.nom)
     }
-    await remplirVaccins(page, choix.vaccins)
-    await remplirHistorique(page, choix.covid_passee, choix.nbMois)
     await remplirSymptomes(
         page,
         choix.symptomesActuels,
@@ -67,6 +65,8 @@ export async function remplirQuestionnaire(page, choix) {
         choix.depistageType,
         choix.depistageResultat
     )
+    await remplirHistorique(page, choix.covid_passee, choix.nbMois)
+    await remplirVaccins(page, choix.vaccins)
     await remplirSituation(page, choix.departement, choix.enfants, choix.activitePro)
     await remplirSante(
         page,
@@ -81,7 +81,10 @@ export async function remplirQuestionnaire(page, choix) {
 async function remplirNom(page, nom) {
     await page.fill('#page.ready #name', nom)
     let bouton = await page.waitForSelector('#page.ready >> text="Continuer"')
-    await Promise.all([bouton.click(), page.waitForNavigation({ url: '**/#vaccins' })])
+    await Promise.all([
+        bouton.click(),
+        page.waitForNavigation({ url: '**/#symptomes' }),
+    ])
 }
 
 async function remplirSituation(page, departement, enfants, activitePro) {
@@ -162,7 +165,7 @@ async function remplirDepistage(page, depistage, date, type, resultat) {
     let bouton = await page.waitForSelector(`#page.ready >> text=${text}`)
     await Promise.all([
         bouton.click(),
-        page.waitForNavigation({ url: `**/#situation` }),
+        page.waitForNavigation({ url: `**/#historique` }),
     ])
 }
 
@@ -175,7 +178,7 @@ async function remplirVaccins(page, vaccins) {
     let bouton = await page.waitForSelector(`#page.ready >> text="Continuer"`)
     await Promise.all([
         bouton.click(),
-        page.waitForNavigation({ url: `**/#historique` }),
+        page.waitForNavigation({ url: `**/#situation` }),
     ])
 }
 
@@ -199,10 +202,7 @@ async function remplirHistorique(page, covid_passee, nbMois) {
     }
 
     let bouton = await page.waitForSelector(`#page.ready >> text=${text}`)
-    await Promise.all([
-        bouton.click(),
-        page.waitForNavigation({ url: `**/#symptomes` }),
-    ])
+    await Promise.all([bouton.click(), page.waitForNavigation({ url: `**/#vaccins` })])
 }
 
 async function remplirSymptomes(page, symptomesActuels, symptomesPasses, date) {

--- a/src/scripts/tests/integration/test.pages.js
+++ b/src/scripts/tests/integration/test.pages.js
@@ -90,7 +90,7 @@ describe('Pages', function () {
             // On retrouve le bouton pour repartir vers le questionnaire.
             let button = await page.waitForSelector('#page.ready .js-profil-empty a')
             assert.equal((await button.innerText()).trim(), 'Démarrer le questionnaire')
-            assert.equal(await button.getAttribute('href'), '#vaccins')
+            assert.equal(await button.getAttribute('href'), '#symptomes')
             // On retrouve le titre explicite.
             let titre = await page.waitForSelector('#page.ready h1')
             assert.equal(await titre.innerText(), 'Conditions d’utilisation')

--- a/src/scripts/tests/integration/test.parcours.js
+++ b/src/scripts/tests/integration/test.parcours.js
@@ -19,27 +19,27 @@ describe('Parcours', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 
         // Remplir le questionnaire.
         await remplirQuestionnaire(page, {
-            vaccins: 'pas_encore',
             symptomesActuels: [],
             symptomesPasses: false,
             contactARisque: [],
             depistage: false,
+            vaccins: 'pas_encore',
             departement: '80',
             enfants: true,
+            activitePro: true,
             age: '42',
             taille: '165',
             poids: '70',
             grossesse: false,
-            activitePro: true,
         })
 
-        await waitForPlausibleTrackingEvent(page, 'Questionnaire commencé:vaccins')
+        await waitForPlausibleTrackingEvent(page, 'Questionnaire commencé:symptomes')
 
         // Conseils.
         {
@@ -121,7 +121,7 @@ describe('Parcours', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 
@@ -140,7 +140,7 @@ describe('Parcours', function () {
             activitePro: true,
         })
 
-        await waitForPlausibleTrackingEvent(page, 'Questionnaire commencé:vaccins')
+        await waitForPlausibleTrackingEvent(page, 'Questionnaire commencé:symptomes')
 
         await waitForPlausibleTrackingEvent(page, 'Questionnaire terminé:conseils')
     })
@@ -158,7 +158,7 @@ describe('Parcours', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 
@@ -193,7 +193,7 @@ describe('Parcours', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 
@@ -230,7 +230,7 @@ describe('Parcours', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 
@@ -277,7 +277,7 @@ describe('Parcours', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 
@@ -325,7 +325,7 @@ describe('Parcours', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 
@@ -373,7 +373,7 @@ describe('Parcours', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 
@@ -423,7 +423,7 @@ describe('Parcours', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 
@@ -471,7 +471,7 @@ describe('Parcours', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 
@@ -507,12 +507,12 @@ describe('Parcours', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
             await page.waitForSelector('#page.ready')
             assert.equal(
                 await page.title(),
-                'Mon statut actuel de vaccination contre la Covid (étape 1) — Mes Conseils Covid — Isolement, tests, vaccins, attestations, contact à risque…'
+                'Mon état actuel (étape 1) — Mes Conseils Covid — Isolement, tests, vaccins, attestations, contact à risque…'
             )
         }
 

--- a/src/scripts/tests/integration/test.plausible.js
+++ b/src/scripts/tests/integration/test.plausible.js
@@ -32,7 +32,7 @@ describe('Plausible', function () {
 
         await Promise.all([
             bouton.click(),
-            page.waitForNavigation({ url: '**/#vaccins' }),
+            page.waitForNavigation({ url: '**/#symptomes' }),
         ])
 
         await page.waitForSelector('#page.ready')
@@ -47,10 +47,10 @@ describe('Plausible', function () {
         )
 
         await waitForPlausibleTrackingEvents(page, [
-            'Questionnaire commencé:vaccins',
-            'Questionnaire commencé pour moi:vaccins',
-            'pageview:vaccins',
-            'Avis flag:vaccins',
+            'Questionnaire commencé:symptomes',
+            'Questionnaire commencé pour moi:symptomes',
+            'pageview:symptomes',
+            'Avis flag:symptomes',
         ])
     })
 
@@ -67,7 +67,7 @@ describe('Plausible', function () {
 
         await Promise.all([
             bouton.click(),
-            page.waitForNavigation({ url: '**/#vaccins' }),
+            page.waitForNavigation({ url: '**/#symptomes' }),
         ])
 
         await remplirQuestionnaire(page, {
@@ -101,13 +101,13 @@ describe('Plausible', function () {
         assert.include(await form.innerHTML(), 'Merci pour votre retour.')
 
         await waitForPlausibleTrackingEvents(page, [
-            'Questionnaire commencé:vaccins',
-            'Questionnaire commencé pour moi:vaccins',
-            'pageview:vaccins',
-            'pageview:historique',
+            'Questionnaire commencé:symptomes',
+            'Questionnaire commencé pour moi:symptomes',
             'pageview:symptomes',
             'pageview:contactarisque',
             'pageview:depistage',
+            'pageview:historique',
+            'pageview:vaccins',
             'pageview:situation',
             'pageview:sante',
             'Questionnaire terminé:conseils',
@@ -162,13 +162,13 @@ describe('Plausible', function () {
 
         await waitForPlausibleTrackingEvents(page, [
             'pageview:nom',
-            'Questionnaire commencé:vaccins',
-            'Questionnaire commencé pour un proche:vaccins',
-            'pageview:vaccins',
-            'pageview:historique',
+            'Questionnaire commencé:symptomes',
+            'Questionnaire commencé pour un proche:symptomes',
             'pageview:symptomes',
             'pageview:contactarisque',
             'pageview:depistage',
+            'pageview:historique',
+            'pageview:vaccins',
             'pageview:situation',
             'pageview:sante',
             'Questionnaire terminé:conseils',
@@ -190,7 +190,7 @@ describe('Plausible', function () {
         )
         await Promise.all([
             bouton.click(),
-            page.waitForNavigation({ url: '**/#vaccins' }),
+            page.waitForNavigation({ url: '**/#symptomes' }),
         ])
         await remplirQuestionnaire(page, {
             vaccins: 'pas_encore',
@@ -223,13 +223,13 @@ describe('Plausible', function () {
         assert.include(await form.innerHTML(), 'Merci pour votre retour.')
 
         await waitForPlausibleTrackingEvents(page, [
-            'Questionnaire commencé:vaccins',
-            'Questionnaire commencé pour moi:vaccins',
-            'pageview:vaccins',
-            'pageview:historique',
+            'Questionnaire commencé:symptomes',
+            'Questionnaire commencé pour moi:symptomes',
             'pageview:symptomes',
             'pageview:contactarisque',
             'pageview:depistage',
+            'pageview:historique',
+            'pageview:vaccins',
             'pageview:situation',
             'pageview:sante',
             'Questionnaire terminé:conseils',
@@ -283,13 +283,13 @@ describe('Plausible', function () {
 
         await waitForPlausibleTrackingEvents(page, [
             'pageview:nom',
-            'Questionnaire commencé:vaccins',
-            'Questionnaire commencé pour un proche:vaccins',
-            'pageview:vaccins',
-            'pageview:historique',
+            'Questionnaire commencé:symptomes',
+            'Questionnaire commencé pour un proche:symptomes',
             'pageview:symptomes',
             'pageview:contactarisque',
             'pageview:depistage',
+            'pageview:historique',
+            'pageview:vaccins',
             'pageview:situation',
             'pageview:sante',
             'Questionnaire terminé:conseils',
@@ -311,7 +311,7 @@ describe('Plausible', function () {
         )
         await Promise.all([
             bouton.click(),
-            page.waitForNavigation({ url: '**/#vaccins' }),
+            page.waitForNavigation({ url: '**/#symptomes' }),
         ])
         await remplirQuestionnaire(page, {
             vaccins: 'pas_encore',
@@ -347,13 +347,13 @@ describe('Plausible', function () {
         )
 
         await waitForPlausibleTrackingEvents(page, [
-            'Questionnaire commencé:vaccins',
-            'Questionnaire commencé pour moi:vaccins',
-            'pageview:vaccins',
-            'pageview:historique',
+            'Questionnaire commencé:symptomes',
+            'Questionnaire commencé pour moi:symptomes',
             'pageview:symptomes',
             'pageview:contactarisque',
             'pageview:depistage',
+            'pageview:historique',
+            'pageview:vaccins',
             'pageview:situation',
             'pageview:sante',
             'Questionnaire terminé:conseils',

--- a/src/scripts/tests/integration/test.profils.js
+++ b/src/scripts/tests/integration/test.profils.js
@@ -25,19 +25,16 @@ describe('Profils', function () {
             let bouton = await page.waitForSelector('#page.ready >> text="Continuer"')
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 
         // Légende adaptée.
         {
             let legend = await page.waitForSelector(
-                '#page.ready #vaccins-form legend h1'
+                '#page.ready #symptomes-form legend h1'
             )
-            assert.equal(
-                await legend.innerText(),
-                'Son statut actuel de vaccination contre la Covid'
-            )
+            assert.equal(await legend.innerText(), 'Son état actuel')
         }
 
         // Remplir le questionnaire.

--- a/src/scripts/tests/integration/test.suivi.js
+++ b/src/scripts/tests/integration/test.suivi.js
@@ -19,7 +19,7 @@ describe('Suivi', function () {
             )
             await Promise.all([
                 bouton.click(),
-                page.waitForNavigation({ url: '**/#vaccins' }),
+                page.waitForNavigation({ url: '**/#symptomes' }),
             ])
         }
 


### PR DESCRIPTION
Maintenant que le questionnaire est recentré sur le cas « J’ai des symptômes », c’est bien de poser cette question en premier.

On en profite pour lever la confusion des gens à qui on demande s’ils ont déjà eu la Covid avant qu’ils aient pu dire qu’ils venaient d’être testés positif.