### PR TITLE
Distinction pour refaire un test si même foyer

### DIFF
--- a/contenus/thematiques/1-cas-contact-a-risque.md
+++ b/contenus/thematiques/1-cas-contact-a-risque.md
@@ -33,36 +33,38 @@ Vous êtes concerné(e) si :
     
 <p class="big">Voici ce que nous vous conseillons de faire :</p>
 
-### 1. Vous isoler
+### 1. Faire un test et vous isoler
 
 <div class="conseil">
 
-Restez isolé·e **au minimum 7 jours** après votre dernier contact à risque.
-
-</div>
-
-Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir vous isoler en attendant le résultat du test.
-
-### 2. Faire un test
-
-<div class="conseil">
-
-Faire un **test antigénique** en pharmacie **immédiatement** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+Faites un **test antigénique** en pharmacie **immédiatement** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)) et **restez isolé(e)**.
 
 </div>
 
 * Si le test est **positif**, restez en **isolement au moins 10 jours** à partir de la date du test.
 
-* Si le test est **négatif**, restez **en isolement**, et **refaites un test 7 jours après** le dernier contact à risque :
+* Si le test est **négatif**, restez **en isolement** et effectuez un test de contrôle (voir ci-dessous).
 
-    * s’il est **négatif**, vous pourrez lever votre isolement ;
-    * s’il est **positif**, restez en isolement au moins 10 jours à partir de la date du test, et surveillez l’apparition de symptômes.
-
+Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir vous isoler en attendant le résultat du test.
 
 Si votre test est **positif**, les autres membres de votre foyer seront considérés comme **cas contact**, et devront :
 
 * se maintenir **en isolement** eux aussi (les enfants ne doivent pas aller à l’**école**) ;
 * faire un **test antigénique immédiatement** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+
+### 2. Faire un test de contrôle
+
+<div class="conseil">
+
+Si votre premier test était **négatif**, vous devez faire un test de contrôle :
+
+* **7 jours après votre dernier contact** avec la personne malade, pour confirmer que vous n’avez pas été contaminé(e).
+* **7 jours après la guérison** de la personne malade (soit 17 jours depuis son test positif ou le début de ses symptômes), si vous êtes en **contact régulier** avec elle (partage de foyer par exemple).
+
+</div>
+
+* s’il est **négatif**, vous pourrez lever votre isolement ;
+* s’il est **positif**, restez en isolement au moins 10 jours à partir de la date du test, et surveillez l’apparition de symptômes.
 
 </details>
 </div>
@@ -98,22 +100,26 @@ Faire un **test antigénique** en pharmacie **immédiatement** (voir la [carte d
     * portez le masque à l’intérieur et à l’extérieur, même dans les lieux qui ne l’exigent plus (restaurant, musées…) ;
     * évitez de rencontrer des personnes vulnérables ou fragiles ;
     * surveillez votre état : température, symptômes…
-    
-### 2. Faire un test de contrôle
-
-<div class="conseil">
-
-Si votre premier test était **négatif**, faire un test de contrôle 7 jours après le dernier contact à risque.
-
-</div>
-
-* s’il est **négatif**, vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale ;
-* s’il est **positif**, restez en isolement au moins 10 jours à partir de la date du test, et surveillez l’apparition de symptômes. Il n’est pas nécessaire de faire un test de contrôle pour sortir de l’isolement.
 
 Si votre test est **positif**, les autres membres de votre foyer seront considérés comme **cas contact**, et devront, selon leur situation personnelle (schéma vaccinal complet ou non) :
 
 * se maintenir **en isolement** eux aussi (les enfants ne doivent pas aller à l’**école**) ;
 * faire un **test antigénique immédiatement** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+
+
+### 2. Faire un test de contrôle
+
+<div class="conseil">
+
+Si votre premier test était **négatif**, vous devez faire un test de contrôle :
+
+* **7 jours après votre dernier contact** avec la personne malade, pour confirmer que vous n’avez pas été contaminé(e).
+* **7 jours après la guérison** de la personne malade (soit 17 jours depuis son test positif ou le début de ses symptômes), si vous êtes en **contact régulier** avec elle (partage de foyer par exemple).
+
+</div>
+
+* s’il est **négatif**, vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale ;
+* s’il est **positif**, il faut vous isoler au moins 10 jours à partir de la date du test, et surveillez l’apparition de symptômes. Il n’est pas nécessaire de faire un test de contrôle pour sortir de l’isolement.
 
 </details>
 </div>

--- a/contenus/thematiques/1-cas-contact-a-risque.md
+++ b/contenus/thematiques/1-cas-contact-a-risque.md
@@ -63,8 +63,10 @@ Si votre premier test était **négatif**, vous devez faire un test de contrôle
 
 </div>
 
-* s’il est **négatif**, vous pourrez lever votre isolement ;
-* s’il est **positif**, restez en isolement au moins 10 jours à partir de la date du test, et surveillez l’apparition de symptômes.
+Si le résultat de ce test de contrôle est :
+
+* **négatif** : vous pourrez lever votre isolement ;
+* **positif** : restez en isolement au moins 10 jours à partir de la date du test, et surveillez l’apparition de symptômes.
 
 </details>
 </div>
@@ -118,8 +120,16 @@ Si votre premier test était **négatif**, vous devez faire un test de contrôle
 
 </div>
 
-* s’il est **négatif**, vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale ;
-* s’il est **positif**, il faut vous isoler au moins 10 jours à partir de la date du test, et surveillez l’apparition de symptômes. Il n’est pas nécessaire de faire un test de contrôle pour sortir de l’isolement.
+Si le résultat de ce test de contrôle est :
+
+* **négatif** : vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale ;
+* **positif** : il faut vous isoler au moins 10 jours à partir de la date du test, et surveiller l’apparition de symptômes. Il n’est pas nécessaire de faire un test de contrôle pour sortir de l’isolement.
+
+<div class="conseil conseil-jaune">
+
+Attention, si vous ressentez des **symptômes** avant la date prévue de votre test de contrôle (17<sup>e</sup> jour), il faut vous faire tester immédiatement et vous isoler en attendant le résultat.
+
+</div>
 
 </details>
 </div>

--- a/contenus/thematiques/4-je-suis-vaccine.md
+++ b/contenus/thematiques/4-je-suis-vaccine.md
@@ -22,8 +22,13 @@
 
 .. question:: Est-ce que je dois m’isoler si je suis « cas contact »  et vacciné(e) ?
 
-    Si vous êtes vacciné(e), en cas de contact à risque avec une personne positive à la Covid : il faut **vous faire tester** immédiatement et informer de votre statut les personnes avec qui vous avez été en contact récemment. Vous n’avez pas besoin de vous isoler mais il est recommandé de respecter les mesures barrières avec toutes les personnes de votre entourage pendant une semaine.
+    Si vous êtes vacciné(e), en cas de contact à risque avec une personne positive à la Covid, il faut :
 
+    1. **Vous faire tester immédiatement** et informer de votre statut les personnes avec qui vous avez été en contact récemment.
+    1. **Si le résultat de votre test est négatif, vous n’avez pas besoin de vous isoler** mais il est recommandé de respecter les mesures barrières avec toutes les personnes de votre entourage pendant une semaine. Vous devrez ensuite faire un test de contrôle :
+        * **7 jours après votre dernier contact** avec la personne malade, pour confirmer que vous n’avez pas été contaminé(e).
+        * **7 jours après la guérison** de la personne malade (soit 17 jours depuis son test positif ou le début de ses symptômes), si vous êtes en **contact régulier** avec elle (partage de foyer par exemple).
+    1. **Si le résultat de votre test est positif, isolez-vous pendant 10 jours.** Nous vous encourageons à [décrire votre situation particulière](/#symptomes) pour obtenir des conseils personnalisés sur la conduite à tenir.
 
 .. question:: Je suis vacciné(e), est-ce que je peux être positif ou positive à la Covid ?
 

--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -19,7 +19,7 @@
 
 Vous êtes concerné(e) si :
 
-* vous n’avez pas reçu(e) toutes les doses nécéssaires (1, 2 ou 3 doses) ;
+* vous n’avez pas reçu(e) toutes les doses nécessaires (1 ou 2 doses) ;
 * vous avez reçu(e) votre dernière dose depuis moins de 7 jours (Pfizer, Moderna, AstraZeneca) ou moins de 28 jours (Janssen) ;
 * vous souffrez d’une forte immunodépression qui réduit l’efficacité du vaccin.
 
@@ -75,7 +75,7 @@ Voici un schéma illustrant la conduite à tenir dans votre situation :
 
 Vous êtes concerné(e) si :
 
-* vous avez reçu(e) toutes les doses nécéssaires (1, 2 ou 3 doses) ;
+* vous avez reçu(e) toutes les doses nécessaires (1 ou 2 doses) ;
 * vous avez reçu(e) la dernière dose prévue depuis plus de 7 jours (Pfizer, Moderna, AstraZeneca) ou plus de 28 jours (Janssen)  ;
 * vous ne souffrez pas d’immunodépression. 
 
@@ -83,7 +83,7 @@ Vous êtes concerné(e) si :
 
 <p class="big">Voici ce que nous vous conseillons de faire :</p>
 
-### 1. Faites un test et isolez-vous
+### 1. Faites un test
 
 <div class="conseil">
 
@@ -107,8 +107,16 @@ Si votre premier test était **négatif**, vous devez faire un test de contrôle
 
 </div>
 
-* s’il est **négatif**, vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale ;
-* s’il est **positif**, il faut vous isoler au moins 10 jours à partir de la date du test, et surveillez l’apparition de symptômes. Il n’est pas nécessaire de faire un test de contrôle pour sortir de l’isolement.
+Si le résultat de ce test de contrôle est :
+
+* **négatif** : vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale ;
+* **positif** : il faut vous isoler au moins 10 jours à partir de la date du test, et surveiller l’apparition de symptômes. Il n’est pas nécessaire de faire un test de contrôle pour sortir de l’isolement.
+
+<div class="conseil conseil-jaune">
+
+Attention, si vous ressentez des **symptômes** avant la date prévue de votre test de contrôle (17<sup>e</sup> jour), il faut vous faire tester immédiatement et vous isoler en attendant le résultat.
+
+</div>
 
 </details>
 </div>

--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -8,9 +8,26 @@
 
 <p class="big">Votre conjoint⸱e, enfant, colocataire… est positif à la Covid et vous ne présentez pas de symptômes ? MesConseilsCovid vous accompagne pour savoir quelle conduite à tenir lorsqu’on est cas contact d’une personne qui partage le même lieu de vie.</p>
 
+## Vous vivez avec une personne positive à la Covid et…
+
+<div class="conseils">
+<details>
+
+.. summary:: vous n’êtes pas vacciné(e) (schéma vaccinal incomplet)
+
+<div class="conseil conseil-jaune">
+
+Vous êtes concerné(e) si :
+
+* vous n’avez pas reçu(e) toutes les doses nécéssaires (1, 2 ou 3 doses) ;
+* vous avez reçu(e) votre dernière dose depuis moins de 7 jours (Pfizer, Moderna, AstraZeneca) ou moins de 28 jours (Janssen) ;
+* vous souffrez d’une forte immunodépression qui réduit l’efficacité du vaccin.
+
+</div>
+    
 <p class="big">Voici ce que nous vous conseillons de faire :</p>
 
-## 1. Faites un test et isolez-vous
+### 1. Faites un test et isolez-vous
 
 <div class="conseil">
 
@@ -24,7 +41,7 @@ Même si vous ne présentez pas de symptômes, il faut vous faire tester immédi
 
 Si vous ne pouvez pas télétravailler, l’Assurance Maladie pourra vous prescrire un arrêt de travail. Pour plus d’information, rendez-vous sur [declare.ameli.fr](https://declare.ameli.fr).
 
-## 2. Refaites un test
+### 2. Faites un test de contrôle
 
 <div class="conseil">
 
@@ -44,6 +61,56 @@ Voici un schéma illustrant la conduite à tenir dans votre situation :
                  alt="Frise chronologique représentant la période d’isolement">
         </a>
     </div>
+</div>
+
+</details>
+</div>
+
+<div class="conseils">
+<details>
+
+.. summary:: vous êtes vacciné(e) (schéma vaccinal complet)
+
+<div class="conseil conseil-jaune">
+
+Vous êtes concerné(e) si :
+
+* vous avez reçu(e) toutes les doses nécéssaires (1, 2 ou 3 doses) ;
+* vous avez reçu(e) la dernière dose prévue depuis plus de 7 jours (Pfizer, Moderna, AstraZeneca) ou plus de 28 jours (Janssen)  ;
+* vous ne souffrez pas d’immunodépression. 
+
+</div>
+
+<p class="big">Voici ce que nous vous conseillons de faire :</p>
+
+### 1. Faites un test et isolez-vous
+
+<div class="conseil">
+
+Même si vous ne présentez pas de symptômes, il faut vous faire tester immédiatement en laboratoire ou en pharmacie :
+
+* Si le test est **positif** : isolez-vous pendant au moins **10 jours**. Vous pourrez lever l’isolement dès le 10<sup>e</sup> jour, si vous ne ressentez pas de fièvre depuis au moins 48 h.
+* Si le test est **négatif**, il ne faut pas vous isoler mais restez prudent(e) :
+    * portez le masque à l’intérieur et à l’extérieur, même dans les lieux qui ne l’exigent plus (restaurant, musées…) ;
+    * évitez de rencontrer des personnes vulnérables ou fragiles ;
+    * surveillez votre état : température, symptômes…
+
+</div>
+
+Si vous ne pouvez pas télétravailler, l’Assurance Maladie pourra vous prescrire un arrêt de travail. Pour plus d’information, rendez-vous sur [declare.ameli.fr](https://declare.ameli.fr).
+
+### 2. Faites un test de contrôle
+
+<div class="conseil">
+
+Si votre premier test était **négatif**, vous devez faire un test de contrôle **7 jours après la guérison** de la personne malade (soit 17 jours depuis son test positif ou le début de ses symptômes).
+
+</div>
+
+* s’il est **négatif**, vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale ;
+* s’il est **positif**, il faut vous isoler au moins 10 jours à partir de la date du test, et surveillez l’apparition de symptômes. Il n’est pas nécessaire de faire un test de contrôle pour sortir de l’isolement.
+
+</details>
 </div>
 
 


### PR DESCRIPTION
Dans le cas d'une personne vaccinée, elle doit attendre la rémission du cas contact si elle est toujours exposée (même foyer) pour faire le test de contrôle.

Source : MINSANTE N°2021-96 (courriel Mélanie)