### PR TITLE
Propose une reformulation de l'invitation à un test utilisateur

### DIFF
--- a/contenus/meta/meta_entretiens_utilisateurs.md
+++ b/contenus/meta/meta_entretiens_utilisateurs.md
@@ -2,7 +2,7 @@
 
 ## Aidez-nous à améliorer MesConseilsCovid
 
-Afin d’améliorer ce site, nous organisons des tests utilisateurs individuels en visioconférence de 20 minutes pour mieux comprendre vos besoins et vous fournir des conseils plus pertinents.
+Afin d’améliorer ce site (navigation, contenu), nous organisons des tests utilisateurs individuels en visioconférence de 20 minutes pour mieux comprendre les attentes de nos utilisateurs.
 
 Vous souhaitez participer à un test utilisateur ? Envoyez-nous simplement **OK** par e-mail à l’adresse <a href="mailto:contact@mesconseilscovid.fr">contact@mesconseilscovid.fr</a>, et nous vous recontacterons pour convenir d’un rendez-vous.
 


### PR DESCRIPTION
Une proposition de reformulation pour réduire la confusion entre le test utilisateur et l'entretien personnel sur sa situation Covid. Ca peut éviter la décéption de l'utilisateur (qui du coup n'est pas motivé par le test) et la perte de temps. 
@juliette-pal est-ce que ça te va ?