### PR TITLE
Ajoute des liens vers des pages thématiques

### DIFF
--- a/contenus/conseils/conseils_vie_quotidienne.md
+++ b/contenus/conseils/conseils_vie_quotidienne.md
@@ -1,6 +1,6 @@
 Le **variant Delta** du Covid-19 est plus contagieux que les précédentes mutations du virus. Nous vous conseillons de rester vigilant.
 
-La [vaccination](https://mesconseilscovid.sante.gouv.fr/je-veux-me-faire-vacciner.html) et les gestes barrières, notamment le port du masque (lors de forte affluence ou en intérieur) sont les mesures les plus efficaces pour empêcher une nouvelle vague épidémique.
+La [vaccination](/je-veux-me-faire-vacciner.html) et les gestes barrières, notamment le port du masque (lors de forte affluence ou en intérieur) sont les mesures les plus efficaces pour empêcher une nouvelle vague épidémique.
 
 <div class="conseil">
 

--- a/contenus/thematiques/1-cas-contact-a-risque.md
+++ b/contenus/thematiques/1-cas-contact-a-risque.md
@@ -14,7 +14,7 @@
 
 ## Vous êtes cas contact et…
 
-<details>
+<details id="schema-vaccinal-incomplet">
 
 .. summary:: vous n’êtes pas vacciné(e) (schéma vaccinal incomplet)
 
@@ -67,7 +67,7 @@ Si le résultat de ce test de contrôle est :
 
 </details>
 
-<details>
+<details id="schema-vaccinal-complet">
 
 .. summary:: vous êtes vacciné(e) (schéma vaccinal complet)
 

--- a/contenus/thematiques/4-je-suis-vaccine.md
+++ b/contenus/thematiques/4-je-suis-vaccine.md
@@ -41,7 +41,7 @@
         * **7 jours après la guérison** de la personne malade (soit 17 jours depuis son test positif ou le début de ses symptômes), si vous êtes en **contact régulier** avec elle (partage de foyer par exemple).
     1. **Si le résultat de votre test est positif, isolez-vous pendant 10 jours.** Nous vous encourageons à [décrire votre situation particulière](/#symptomes) pour obtenir des conseils personnalisés sur la conduite à tenir.
 
-    Pour plus d'informations sur la conduite à tenir, [**consultez notre page « Je suis cas contact Covid, que faire ? »**](/cas-contact-a-risque.html#schema-vaccinal-complet).
+    Pour plus d’informations sur la conduite à tenir, [**consultez notre page « Je suis cas contact Covid, que faire ? »**](/cas-contact-a-risque.html#schema-vaccinal-complet).
 
 .. question:: Je suis vacciné(e), est-ce que je peux être positif ou positive à la Covid ?
 

--- a/contenus/thematiques/4-je-suis-vaccine.md
+++ b/contenus/thematiques/4-je-suis-vaccine.md
@@ -35,11 +35,13 @@
 
     Si vous êtes vacciné(e), en cas de contact à risque avec une personne positive à la Covid, il faut :
 
-    1. **Vous faire tester immédiatement** et informer de votre statut les personnes avec qui vous avez été en contact récemment.
+    1. [**Vous faire tester immédiatement**](https://mesconseilscovid.sante.gouv.fr/tests-de-depistage.html) et informer de votre statut les personnes avec qui vous avez été en contact récemment.
     1. **Si le résultat de votre test est négatif, vous n’avez pas besoin de vous isoler** mais il est recommandé de respecter les mesures barrières avec toutes les personnes de votre entourage pendant une semaine. Vous devrez ensuite faire un test de contrôle :
         * **7 jours après votre dernier contact** avec la personne malade, pour confirmer que vous n’avez pas été contaminé(e).
         * **7 jours après la guérison** de la personne malade (soit 17 jours depuis son test positif ou le début de ses symptômes), si vous êtes en **contact régulier** avec elle (partage de foyer par exemple).
     1. **Si le résultat de votre test est positif, isolez-vous pendant 10 jours.** Nous vous encourageons à [décrire votre situation particulière](/#symptomes) pour obtenir des conseils personnalisés sur la conduite à tenir.
+    
+    Pour plus d'informations sur la conduite à tenir, [**consultez notre page « Je suis cas contact Covid, que faire ? »**](https://mesconseilscovid.sante.gouv.fr/cas-contact-a-risque.html).
 
 .. question:: Je suis vacciné(e), est-ce que je peux être positif ou positive à la Covid ?
 

--- a/contenus/thematiques/4-je-suis-vaccine.md
+++ b/contenus/thematiques/4-je-suis-vaccine.md
@@ -35,13 +35,13 @@
 
     Si vous êtes vacciné(e), en cas de contact à risque avec une personne positive à la Covid, il faut :
 
-    1. [**Vous faire tester immédiatement**](https://mesconseilscovid.sante.gouv.fr/tests-de-depistage.html) et informer de votre statut les personnes avec qui vous avez été en contact récemment.
+    1. [**Vous faire tester immédiatement**](/tests-de-depistage.html) et informer de votre statut les personnes avec qui vous avez été en contact récemment.
     1. **Si le résultat de votre test est négatif, vous n’avez pas besoin de vous isoler** mais il est recommandé de respecter les mesures barrières avec toutes les personnes de votre entourage pendant une semaine. Vous devrez ensuite faire un test de contrôle :
         * **7 jours après votre dernier contact** avec la personne malade, pour confirmer que vous n’avez pas été contaminé(e).
         * **7 jours après la guérison** de la personne malade (soit 17 jours depuis son test positif ou le début de ses symptômes), si vous êtes en **contact régulier** avec elle (partage de foyer par exemple).
     1. **Si le résultat de votre test est positif, isolez-vous pendant 10 jours.** Nous vous encourageons à [décrire votre situation particulière](/#symptomes) pour obtenir des conseils personnalisés sur la conduite à tenir.
     
-    Pour plus d'informations sur la conduite à tenir, [**consultez notre page « Je suis cas contact Covid, que faire ? »**](https://mesconseilscovid.sante.gouv.fr/cas-contact-a-risque.html).
+    Pour plus d'informations sur la conduite à tenir, [**consultez notre page « Je suis cas contact Covid, que faire ? »**](/cas-contact-a-risque.html).
 
 .. question:: Je suis vacciné(e), est-ce que je peux être positif ou positive à la Covid ?
 

--- a/contenus/thematiques/4-je-suis-vaccine.md
+++ b/contenus/thematiques/4-je-suis-vaccine.md
@@ -40,8 +40,8 @@
         * **7 jours après votre dernier contact** avec la personne malade, pour confirmer que vous n’avez pas été contaminé(e).
         * **7 jours après la guérison** de la personne malade (soit 17 jours depuis son test positif ou le début de ses symptômes), si vous êtes en **contact régulier** avec elle (partage de foyer par exemple).
     1. **Si le résultat de votre test est positif, isolez-vous pendant 10 jours.** Nous vous encourageons à [décrire votre situation particulière](/#symptomes) pour obtenir des conseils personnalisés sur la conduite à tenir.
-    
-    Pour plus d'informations sur la conduite à tenir, [**consultez notre page « Je suis cas contact Covid, que faire ? »**](/cas-contact-a-risque.html).
+
+    Pour plus d'informations sur la conduite à tenir, [**consultez notre page « Je suis cas contact Covid, que faire ? »**](/cas-contact-a-risque.html#schema-vaccinal-complet).
 
 .. question:: Je suis vacciné(e), est-ce que je peux être positif ou positive à la Covid ?
 

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -67,7 +67,7 @@
 
 .. question:: Je suis cas contact, puis-je me faire vacciner (1<sup>re</sup> ou 2<sup>e</sup> dose) ?
 
-     **Non.** Si vous êtes [cas contact](https://mesconseilscovid.sante.gouv.fr/cas-contact-a-risque.html) ou avez été alerté(e) d’un contact à risque par l’application TousAntiCovid, **vous ne devez pas vous faire vacciner**. Il faut d’abord vous assurer que vous n’avez pas été contaminé(e) en faisant un test 7 jours après votre dernier contact à risque. Si ce test de dépistage est négatif, alors vous pourrez vous faire vacciner.
+     **Non.** Si vous êtes [cas contact](/cas-contact-a-risque.html) ou avez été alerté(e) d’un contact à risque par l’application TousAntiCovid, **vous ne devez pas vous faire vacciner**. Il faut d’abord vous assurer que vous n’avez pas été contaminé(e) en faisant un test 7 jours après votre dernier contact à risque. Si ce test de dépistage est négatif, alors vous pourrez vous faire vacciner.
 
 
 .. question:: J’ai déjà eu la Covid, dois-je me faire vacciner (1<sup>re</sup> dose) ?

--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -99,13 +99,13 @@
 
 <div id="tests-de-depistage-symptomes-moins-4-jours-reponse" class="statut statut-bleu" hidden>
 
-Vous avez des symptômes qui peuvent évoquer la Covid depuis moins de 4 jours, nous vous recommandons de faire un test **antigénique** ou **RT-PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](https://mesconseilscovid.sante.gouv.fr/j-ai-des-symptomes-covid.html).
+Vous avez des symptômes qui peuvent évoquer la Covid depuis moins de 4 jours, nous vous recommandons de faire un test **antigénique** ou **RT-PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
 
 </div>
 
 <div id="tests-de-depistage-symptomes-plus-4-jours-reponse" class="statut statut-bleu" hidden>
 
-Vous avez des symptômes qui peuvent évoquer la Covid depuis plus de 4 jours, nous vous recommandons de faire un **test RT-PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](https://mesconseilscovid.sante.gouv.fr/j-ai-des-symptomes-covid.html).
+Vous avez des symptômes qui peuvent évoquer la Covid depuis plus de 4 jours, nous vous recommandons de faire un **test RT-PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
 
 </div>
 
@@ -113,7 +113,7 @@ Vous avez des symptômes qui peuvent évoquer la Covid depuis plus de 4 jours, 
 
 Vous n’avez pas de symptômes qui peuvent évoquer la Covid mais vous êtes cas contact, nous vous recommandons de faire un **test antigénique** si vous venez de l’apprendre.
 
-Pour un test de contrôle (7 jours après votre contact à risque ), les tests **antigénique** ou **RT-PCR nasopharyngé** sont indiqués.  Consultez notre page thématique [« Je suis cas contact Covid, que faire ? »](https://mesconseilscovid.sante.gouv.fr/cas-contact-a-risque.html).
+Pour un test de contrôle (7 jours après votre contact à risque ), les tests **antigénique** ou **RT-PCR nasopharyngé** sont indiqués.  Consultez notre page thématique [« Je suis cas contact Covid, que faire ? »](/cas-contact-a-risque.html).
 
 </div>
 

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -82,7 +82,7 @@
 
     Par ailleurs, le ou la mineur(e) non-vacciné(e) accompagnant ses parents vaccinés lors d’un voyage bénéficiera des mêmes facilités qu’eux. Par exemple, un(e) mineur(e) non-vacciné(e) pourra accompagner ses parents vaccinés lors d’un voyage dans un [pays classé orange](https://www.gouvernement.fr/voyager-depuis-et-vers-l-etranger-mode-d-emploi) sans justifier d’un motif impérieux pour s’y rendre.
 
-    Pour plus d’informations sur les voyages et le pass sanitaire en général, consultez notre [page thématique](https://mesconseilscovid.sante.gouv.fr/pass-sanitaire-qr-code-voyages.html).
+    Pour plus d’informations sur les voyages et le pass sanitaire en général, consultez notre [page thématique](/pass-sanitaire-qr-code-voyages.html).
 
 
 ## Rentrée scolaire 2021-2022

--- a/src/scripts/page/thematique.js
+++ b/src/scripts/page/thematique.js
@@ -50,11 +50,14 @@ export function navigueVersUneThematique(app, goal) {
 
 function ouvreDetailsSiFragment() {
     const currentAnchor = document.location.hash ? document.location.hash.slice(1) : ''
-    if (currentAnchor.substring(0, 7) === 'anchor-') {
-        const target = document.querySelector(`#${currentAnchor}`)
-        if (!target) return
-        if (target.parentElement.tagName === 'DETAILS')
-            target.parentElement.setAttribute('open', '')
+    if (currentAnchor) {
+        let elem = document.querySelector(`#${currentAnchor}`)
+        while (elem) {
+            if (elem.tagName.toLowerCase() === 'details') {
+                elem.setAttribute('open', '')
+            }
+            elem = elem.parentElement
+        }
     }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -280,7 +280,8 @@ legend h1 {
     flex-basis: 288px;
     margin: 1rem;
 }
-.page-thematique :target {
+.page-thematique :target,
+.page-thematique .conseils :target summary {
     background: #ffd;
 }
 .page-thematique .conseils details > summary {


### PR DESCRIPTION
Ajoute des liens vers les pages des tests de dépistage et cas contact.

J'ai hésité entre garder l'explication sur la façon d'agir quand on est cas contact, ou l'enlever et renvoyer simplement vers la page cas contact. Est-ce qu'on saute le pas ? 👷‍♀️