### PR TITLE
Corrige la position des boutons de feedback sur deux questions

### DIFF
--- a/build.py
+++ b/build.py
@@ -85,6 +85,10 @@ class QuestionDirective(Directive):
         level = int(dict(options).get("level")) if options else 2
         text = self.parse_text(m)
         children = block.parse(text, state, block.rules)
+        if not children:
+            raise ValueError(
+                f"Question sans réponse : indentation manquante ?\n« {question} »"
+            )
         return {"type": "question", "children": children, "params": (question, level)}
 
     def __call__(self, md):

--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -141,21 +141,21 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes 
 
 .. question:: Où puis-je faire un test de dépistage Covid-19 ?
 
-<div class="conseil">
+    <div class="conseil">
 
-[Cliquez ici pour trouver un lieu de dépistage](https://www.sante.fr/cf/centres-depistage-covid.html) au plus proche de vous.
+    [Cliquez ici pour trouver un lieu de dépistage](https://www.sante.fr/cf/centres-depistage-covid.html) au plus proche de vous.
 
-</div>
+    </div>
 
 .. question:: Les tests de dépistage sont-ils payants ?
 
-Les tests de dépistage réalisés par un professionnel de santé sont **gratuits**, sans condition de prescription médicale, pour :
+    Les tests de dépistage réalisés par un professionnel de santé sont **gratuits**, sans condition de prescription médicale, pour :
 
-* les **résidents en France** ;
-* les français qui résident habituellement à l’étranger ;
-* les européens qui disposent d’une carte européenne d’assurance maladie.
+    * les **résidents en France** ;
+    * les français qui résident habituellement à l’étranger ;
+    * les européens qui disposent d’une carte européenne d’assurance maladie.
 
-Les touristes non européens peuvent bénéficier de la gratuité sur présentation d’une prescription médicale ou s’ils ont été identifiés cas contact par l’Assurance maladie, sur présentation d’un justificatif (SMS, courriel). En dehors de ces cas de figure, les prix des tests sont fixés à **49,89 euros** (RT-PCR) et **25 euros** (test antigénique rapide).
+    Les touristes non européens peuvent bénéficier de la gratuité sur présentation d’une prescription médicale ou s’ils ont été identifiés cas contact par l’Assurance maladie, sur présentation d’un justificatif (SMS, courriel). En dehors de ces cas de figure, les prix des tests sont fixés à **49,89 euros** (RT-PCR) et **25 euros** (test antigénique rapide).
 
 
 ## Quels sont les différents tests de dépistage de la Covid-19 ?

--- a/src/style.css
+++ b/src/style.css
@@ -1152,7 +1152,7 @@ a.button-feedback-social-whatsapp {
     font-size: 14px;
 }
 .question-feedback legend {
-    margin: 0.25rem 0;
+    margin: 0.25rem auto;
 }
 .question-feedback div {
     display: flex;


### PR DESCRIPTION
Deux questions étaient vides car la réponse n’était pas bien indentée.

Le symptôme était que les boutons de feedback apparaissaient alors au dessus de la réponse.

Pour éviter que le problème ne se reproduise, une erreur est maintenant levée en cas de réponse manquante.