### PR TITLE
Modifie la réponse pass sanitaire du questionnaire

### DIFF
--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -127,7 +127,7 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pa
 
 Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes pas cas contact :
 
-* Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **RT-PCR nasopharyngé** ou **antigénique** réalisé il y a moins de 48 h pour l’usage en France et 72 h pour le contrôle aux frontières est nécessaire.
+* Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **RT-PCR nasopharyngé**, **antigénique** ou **auto-test supervisé** par un professionnel de santé réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
 * Si vous rendez visite à des personnes vulnérables, un test **antigénique** ou **RT-PCR nasopharyngé** est indiqué.
 * Si vous travaillez régulièrement avec des personnes fragiles, il est recommandé de vous tester régulièrement avec les **autotests** vendus en pharmacie (les professionnels exerçant à domicile auprès de personnes vulnérables peuvent obtenir la prise en charge de 10 auto-tests par mois en présentant leur carte professionnelle au pharmacien).
 
@@ -231,6 +231,8 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes 
     - on a eu un contact à risque récent (cas contact).
 
     Ce type de test est utile à condition de le pratiquer régulièrement (plusieurs fois par semaine).
+    
+    Pour obtenir un pass sanitaire, l'auto-test doit être réalisé sous la supervision d'un professionnel de santé.
 
 </details>
 

--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -127,7 +127,7 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pa
 
 Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes pas cas contact :
 
-* Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **RT-PCR nasopharyngé**, **antigénique** ou **auto-test supervisé** par un professionnel de santé réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
+* Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **RT-PCR nasopharyngé**, **antigénique** ou **autotest supervisé** par un professionnel de santé réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
 * Si vous rendez visite à des personnes vulnérables, un test **antigénique** ou **RT-PCR nasopharyngé** est indiqué.
 * Si vous travaillez régulièrement avec des personnes fragiles, il est recommandé de vous tester régulièrement avec les **autotests** vendus en pharmacie (les professionnels exerçant à domicile auprès de personnes vulnérables peuvent obtenir la prise en charge de 10 auto-tests par mois en présentant leur carte professionnelle au pharmacien).
 
@@ -232,7 +232,7 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes 
 
     Ce type de test est utile à condition de le pratiquer régulièrement (plusieurs fois par semaine).
     
-    Pour obtenir un pass sanitaire, l'auto-test doit être réalisé sous la supervision d'un professionnel de santé.
+    Pour obtenir un pass sanitaire, l'autotest doit être réalisé sous la supervision d'un professionnel de santé.
 
 </details>
 

--- a/src/scripts/tests/integration/test.tests.js
+++ b/src/scripts/tests/integration/test.tests.js
@@ -166,10 +166,10 @@ describe('Tests', function () {
             page,
             'pas-symptomes-pas-cas-contact-auto-test-non'
         )
-        // On propose un test RT-PCR ou antigénique pour le Pass sanitaire.
+        // On propose différents tests pour le pass sanitaire.
         assert.include(
             statut,
-            'un test négatif RT-PCR nasopharyngé ou antigénique réalisé il y a moins de 48 h'
+            'un test négatif RT-PCR nasopharyngé, antigénique ou autotest supervisé'
         )
         // On propose un test RT-PCR ou antigénique pour visiter des personnes vulnérables.
         assert.include(


### PR DESCRIPTION
Ajoute l'auto-test supervisé par un professionnel pour le pass sanitaire.

Corrige la durée de validité d'un test négatif en France 72h ou 48h pour les voyages en Corse et Dom-TOM. Enlève l'indication pour les voyages car moins pertinente sur cette page et ça permet de raccourcir la réponse déjà longue.

Source : https://www.gouvernement.fr/info-coronavirus/pass-sanitaire