### PR TITLE
Homogénéise la nomenclature des tests

### DIFF
--- a/contenus/conseils/conseils_personnels_depistage_positif_antigenique_asymptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_antigenique_asymptomatique.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour confirmer le résultat et identifier un éventuel **variant** du virus.
+1. **Réaliser un test PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour confirmer le résultat et identifier un éventuel **variant** du virus.
 1. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date du test antigénique.
 1. {.seulement-si-activite-pro-et-autotest} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat du test PCR.
 1. {.seulement-si-activite-pro-et-pas-autotest} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.

--- a/contenus/conseils/conseils_personnels_depistage_positif_antigenique_symptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_antigenique_symptomatique.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour confirmer le résultat et identifier un éventuel **variant** du virus.
+1. **Réaliser un test PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour confirmer le résultat et identifier un éventuel **variant** du virus.
 1. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes.
 1. {.seulement-si-activite-pro-et-autotest} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat du test PCR.
 1. {.seulement-si-activite-pro-et-pas-autotest} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.

--- a/contenus/conseils/conseils_personnels_symptômes_actuels_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_symptômes_actuels_sans_depistage.md
@@ -1,7 +1,7 @@
 Même si vous avez été vacciné‚ nous vous conseillons de :
 
 1. **Contacter votre médecin généraliste**.
-1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
+1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test PCR en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test PCR en laboratoire est conseillé.
 1. Vous maintenir **en isolement** jusqu’au résultat du test :
     * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.

--- a/contenus/conseils/conseils_personnels_symptômes_actuels_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_symptômes_actuels_sans_depistage.md
@@ -1,7 +1,7 @@
 Même si vous avez été vacciné‚ nous vous conseillons de :
 
 1. **Contacter votre médecin généraliste**.
-1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test PCR en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test PCR en laboratoire est conseillé.
+1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire). Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique ou un test PCR en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test PCR en laboratoire est conseillé.
 1. Vous maintenir **en isolement** jusqu’au résultat du test :
     * {.seulement-si-activite-pro} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat.
     * Si le résultat est **négatif**, vous pourrez mettre fin à votre isolement.

--- a/contenus/conseils/conseils_personnels_symptômes_passés_positif_antigenique.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_positif_antigenique.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. **Réaliser un test RT-PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour confirmer le résultat et identifier un éventuel **variant** du virus.
+1. **Réaliser un test PCR en laboratoire** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a> (vous serez prioritaire), pour confirmer le résultat et identifier un éventuel **variant** du virus.
 1. Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes.
 1. {.seulement-si-activite-pro-et-autotest} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat du test PCR.
 1. {.seulement-si-activite-pro-et-pas-autotest} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.

--- a/contenus/conseils/conseils_personnels_symptômes_passés_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_sans_depistage.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>. Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test en laboratoire est conseillé.
+1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>. Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test PCR en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test PCR en laboratoire est conseillé.
 1. Vous maintenir **en isolement** jusqu’au résultat du test. Si le résultat est négatif, vous pourrez mettre fin à votre isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).
 1. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.

--- a/contenus/conseils/conseils_personnels_symptômes_passés_sans_depistage.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_sans_depistage.md
@@ -1,6 +1,6 @@
 Nous vous conseillons de :
 
-1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>. Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique rapide ou un test PCR en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test PCR en laboratoire est conseillé.
+1. **Réaliser un test** en consultant la <a href="#conseils-depistage" class="lien-depistage">carte des lieux de test</a>. Si vos symptômes datent de moins de 4 jours, vous pouvez faire un test antigénique ou un test PCR en laboratoire. Si vos symptômes datent de plus de 4 jours, seul un test PCR en laboratoire est conseillé.
 1. Vous maintenir **en isolement** jusqu’au résultat du test. Si le résultat est négatif, vous pourrez mettre fin à votre isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).
 1. Si le test est positif, pour **limiter la chaîne de transmission**, contacter vos proches et les personnes que vous avez croisés dernièrement, depuis **48 h avant les premiers symptômes** jusqu’à maintenant. Des outils, comme [BriserLaChaine.org](https://www.briserlachaine.org/statut) de l’ONG BAYES, peuvent vous aider à vous souvenir de toutes les personnes que vous avez croisées.

--- a/contenus/conseils/conseils_tests.md
+++ b/contenus/conseils/conseils_tests.md
@@ -8,7 +8,7 @@ Retrouvez le <a href="#conseils-depistage" class="lien-depistage">lieu de test l
 * Les **tests antigéniques** réalisés en pharmacie permettent d’avoir des résultats plus rapidement mais ils sont moins fiables que les tests PCR en laboratoire.
 * Des **autotests** sont disponibles en pharmacie, pour les personnes sans symptômes et qui ne sont pas personnes contacts :
     * faire un autotest régulièrement (1 à 2 fois par semaine) permet de savoir si on est porteur ou non de la Covid ;
-    * en cas de symptômes, ou de contact avec une personne testée positive à la Covid, il faut faire un test RT-PCR ou antigénique ;
+    * en cas de symptômes, ou de contact avec une personne testée positive à la Covid, il faut faire un test PCR ou antigénique ;
     * un résultat positif à un autotest devra être confirmé par un test PCR en laboratoire.
 
 * Plus d’informations :

--- a/contenus/questions/question_dépistage_antigénique_libellé.md
+++ b/contenus/questions/question_dépistage_antigénique_libellé.md
@@ -1,1 +1,1 @@
-C’était un **test antigénique rapide** (résultat en 15 à 30 minutes)
+C’était un **test antigénique** (résultat en 15 à 30 minutes)

--- a/contenus/questions/question_dépistage_rtpcr_libellé.md
+++ b/contenus/questions/question_dépistage_rtpcr_libellé.md
@@ -1,1 +1,1 @@
-C’était un **test RT-PCR** (résultat en 24 h ou plus)
+C’était un **test PCR** en laboratoire (résultat en 24 h ou plus)

--- a/contenus/statuts/statut_asymptomatique_positif_antigenique.md
+++ b/contenus/statuts/statut_asymptomatique_positif_antigenique.md
@@ -1,1 +1,1 @@
-Même sans symptômes, maintenez-vous **en isolement** pour ne pas contaminer d’autres personnes, et faites un **test en laboratoire** pour identifier un éventuel **variant**.
+Même sans symptômes, maintenez-vous **en isolement** pour ne pas contaminer d’autres personnes, et faites un **test PCR en laboratoire** pour identifier un éventuel **variant**.

--- a/contenus/statuts/statut_symptomatique_antigenique_positif.md
+++ b/contenus/statuts/statut_symptomatique_antigenique_positif.md
@@ -1,1 +1,1 @@
-Maintenez-vous **en isolement**, et faites un **test en laboratoire** pour identifier un éventuel **variant**.
+Maintenez-vous **en isolement**, et faites un **test PCR en laboratoire** pour identifier un éventuel **variant**.

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -39,9 +39,9 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 .. question:: <span class="visually-hidden">Je ne suis pas vacciné(e) :</span> Quel justificatif présenter pour partir en Corse ou vers les destinations d’Outre-mer ?
     :level: 4
 
-    **Pour la Corse** : vous devez présenter un **test RT-PCR négatif** réalisé il y a moins de 72 h *ou* un **test antigénique négatif** réalisé il y a moins de 48 h. Pour en savoir plus, rendez-vous sur le site de l’[ARS de Corse](https://www.corse.ars.sante.fr/covid19-pass-sanitaire-obligatoire-pour-venir-en-corse).
+    **Pour la Corse** : vous devez présenter un **test PCR négatif** réalisé il y a moins de 72 h *ou* un **test antigénique négatif** réalisé il y a moins de 48 h. Pour en savoir plus, rendez-vous sur le site de l’[ARS de Corse](https://www.corse.ars.sante.fr/covid19-pass-sanitaire-obligatoire-pour-venir-en-corse).
 
-    **Pour l’Outre-mer** : toutes les destinations d’Outre-mer exigent la présentation d’un **test RT-PCR négatif** de moins de 72 h lors de l’embarquement. D’autres conditions de voyages plus ou moins contraignantes s’ajoutent selon la destination. Nous vous invitons à consulter [cette page](https://www.gouvernement.fr/info-coronavirus/outre-mer) pour en obtenir le détail.
+    **Pour l’Outre-mer** : toutes les destinations d’Outre-mer exigent la présentation d’un **test PCR négatif** de moins de 72 h lors de l’embarquement. D’autres conditions de voyages plus ou moins contraignantes s’ajoutent selon la destination. Nous vous invitons à consulter [cette page](https://www.gouvernement.fr/info-coronavirus/outre-mer) pour en obtenir le détail.
 
 
 .. question:: <span class="visually-hidden">Je ne suis pas vacciné(e) :</span> Je pars bientôt en voyage vers un pays de l’Espace européen. Comment obtenir un « pass sanitaire européen » ?
@@ -65,7 +65,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 .. question:: <span class="visually-hidden">Je ne suis pas vacciné(e) :</span> Je rentre d’un pays de l’Espace européen. Quelles mesures s’appliquent à mon retour en France métropolitaine ?
     :level: 4
 
-    À l’embarquement sur votre vol retour vers la France, vous devrez présenter un **test antigénique ou RT-PCR négatif** réalisé dans les 72 h précédant votre vol  (moins de 24 h pour les pays sous surveillance : Chypre, Espagne, Grèce, Malte, Pays-Bas, Portugal).
+    À l’embarquement sur votre vol retour vers la France, vous devrez présenter un **test antigénique ou PCR négatif** réalisé dans les 72 h précédant votre vol  (moins de 24 h pour les pays sous surveillance : Chypre, Espagne, Grèce, Malte, Pays-Bas, Portugal).
 
     Pour plus de détails, consultez le [site du ministère de l’Intérieur](https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestation-de-deplacement-et-de-voyage#from8).
 
@@ -79,7 +79,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 
     Pour vérifier à quelle catégorie (**verte**, **orange** ou **rouge**) appartient votre pays de destination, rendez-vous sur [le site du gouvernement](https://www.gouvernement.fr/info-coronavirus/deplacements#informations).
 
-    La plupart des pays exigent la présentation d’un **test RT-PCR négatif** récent (réalisé il y a moins de 48 h ou 72 h). Pour connaître les conditions d’entrée dans votre pays de destination, vous pouvez consulter le site internet de son ambassade et/ou celui de [France Diplomatie](https://www.diplomatie.gouv.fr/fr/je-pars-a-l-etranger/).
+    La plupart des pays exigent la présentation d’un **test PCR négatif** récent (réalisé il y a moins de 48 h ou 72 h). Pour connaître les conditions d’entrée dans votre pays de destination, vous pouvez consulter le site internet de son ambassade et/ou celui de [France Diplomatie](https://www.diplomatie.gouv.fr/fr/je-pars-a-l-etranger/).
 
 
 .. question:: <span class="visually-hidden">Je ne suis pas vacciné(e) :</span> Je rentre de voyage d’un pays extérieur à l’Espace européen. Quelles mesures s’appliquent à mon retour en France métropolitaine ?
@@ -87,17 +87,17 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 
     Les mesures sont plus ou moins contraignantes selon le pays d’où vous revenez :
 
-    * d’un [pays classé **vert**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (États membres de l’Union européenne ainsi que Andorre, l’Islande, le Liechtenstein, Monaco, la Norvège, Saint-Marin, la Suisse et le Vatican ; s’y ajoutent l’Arabie Saoudite, l’Australie, le Bahreïn, Brunei, le Canada, le Chili, la Corée du Sud, les États-Unis, Hong-Kong, Israël, le Japon, la Jordanie, le Liban,  la Nouvelle-Zélande, Singapour, Taïwan, Ukraine, Union des Comores, l’Uruguay et Vanuatu) : vous n’aurez pas à respecter une quarantaine à votre retour mais vous devez présenter un test antigénique ou RT-PCR négatif de moins de 72 h (moins de 24 h pour les pays sous surveillance : Chypre, Espagne, Grèce, Malte, Pays-Bas, Portugal).
+    * d’un [pays classé **vert**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (États membres de l’Union européenne ainsi que Andorre, l’Islande, le Liechtenstein, Monaco, la Norvège, Saint-Marin, la Suisse et le Vatican ; s’y ajoutent l’Arabie Saoudite, l’Australie, le Bahreïn, Brunei, le Canada, le Chili, la Corée du Sud, les États-Unis, Hong-Kong, Israël, le Japon, la Jordanie, le Liban,  la Nouvelle-Zélande, Singapour, Taïwan, Ukraine, Union des Comores, l’Uruguay et Vanuatu) : vous n’aurez pas à respecter une quarantaine à votre retour mais vous devez présenter un test antigénique ou PCR négatif de moins de 72 h (moins de 24 h pour les pays sous surveillance : Chypre, Espagne, Grèce, Malte, Pays-Bas, Portugal).
 
     * d’un [pays classé **rouge**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (Afghanistan, Afrique du Sud, Algérie, Argentine, Bangladesh, Brésil, Colombie, Costa-Rica, Cuba, Géorgie, Indonésie, Iran, Maldives, Maroc, Mozambique, Namibie, Népal, Oman, Pakistan, République Démocratique du Congo, Russie, Seychelles, Suriname, Tunisie et Turquie), vous devez :
 
-        - à l’embarquement, présenter un **test RT-PCR ou antigénique négatif** réalisé il y a moins de 48 h ;
+        - à l’embarquement, présenter un **test PCR ou antigénique négatif** réalisé il y a moins de 48 h ;
         - à l’arrivée, vous soumettre à un **test antigénique** ;
         - respecter une **quarantaine obligatoire de 10 jours** à votre retour en France.
 
     * d’un [pays classé **orange**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (tous les pays, hors pays définis tels que « verts » et « rouges ») :
 
-        - à l’embarquement, vous devez présenter un **test RT-PCR ou antigénique négatif** récent (moins de 48 h ou 72 h) ;
+        - à l’embarquement, vous devez présenter un **test PCR ou antigénique négatif** récent (moins de 48 h ou 72 h) ;
         - respecter un **auto-isolement de 7 jours** à votre retour en France.
 
 </details>
@@ -134,7 +134,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
     :level: 4
 
     **Oui.** Le « pass sanitaire européen », ou encore « <span lang="en">Digital Covid Certificate</span> » est entré en application le 1<sup>er</sup> juillet. Il permet de faciliter les voyages entre les pays membres.
-    Attention, le « pass sanitaire européen » n’harmonise pas les critères d’accès dans les pays membres. Chaque pays peut exiger un type de justificatif différent : test de dépistage RT-PCR ou antigénique, attestation de vaccination…
+    Attention, le « pass sanitaire européen » n’harmonise pas les critères d’accès dans les pays membres. Chaque pays peut exiger un type de justificatif différent : test de dépistage PCR ou antigénique, attestation de vaccination…
     Pour vérifiez les conditions d’entrée dans votre pays de destination, vous pouvez consulter le site internet de son ambassade et/ou celui de [France Diplomatie](https://www.diplomatie.gouv.fr/fr/je-pars-a-l-etranger/).
 
 
@@ -157,7 +157,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 
     **Cela dépend de votre destination.** Le « pass sanitaire européen » permet de faciliter le contrôle des justificatifs (vaccination, tests de dépistage) lors des voyages au sein de l’Espace européen, mais il n’harmonise pas les conditions d’entrées dans les pays membres. Vous ne pourrez donc pas faire automatiquement valoir votre vaccination pour voyager au sein de l’Union européenne.
 
-    Certains pays exigent encore la présentation d’un **test RT-PCR ou antigénique négatif** récent (réalisé dans les 48 h ou 72 h), même pour les personnes vaccinées. Attention, le délai de validité des tests de dépistage varie selon les pays, et tous n’acceptent pas les tests antigéniques.
+    Certains pays exigent encore la présentation d’un **test PCR ou antigénique négatif** récent (réalisé dans les 48 h ou 72 h), même pour les personnes vaccinées. Attention, le délai de validité des tests de dépistage varie selon les pays, et tous n’acceptent pas les tests antigéniques.
 
     Pour vérifier les conditions d’entrée dans votre pays de destination, vous pouvez consulter le site internet de son ambassade et/ou celui de [France Diplomatie](https://www.diplomatie.gouv.fr/fr/je-pars-a-l-etranger/).
 
@@ -183,7 +183,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 
     Pour vérifier à quelle catégorie (**verte**, **orange** ou **rouge**) appartient votre pays de destination, rendez-vous sur [le site du gouvernement](https://www.gouvernement.fr/info-coronavirus/deplacements#informations).
 
-    La plupart des pays exigent la présentation d’un **test RT-PCR négatif** récent (réalisé dans les 48 h ou 72 h). Pour connaître les conditions d’entrée dans votre pays de destination, vous pouvez consulter le site internet de son ambassade et/ou celui de [France Diplomatie](https://www.diplomatie.gouv.fr/fr/je-pars-a-l-etranger/).
+    La plupart des pays exigent la présentation d’un **test PCR négatif** récent (réalisé dans les 48 h ou 72 h). Pour connaître les conditions d’entrée dans votre pays de destination, vous pouvez consulter le site internet de son ambassade et/ou celui de [France Diplomatie](https://www.diplomatie.gouv.fr/fr/je-pars-a-l-etranger/).
 
 
 .. question:: <span class="visually-hidden">Je suis vacciné(e) :</span> Je reviens d’une destination extérieure à l’Espace européen. Quelles mesures s’appliquent à mon retour ?
@@ -194,11 +194,11 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
     * D’un [pays classé **vert**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (États membres de l’Union européenne ainsi que Andorre, l’Islande, le Liechtenstein, Monaco, la Norvège, Saint-Marin, la Suisse et le Vatican ; s’y ajoutent l’Arabie Saoudite, l’Australie, le Bahreïn, Brunei, le Canada, le Chili, la Corée du Sud, les États-Unis, Hong-Kong, Israël, le Japon, la Jordanie, le Liban,  la Nouvelle-Zélande, Singapour, Taïwan, Ukraine, Union des Comores, l’Uruguay et Vanuatu) : vous n’aurez pas à respecter une quarantaine à votre retour mais vous devez présenter votre attestation de vaccination à l’embarquement sur votre vol retour.
 
     * D’un [pays classé **rouge**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (Afghanistan, Afrique du Sud, Algérie, Argentine, Bangladesh, Brésil, Colombie, Costa-Rica, Cuba, Géorgie, Indonésie, Iran, Maldives, Maroc, Mozambique, Namibie, Népal, Oman, Pakistan, République Démocratique du Congo, Russie, Seychelles, Suriname, Tunisie et Turquie), vous devez :
-        - à l’embarquement, présenter un **test RT-PCR ou antigénique négatif** réalisé il y a moins de 48 h ;
+        - à l’embarquement, présenter un **test PCR ou antigénique négatif** réalisé il y a moins de 48 h ;
         - à l’arrivée, vous soumettre à un **test antigénique** ;
         - respecter un **auto-isolement de 7 jours**.
 
-    * D’un [pays classé **orange**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (tous les pays, hors pays définis tels que « verts » et « rouges ») : à l’embarquement, vous devez présenter un **test RT-PCR négatif** de moins de 72 h ou **test antigénique négatif** de moins de 48 h.
+    * D’un [pays classé **orange**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (tous les pays, hors pays définis tels que « verts » et « rouges ») : à l’embarquement, vous devez présenter un **test PCR négatif** de moins de 72 h ou **test antigénique négatif** de moins de 48 h.
 
 </details>
 
@@ -222,7 +222,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 
     Si vous êtes en cours de vaccination (1 dose reçue sur 2 doses prévues, ou 2<sup>e</sup> dose reçue depuis moins de 2 semaines), c’est-à-dire que vous n’avez pas finalisé votre cycle vaccinal, il est probable que vous ne puissiez pas faire valoir cette vaccination pour voyager vers toutes les destinations.
 
-    Dans la plupart des cas, vous devrez présenter un **test RT-PCR ou antigénique négatif** récent (réalisé dans les 48 h ou 72 h) sur lequel figure un QR code aux normes européennes. Ce justificatif fera office de « pass sanitaire européen ».
+    Dans la plupart des cas, vous devrez présenter un **test PCR ou antigénique négatif** récent (réalisé dans les 48 h ou 72 h) sur lequel figure un QR code aux normes européennes. Ce justificatif fera office de « pass sanitaire européen ».
 
     Attention, tous les pays n’acceptent pas les **tests antigéniques**. Par ailleurs, la durée de validité du résultat varie selon les destinations de 48 h à 72 h. Nous vous conseillons de vérifier les critères d’accès à votre pays de destination avant de partir, en vous rendant sur [France Diplomatie](https://www.diplomatie.gouv.fr/fr/je-pars-a-l-etranger/).
 
@@ -242,7 +242,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 .. question:: <span class="visually-hidden">Je suis en cours de vaccination :</span> Quel justificatif présenter pour partir en Corse ou vers les destinations d’Outre-mer ?
     :level: 4
 
-    **Pour la Corse** : vous devez présenter un **test RT-PCR négatif** réalisé il y a moins de 72 h *ou* un **test antigénique négatif** réalisé il y a moins de 48 h. Pour en savoir plus, rendez-vous sur le site de l’[ARS de Corse](https://www.corse.ars.sante.fr/covid19-pass-sanitaire-obligatoire-pour-venir-en-corse).
+    **Pour la Corse** : vous devez présenter un **test PCR négatif** réalisé il y a moins de 72 h *ou* un **test antigénique négatif** réalisé il y a moins de 48 h. Pour en savoir plus, rendez-vous sur le site de l’[ARS de Corse](https://www.corse.ars.sante.fr/covid19-pass-sanitaire-obligatoire-pour-venir-en-corse).
 
     **Pour l’Outre-mer** : les conditions de voyages diffèrent selon la destination. Nous vous invitons à consulter [cette page](https://www.gouvernement.fr/info-coronavirus/outre-mer) pour en obtenir le détail.
 
@@ -250,7 +250,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 .. question:: <span class="visually-hidden">Je suis en cours de vaccination :</span> Je rentre d’un pays de l’Espace européen. Quelles mesures s’appliquent à mon retour en France métropolitaine ?
     :level: 4
 
-    À l’embarquement sur votre vol retour vers la France, vous devrez présenter un **test antigénique ou RT-PCR négatif** réalisé dans les 72 h précédant votre vol (moins de 24 h pour les pays sous surveillance : Chypre, Espagne, Grèce, Malte, Pays-Bas, Portugal).
+    À l’embarquement sur votre vol retour vers la France, vous devrez présenter un **test antigénique ou PCR négatif** réalisé dans les 72 h précédant votre vol (moins de 24 h pour les pays sous surveillance : Chypre, Espagne, Grèce, Malte, Pays-Bas, Portugal).
 
     Pour plus de détails, consultez le [site du ministère de l’Intérieur](https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestation-de-deplacement-et-de-voyage#from8).
 
@@ -264,7 +264,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 
     Pour vérifier à quelle catégorie (**verte**, **orange** ou **rouge**) appartient votre pays de destination, rendez-vous sur [le site du gouvernement](https://www.gouvernement.fr/info-coronavirus/deplacements#informations).
 
-    La plupart des pays exigent la présentation d’un **test RT-PCR négatif** récent (réalisé il y a moins de 48 h ou 72 h). Pour connaître les conditions d’entrée dans votre pays de destination, vous pouvez consulter le site internet de son ambassade et/ou celui de [France Diplomatie](https://www.diplomatie.gouv.fr/fr/je-pars-a-l-etranger/).
+    La plupart des pays exigent la présentation d’un **test PCR négatif** récent (réalisé il y a moins de 48 h ou 72 h). Pour connaître les conditions d’entrée dans votre pays de destination, vous pouvez consulter le site internet de son ambassade et/ou celui de [France Diplomatie](https://www.diplomatie.gouv.fr/fr/je-pars-a-l-etranger/).
 
 
 .. question:: <span class="visually-hidden">Je suis en cours de vaccination :</span> Je rentre de voyage d’un pays extérieur à l’Espace européen. Quelles mesures s’appliquent à mon retour en France métropolitaine ?
@@ -272,15 +272,15 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 
     Les mesures sont plus ou moins contraignantes selon le pays d’où vous revenez :
 
-    * D’un [pays classé **vert**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (États membres de l’Union européenne ainsi que Andorre, l’Islande, le Liechtenstein, Monaco, la Norvège, Saint-Marin, la Suisse et le Vatican ; s’y ajoutent l’Arabie Saoudite, l’Australie, le Bahreïn, Brunei, le Canada, le Chili, la Corée du Sud, les États-Unis, Hong-Kong, Israël, le Japon, la Jordanie, le Liban,  la Nouvelle-Zélande, Singapour, Taïwan, Ukraine, Union des Comores, l’Uruguay et Vanuatu) : vous n’aurez pas à respecter une quarantaine à votre retour mais vous devez présenter un test antigénique ou RT-PCR négatif de moins de 72 h (moins de 24 h pour les pays sous surveillance : Chypre, Espagne, Grèce, Malte, Pays-Bas, Portugal).
+    * D’un [pays classé **vert**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (États membres de l’Union européenne ainsi que Andorre, l’Islande, le Liechtenstein, Monaco, la Norvège, Saint-Marin, la Suisse et le Vatican ; s’y ajoutent l’Arabie Saoudite, l’Australie, le Bahreïn, Brunei, le Canada, le Chili, la Corée du Sud, les États-Unis, Hong-Kong, Israël, le Japon, la Jordanie, le Liban,  la Nouvelle-Zélande, Singapour, Taïwan, Ukraine, Union des Comores, l’Uruguay et Vanuatu) : vous n’aurez pas à respecter une quarantaine à votre retour mais vous devez présenter un test antigénique ou PCR négatif de moins de 72 h (moins de 24 h pour les pays sous surveillance : Chypre, Espagne, Grèce, Malte, Pays-Bas, Portugal).
 
     * D’un [pays classé **rouge**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (Afghanistan, Afrique du Sud, Algérie, Argentine, Bangladesh, Brésil, Colombie, Costa-Rica, Cuba, Géorgie, Indonésie, Iran, Maldives, Maroc, Mozambique, Namibie, Népal, Oman, Pakistan, République Démocratique du Congo, Russie, Seychelles, Suriname, Tunisie et Turquie), vous devez :
-        - à l’embarquement, présenter un **test RT-PCR ou antigénique négatif** réalisé il y a moins de 48 h ;
+        - à l’embarquement, présenter un **test PCR ou antigénique négatif** réalisé il y a moins de 48 h ;
         - à l’arrivée, vous soumettre à un **test antigénique** ;
         - respecter une **quarantaine obligatoire de 10 jours** à votre retour en France.
 
     * D’un [pays classé **orange**](https://www.gouvernement.fr/info-coronavirus/deplacements#informations) (tous les pays, hors pays définis tels que « verts » et « rouges ») :
-        - à l’embarquement, vous devez présenter un **test RT-PCR ou antigénique négatif** récent (moins de 48 h ou 72 h) ;
+        - à l’embarquement, vous devez présenter un **test PCR ou antigénique négatif** récent (moins de 48 h ou 72 h) ;
         - respecter un **auto-isolement de 7 jours** à votre retour en France.
 
 </details>
@@ -301,9 +301,9 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 .. question:: <span class="visually-hidden">Je suis guéri(e) de la Covid :</span> Comment obtenir un « pass sanitaire européen » ?
     :level: 4
 
-    Si votre **test RT-PCR positif** date de plus de 11 jours et de moins de 6 mois et qu’il comporte un QR code aux normes européennes, alors il fait office de **« certificat de rétablissement »** reconnu comme « pass sanitaire » en France et dans l’Espace européen.
+    Si votre **test PCR positif** date de plus de 11 jours et de moins de 6 mois et qu’il comporte un QR code aux normes européennes, alors il fait office de **« certificat de rétablissement »** reconnu comme « pass sanitaire » en France et dans l’Espace européen.
 
-    Cependant, certains pays européens peuvent continuer à exiger un **test de dépistage négatif** (RT-PCR ou antigénique) récent (48 h ou 72 h).
+    Cependant, certains pays européens peuvent continuer à exiger un **test de dépistage négatif** (PCR ou antigénique) récent (48 h ou 72 h).
 
     Pour télécharger le **certificat de dépistage** comportant un QR code aux normes européennes, rendez-vous sur le [portail SI-DEP](https://sidep.gouv.fr/cyberlab/patientviewer.jsp).
 
@@ -323,7 +323,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 .. question:: <span class="visually-hidden">Je suis guéri(e) de la Covid :</span> Je rentre d’un pays de l’Espace européen. Quelles mesures s’appliquent à mon retour en France métropolitaine ?
     :level: 4
 
-    À l’embarquement sur votre vol retour vers la France, vous devrez présenter un **test antigénique ou RT-PCR négatif** réalisé dans les 72 h précédant votre vol (moins de 24 h pour les pays sous surveillance : Chypre, Espagne, Grèce, Malte, Pays-Bas, Portugal).
+    À l’embarquement sur votre vol retour vers la France, vous devrez présenter un **test antigénique ou PCR négatif** réalisé dans les 72 h précédant votre vol (moins de 24 h pour les pays sous surveillance : Chypre, Espagne, Grèce, Malte, Pays-Bas, Portugal).
 
     Pour plus de détails, consultez le [site du ministère de l’Intérieur](https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestation-de-deplacement-et-de-voyage#from8).
 
@@ -341,9 +341,9 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 .. question:: <span class="visually-hidden">Je suis guéri(e) de la Covid :</span> Est-ce que je peux partir en Corse ou vers les destinations d’Outre-mer ?
     :level: 4
 
-    **Pour la Corse** : vous devez présenter un **test RT-PCR négatif** réalisé il y a moins de 72 h **ou** un test antigénique négatif réalisé il y a moins de 48 h. Pour en savoir plus, rendez-vous sur le site de l’[ARS de Corse](https://www.corse.ars.sante.fr/covid19-pass-sanitaire-obligatoire-pour-venir-en-corse).
+    **Pour la Corse** : vous devez présenter un **test PCR négatif** réalisé il y a moins de 72 h **ou** un test antigénique négatif réalisé il y a moins de 48 h. Pour en savoir plus, rendez-vous sur le site de l’[ARS de Corse](https://www.corse.ars.sante.fr/covid19-pass-sanitaire-obligatoire-pour-venir-en-corse).
 
-    **Pour l’Outre-mer** : toutes les destinations d’Outre-mer exigent la présentation d’un **test RT-PCR négatif** de moins de 72 h lors de l’embarquement. D’autres conditions de voyages plus ou moins contraignantes s’ajoutent selon la destination. Nous vous invitons à consulter [cette page](https://www.gouvernement.fr/info-coronavirus/outre-mer) pour en obtenir le détail.
+    **Pour l’Outre-mer** : toutes les destinations d’Outre-mer exigent la présentation d’un **test PCR négatif** de moins de 72 h lors de l’embarquement. D’autres conditions de voyages plus ou moins contraignantes s’ajoutent selon la destination. Nous vous invitons à consulter [cette page](https://www.gouvernement.fr/info-coronavirus/outre-mer) pour en obtenir le détail.
 
 </details>
 
@@ -409,8 +409,8 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
 
     **3 types de justificatifs** peuvent constituer un « pass sanitaire » grâce à un **QR code** intégré reconnu dans tout l’Espace européen :
 
-    - **non-contamination** : le résultat *négatif* d’un **test RT-PCR ou antigénique** réalisé il y a moins de 72 h ;
-    - **certificat de rétablissement** : le résultat *positif* d’un **test RT-PCR** de plus de 11 jours et de moins de 6 mois ;
+    - **non-contamination** : le résultat *négatif* d’un **test PCR ou antigénique** réalisé il y a moins de 72 h ;
+    - **certificat de rétablissement** : le résultat *positif* d’un **test PCR** de plus de 11 jours et de moins de 6 mois ;
     - **certificat de vaccination** : une attestation de **vaccination complète**, c’est-à-dire que vous avez reçu toutes les doses nécessaires depuis au moins **2 semaines** (*Pfizer*, *Moderna*, *AstraZeneca*) ou 4 semaines (*Janssen*) ; pour une utilisation en **France**, le délai d’attente après la 2<sup>e</sup> dose est réduit à **1 semaine** pour les vaccins *Pfizer*, *Moderna* et *AstraZeneca*.
 
     **Note :** en cas de [contre-indication à la vaccination](/je-veux-me-faire-vacciner.html#y-a-t-il-des-contre-indications-la-vaccination), il est possible de demander à son médecin un **certificat médical** qui fera office de passe sanitaire.
@@ -457,7 +457,7 @@ Pour obtenir une réponse à votre question, cliquez sur la situation qui vous c
     Pour savoir comment importer (scanner) votre QR code dans l’application TousAntiCovid :
 
     - [Cliquez ici](https://tousanticovid.stonly.com/kb/guide/fr/importer-son-certificat-de-vaccination-TJLG8dT8fs/Steps/347514) si c’est un certificat de vaccination.
-    - [Cliquez ici](https://tousanticovid.stonly.com/kb/guide/fr/importer-son-certificat-de-test-siCsOIDGCZ/Steps/320836) si c’est un test de dépistage antigénique ou RT-PCR.
+    - [Cliquez ici](https://tousanticovid.stonly.com/kb/guide/fr/importer-son-certificat-de-test-siCsOIDGCZ/Steps/320836) si c’est un test de dépistage antigénique ou PCR.
 
 
 .. question:: Est-ce que je peux importer le « pass sanitaire » de mes enfants, ou de mon (ma) conjoint(e) dans mon application TousAntiCovid ?

--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -99,13 +99,13 @@
 
 <div id="tests-de-depistage-symptomes-moins-4-jours-reponse" class="statut statut-bleu" hidden>
 
-Vous avez des symptômes qui peuvent évoquer la Covid depuis moins de 4 jours, nous vous recommandons de faire un test **antigénique** ou **RT-PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
+Vous avez des symptômes qui peuvent évoquer la Covid depuis moins de 4 jours, nous vous recommandons de faire un test **antigénique** ou **PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
 
 </div>
 
 <div id="tests-de-depistage-symptomes-plus-4-jours-reponse" class="statut statut-bleu" hidden>
 
-Vous avez des symptômes qui peuvent évoquer la Covid depuis plus de 4 jours, nous vous recommandons de faire un **test RT-PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
+Vous avez des symptômes qui peuvent évoquer la Covid depuis plus de 4 jours, nous vous recommandons de faire un **test PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
 
 </div>
 
@@ -113,13 +113,13 @@ Vous avez des symptômes qui peuvent évoquer la Covid depuis plus de 4 jours, 
 
 Vous n’avez pas de symptômes qui peuvent évoquer la Covid mais vous êtes cas contact, nous vous recommandons de faire un **test antigénique** si vous venez de l’apprendre.
 
-Pour un test de contrôle (7 jours après votre contact à risque ), les tests **antigénique** ou **RT-PCR nasopharyngé** sont indiqués.  Consultez notre page thématique [« Je suis cas contact Covid, que faire ? »](/cas-contact-a-risque.html).
+Pour un test de contrôle (7 jours après votre contact à risque ), les tests **antigénique** ou **PCR nasopharyngé** sont indiqués.  Consultez notre page thématique [« Je suis cas contact Covid, que faire ? »](/cas-contact-a-risque.html).
 
 </div>
 
 <div id="tests-de-depistage-pas-symptomes-pas-cas-contact-auto-test-oui-reponse" class="statut statut-bleu" hidden>
 
-Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pas cas contact mais votre auto-test est positif. Vous devez confirmer ce résultat avec un test **RT-PCR nasopharyngé** et rester en isolement le temps d’obtenir cette confirmation.
+Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pas cas contact mais votre auto-test est positif. Vous devez confirmer ce résultat avec un test **PCR nasopharyngé** et rester en isolement le temps d’obtenir cette confirmation.
 
 </div>
 
@@ -127,8 +127,8 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pa
 
 Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes pas cas contact :
 
-* Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **RT-PCR nasopharyngé**, **antigénique** ou **autotest supervisé** par un professionnel de santé réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
-* Si vous rendez visite à des personnes vulnérables, un test **antigénique** ou **RT-PCR nasopharyngé** est indiqué.
+* Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **PCR nasopharyngé**, **antigénique** ou **autotest supervisé** par un professionnel de santé réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
+* Si vous rendez visite à des personnes vulnérables, un test **antigénique** ou **PCR nasopharyngé** est indiqué.
 * Si vous travaillez régulièrement avec des personnes fragiles, il est recommandé de vous tester régulièrement avec les **autotests** vendus en pharmacie (les professionnels exerçant à domicile auprès de personnes vulnérables peuvent obtenir la prise en charge de 10 auto-tests par mois en présentant leur carte professionnelle au pharmacien).
 
 </div>
@@ -155,23 +155,23 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes 
     * les français qui résident habituellement à l’étranger ;
     * les européens qui disposent d’une carte européenne d’assurance maladie.
 
-    Les touristes non européens peuvent bénéficier de la gratuité sur présentation d’une prescription médicale ou s’ils ont été identifiés cas contact par l’Assurance maladie, sur présentation d’un justificatif (SMS, courriel). En dehors de ces cas de figure, les prix des tests sont fixés à **49,89 euros** (RT-PCR) et **25 euros** (test antigénique rapide).
+    Les touristes non européens peuvent bénéficier de la gratuité sur présentation d’une prescription médicale ou s’ils ont été identifiés cas contact par l’Assurance maladie, sur présentation d’un justificatif (SMS, courriel). En dehors de ces cas de figure, les prix des tests sont fixés à **49,89 euros** (PCR) et **25 euros** (test antigénique).
 
 
 ## Quels sont les différents tests de dépistage de la Covid-19 ?
 
 <details>
 
-.. summary:: Test RT-PCR nasopharyngé
+.. summary:: Test PCR nasopharyngé
 
-.. question:: Le test RT-PCR nasopharyngé (prélèvement nasal)
+.. question:: Le test PCR nasopharyngé (prélèvement nasal)
     :level: 4
 
-    Le test RT-PCR nasopharyngé est le test de dépistage de la Covid-19 de référence.
+    Le test PCR nasopharyngé est le test de dépistage de la Covid-19 de référence.
     Un écouvillon (long coton-tige) est inséré dans les deux narines pour réaliser un prélèvement.
     Le résultat est habituellement disponible en 24 h.
 
-.. question:: Où faire un test RT-PCR nasopharyngé ?
+.. question:: Où faire un test PCR nasopharyngé ?
     :level: 4
 
     Ce test est réalisé exclusivement par un professionnel de santé en laboratoire ou dans un centre de dépistage.
@@ -200,9 +200,9 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes 
 
 <details>
 
-.. summary:: Test RT-PCR salivaire
+.. summary:: Test PCR salivaire
 
-.. question:: Le test RT-PCR salivaire (prélèvement buccal)
+.. question:: Le test PCR salivaire (prélèvement buccal)
     :level: 3
 
     Ce test est réalisé grâce au prélèvement de la salive, avec un écouvillon (long coton-tige) ou sans (par crachat). Moins contraignant que les tests nasopharyngés, il est recommandé **lorsque le prélèvement nasal est compliqué ou impossible** (très jeunes enfants, déviation de la cloison nasale, troubles psychiatriques…).
@@ -239,6 +239,6 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes 
 .. question:: Je souhaite me faire dépister mais les prélèvements nasopharyngés sont impossibles dans mon cas
     :level: 3
 
-    Le test **RT-PCR salivaire** est indiqué dans ces cas : enfant en bas âge, personnes présentant des troubles psychiatriques, déviation de la cloison nasale…
+    Le test **PCR salivaire** est indiqué dans ces cas : enfant en bas âge, personnes présentant des troubles psychiatriques, déviation de la cloison nasale…
 
 </div>

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -62,7 +62,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     * Si l’adolescent(e) a **moins de 16 ans**, [l’autorisation parentale de vaccination](https://solidarites-sante.gouv.fr/IMG/pdf/fiche_-_autorisation_parentale_vaccin_covid-19.pdf) signée par un des deux parents ou par le tuteur.
     * La **carte vitale** de l’adolescent(e) (si disponible), et **celle d’un parent** (ou une [attestation de droits](https://www.ameli.fr/paris/assure/adresses-et-contacts/lobtention-dun-document/obtenir-une-attestation/obtenir-une-attestation-de-droits) mentionnant le numéro de sécurité sociale d’un parent).
-    * La preuve de contamination antérieure, si le mineur a déjà été contaminé par la Covid. Cette preuve peut-être un ancien **test positif** (RT-PCR ou antigénique), ou une **sérologie** (prise de sang) indiquant la présence d’anticorps. Il faut respecter un délai de **2 mois minimum** après ce test positif avant de se faire vacciner.
+    * La preuve de contamination antérieure, si le mineur a déjà été contaminé par la Covid. Cette preuve peut-être un ancien **test positif** (PCR ou antigénique), ou une **sérologie** (prise de sang) indiquant la présence d’anticorps. Il faut respecter un délai de **2 mois minimum** après ce test positif avant de se faire vacciner.
 
 
 .. question:: Comment obtenir une attestation de vaccination (valable comme « pass sanitaire ») pour un mineur ?

--- a/diagrammes/matrice-statuts-conseils.md
+++ b/diagrammes/matrice-statuts-conseils.md
@@ -9,7 +9,7 @@
             <th style="border: 1px solid black; padding: 1rem;" rowspan="2" valign="middle" bgcolor="#EEEEEE" align="center">Pas testé<br>(ou test trop ancien)</th>
         </tr>
         <tr>
-            <th style="border: 1px solid black; padding: 1rem;" valign="middle" bgcolor="#EEEEEE" align="center">Test RT-PCR</th>
+            <th style="border: 1px solid black; padding: 1rem;" valign="middle" bgcolor="#EEEEEE" align="center">Test PCR</th>
             <th style="border: 1px solid black; padding: 1rem;" valign="middle" bgcolor="#EEEEEE" align="center">Test antigénique ou autotest</th>
             <th style="border: 1px solid black; padding: 1rem;" valign="middle" bgcolor="#EEEEEE" align="center">Test antigénique<br>(personne fragile)</th>
             <th style="border: 1px solid black; padding: 1rem;" valign="middle" bgcolor="#EEEEEE" align="center">Autres cas</th>

--- a/src/scripts/page/questionnaire/depistage.js
+++ b/src/scripts/page/questionnaire/depistage.js
@@ -48,7 +48,7 @@ export default function depistage(page, app) {
         enableOrDisableSecondaryFields(form, primary)
     })
 
-    // On ne propose "en attente" que pour les tests RT-PCR.
+    // On ne propose "en attente" que pour les tests PCR.
     const enAttente = form.querySelector('#depistage_resultat_en_attente')
     const enAttenteLabel = form.querySelector(
         'label[for="depistage_resultat_en_attente"]'

--- a/src/scripts/tests/integration/test.tests.js
+++ b/src/scripts/tests/integration/test.tests.js
@@ -83,10 +83,10 @@ describe('Tests', function () {
         await remplirSymptomes(page, 'oui')
         // De moins de 4 jours.
         await remplirDepuisQuand(page, 'moins_4_jours')
-        // On propose un test RT-PCR ou antigénique.
+        // On propose un test PCR ou antigénique.
         assert.include(
             await recuperationStatut(page, 'symptomes-moins-4-jours'),
-            'faire un test antigénique ou RT-PCR nasopharyngé.'
+            'faire un test antigénique ou PCR nasopharyngé.'
         )
     })
 
@@ -101,10 +101,10 @@ describe('Tests', function () {
         await remplirSymptomes(page, 'oui')
         // De plus de 4 jours.
         await remplirDepuisQuand(page, 'plus_4_jours')
-        // On propose un test RT-PCR.
+        // On propose un test PCR.
         assert.include(
             await recuperationStatut(page, 'symptomes-plus-4-jours'),
-            'faire un test RT-PCR nasopharyngé.'
+            'faire un test PCR nasopharyngé.'
         )
     })
 
@@ -139,13 +139,13 @@ describe('Tests', function () {
         await remplirCasContact(page, 'non')
         // Avec autotest.
         await remplirAutoTest(page, 'oui')
-        // On propose un test RT-PCR + isolement.
+        // On propose un test PCR + isolement.
         assert.include(
             await recuperationStatut(
                 page,
                 'pas-symptomes-pas-cas-contact-auto-test-oui'
             ),
-            'un test RT-PCR nasopharyngé et rester en isolement'
+            'un test PCR nasopharyngé et rester en isolement'
         )
     })
 
@@ -169,12 +169,12 @@ describe('Tests', function () {
         // On propose différents tests pour le pass sanitaire.
         assert.include(
             statut,
-            'un test négatif RT-PCR nasopharyngé, antigénique ou autotest supervisé'
+            'un test négatif PCR nasopharyngé, antigénique ou autotest supervisé'
         )
-        // On propose un test RT-PCR ou antigénique pour visiter des personnes vulnérables.
+        // On propose un test PCR ou antigénique pour visiter des personnes vulnérables.
         assert.include(
             statut,
-            'personnes vulnérables, un test antigénique ou RT-PCR nasopharyngé'
+            'personnes vulnérables, un test antigénique ou PCR nasopharyngé'
         )
         // On propose les autotests pour les personnes au contact de personnes fragiles.
         assert.include(statut, 'vous tester régulièrement avec les autotests')


### PR DESCRIPTION
J’ai l’impression que :
- tout le monde dit test PCR à la place de RT-PCR
- la précision « rapide » pour les tests antigéniques n’est désormais plus nécessaire