### PR TITLE
Évite l'isolement pour les guérisons récentes

### DIFF
--- a/contenus/conseils/conseils_isolement_contact_a_risque.md
+++ b/contenus/conseils/conseils_isolement_contact_a_risque.md
@@ -1,3 +1,5 @@
 Restez isolé·e **au minimum 7 jours** après votre dernier contact avec une personne malade.
 
+**Si vous êtes guéri(e) de la Covid depuis moins de 2 mois**, vous pouvez dès à présent sortir de votre isolement.
+
 Si des symptômes apparaissent pendant votre isolement, revenez sur [MesConseilsCovid.fr](https://mesconseilscovid.sante.gouv.fr/#introduction) pour des conseils mis à jour.

--- a/contenus/conseils/conseils_isolement_depistage_positif.md
+++ b/contenus/conseils/conseils_isolement_depistage_positif.md
@@ -1,3 +1,5 @@
 **Isolez-vous pendant 10 jours** après le résultat de votre test positif. Au bout de cette période, si vous n’avez plus de fièvre ni de gêne respiratoire pendant plus de 48 heures, vous pourrez sortir de votre isolement.
 
+**Si vous êtes guéri(e) de la Covid depuis moins de 2 mois**, vous pouvez dès à présent sortir de votre isolement.
+
 Si vous respectez ces indications, il n’est **pas nécessaire de réaliser un test pour sortir d’isolement** : le résultat pourrait être positif alors que vous n’êtes plus contagieux.

--- a/contenus/conseils/conseils_isolement_symptomes.md
+++ b/contenus/conseils/conseils_isolement_symptomes.md
@@ -1,3 +1,5 @@
 **Isolez-vous pendant 10 jours** après le début de vos symptômes. Au bout de cette période, si vous n’avez plus de fièvre ni de gêne respiratoire pendant plus de 48 heures, vous pourrez sortir de votre isolement.
 
+**Si vous êtes guéri(e) de la Covid depuis moins de 2 mois**, vous pouvez dès à présent sortir de votre isolement.
+
 Si vous respectez ces indications, il n’est **pas nécessaire de réaliser un test pour sortir d’isolement** : le résultat pourrait être positif alors que vous n’êtes plus contagieux.

--- a/contenus/conseils/conseils_personnels_contact_à_risque_avec_test.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_avec_test.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. Vous maintenir **en isolement**.
+1. Vous maintenir **en isolement** (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois).
 1. **Refaire un test antigénique immédiatement**, si votre dernier test date d’avant votre dernier contact à risque (voir la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>.
     * Si le test est **positif**, restez **en isolement au moins 10 jours** à partir de la date du test, et renseignez le [résultat du test](#depistage) pour mettre à jour ces conseils.
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après le dernier contact à risque** ;

--- a/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. Vous maintenir **en isolement**.
+1. Vous maintenir **en isolement** (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois).
 1. Mettre en place des **mesures d’hygiène renforcée** dans votre foyer (voir la section **Isolement** plus bas).
 1. Faire un test **7 jours après la guérison** de la personne malade :
     * s’il est **négatif**, vous pourrez lever votre isolement ;

--- a/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_sans_depistage.md
@@ -1,6 +1,6 @@
 Même si vous avez été vacciné‚ nous vous conseillons de :
 
-1. Vous maintenir **en isolement**.
+1. Vous maintenir **en isolement** (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois).
 1. Faire un **test antigénique immédiatement** (voir la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>).
     * Si le test est **positif**, restez **en isolement au moins 10 jours** à partir de la date du test, et renseignez le [résultat du test](#depistage) pour mettre à jour ces conseils.
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après la guérison** de la personne malade ;

--- a/contenus/conseils/conseils_personnels_contact_à_risque_sans_test.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_sans_test.md
@@ -1,6 +1,6 @@
 Même si vous avez été vacciné‚ nous vous conseillons de :
 
-1. Vous maintenir **en isolement**.
+1. Vous maintenir **en isolement** (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois).
 1. Faire un **test antigénique immédiatement** (voir la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>).
     * Si le test est **positif**, restez **en isolement au moins 10 jours** à partir de la date du test, et renseignez le [résultat du test](#depistage) pour mettre à jour ces conseils.
     * Si le test est **négatif**, restez **en isolement**, et faites un test **7 jours après le dernier contact à risque** ;

--- a/contenus/conseils/conseils_personnels_depistage_positif_antigenique_asymptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_antigenique_asymptomatique.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour confirmer le résultat et identifier un éventuel **variant** du virus.
-1. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date du test antigénique.
+1. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date du test antigénique (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois).
 1. {.seulement-si-activite-pro-et-autotest} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat du test PCR.
 1. {.seulement-si-activite-pro-et-pas-autotest} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).

--- a/contenus/conseils/conseils_personnels_depistage_positif_antigenique_symptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_antigenique_symptomatique.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour confirmer le résultat et identifier un éventuel **variant** du virus.
-1. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes.
+1. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois).
 1. {.seulement-si-activite-pro-et-autotest} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat du test PCR.
 1. {.seulement-si-activite-pro-et-pas-autotest} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).

--- a/contenus/conseils/conseils_personnels_depistage_positif_asymptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_asymptomatique.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date du test.
+1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date du test (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois).
 1. {.seulement-si-activite-pro} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).
 1. {.seulement-si-foyer} Les autres membres de votre foyer sont considérés comme **cas contact**, et doivent :

--- a/contenus/conseils/conseils_personnels_depistage_positif_symptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_symptomatique.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date d’apparition des symptômes, et de contacter votre médecin au moindre doute.
+1. Vous maintenir **en isolement**, au moins 10 jours à partir de la date d’apparition des symptômes (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois), et de contacter votre médecin au moindre doute.
 1. {.seulement-si-activite-pro} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).
 1. {.seulement-si-foyer} Les autres membres de votre foyer sont considérés comme **cas contact**, et doivent :

--- a/contenus/conseils/conseils_personnels_symptômes_actuels_en_attente.md
+++ b/contenus/conseils/conseils_personnels_symptômes_actuels_en_attente.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. **Contacter votre médecin généraliste** pour lui parler de vos symptômes.
-1. Vous maintenir **en isolement** jusqu’au résultat du test :
+1. Vous maintenir **en isolement** jusqu’au résultat du test (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois) :
     * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).

--- a/contenus/conseils/conseils_personnels_symptômes_actuels_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_symptômes_actuels_sans_depistage.md
@@ -2,7 +2,7 @@ Même si vous avez été vacciné‚ nous vous conseillons de :
 
 1. **Contacter votre médecin généraliste**.
 1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
-1. Vous maintenir **en isolement** jusqu’au résultat du test :
+1. Vous maintenir **en isolement** jusqu’au résultat du test (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois) :
     * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).

--- a/contenus/conseils/conseils_personnels_symptômes_passés_en_attente.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_en_attente.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. Vous maintenir **en isolement** jusqu’au résultat du test.
+1. Vous maintenir **en isolement** jusqu’au résultat du test (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois).
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer (voir la section **Isolement** plus bas).
 1. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 1. Revenir sur Mes Conseils Covid **quand vous aurez reçu vos résultats** afin d’avoir les conseils adaptés à votre nouvelle situation !

--- a/contenus/conseils/conseils_personnels_symptômes_passés_positif.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_positif.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. Vous maintenir **en isolement** au moins 10 jours à partir de la date d’apparition des symptômes.
+1. Vous maintenir **en isolement** au moins 10 jours à partir de la date d’apparition des symptômes (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois).
 1. {.seulement-si-activite-pro} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).
 1. {.seulement-si-foyer} Les autres membres de votre foyer sont considérés comme **cas contact**, et doivent :

--- a/contenus/conseils/conseils_personnels_symptômes_passés_positif_antigenique.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_positif_antigenique.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour confirmer le résultat et identifier un éventuel **variant** du virus.
-1. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes.
+1. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois).
 1. {.seulement-si-activite-pro-et-autotest} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat du test PCR.
 1. {.seulement-si-activite-pro-et-pas-autotest} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).

--- a/contenus/conseils/conseils_personnels_symptômes_passés_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_sans_depistage.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>. Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
-1. Vous maintenir **en isolement** jusqu’au résultat du test. Si le résultat est négatif, vous pourrez mettre fin à votre isolement.
+1. Vous maintenir **en isolement** jusqu’au résultat du test (sauf si vous êtes guéri(e) de la Covid depuis moins de 2 mois). Si le résultat est négatif, vous pourrez mettre fin à votre isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).
 1. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.
 1. Revenir sur Mes Conseils Covid **si votre situation change** afin d’avoir les conseils adaptés à votre nouvelle situation !


### PR DESCRIPTION
Source :

> En cas de test positif (RT-PCR, RT-LAMP) chez une personne ayant un antécédent d’infection documentée à SARS-CoV- 2 de moins de 2 mois, considérée comme rétablie et en dehors de la période d’isolement de l’épisode initial, il est recommandé de ne pas considérer le résultat comme une nouvelle infection. Le résultat positif ne doit pas conduire à un nouvel isolement de la personne ni à la réalisation d’un contact-tracing autour de celle-ci.