### PR TITLE
Simplifie le bloc du test antigénique

### DIFF
--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -166,7 +166,7 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pa
 .. question:: Le test antigénique nasopharyngé (prélèvement nasal)
     :level: 4
 
-    Le test antigénique permet d’avoir le résultat plus rapidement, mais il est moins fiable que les tests réalisés en laboratoire. C’est pourquoi, il n’est pas recommandé pour le dépistage des personnes qui ne présentent pas de symptômes (sauf en cas de contact à risque).
+    Le test antigénique permet d’avoir le résultat plus rapidement, mais il est moins fiable que les tests réalisés en laboratoire.
 
 .. question:: Où faire un test antigénique nasopharyngé (prélèvement nasal) ?
     :level: 4


### PR DESCRIPTION
Modification qui fait suite à un retour sur Covibot.
 
Les sources indiquent qu'il faut privilégier les tests antigéniques lorsqu'on a des symptômes (depuis 4 jours ou moins) sauf dans certains cas : cas contact / prescription du médecin... 
Sources : https://www.ameli.fr/sites/default/files/Documents/737220/document/infographie-test-grand-public.pdf 
et https://www.sante.fr/coronavirus-covid-19-questions-et-reponses-sur-les-tests-de-depistage#p3 
Le plus simple est de ne pas rentrer dans le détail (au risque de trop simplifier) dans le bloc, mais laisser les utilisateurs obtenir leur réponse dans le questionnaire.