### PR TITLE
Mise à jour des réponses sur la campagne de rappel (3e dose)

### DIFF
--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -22,14 +22,17 @@
 
 .. question:: Quand pourrai-je recevoir la dose de rappel, dite 3<sup>e</sup> dose ?
 
-    Les personnes concernées par ce rappel ([voir ci-dessus](#devrai-je-recevoir-une-dose-de-rappel-dite-3-e-dose)) devront attendre un délai d’**au moins 6 mois**, sauf :
+    Le **délai recommandé** par la Haute autorité de santé (HAS) pour un **rappel vaccinal** (2<sup>e</sup>, 3<sup>e</sup> ou 4<sup>e</sup> dose selon les cas), est le suivant :
 
-    * les personnes sévèrement **immunodéprimées**, qui peuvent recevoir leur **4<sup>e</sup> dose à partir de 3 mois** après leur 3<sup>e</sup> dose ;
-    * les personnes vaccciné(e)s avec le vaccin **Janssen** qui peuvent recevoir leur **2<sup>e</sup> dose à partir de 4 semaines** après la première dose.
+    * pour les personnes de **65 ans et plus** ou avec des **comorbidités** augmentant le risque de formes graves (*3<sup>e</sup> dose*) : au moins **6 mois** après la dernière injection de vaccin ;
+
+    * pour les personnes vaccciné(e)s avec le vaccin **Janssen** (*2<sup>e</sup> dose*) : au moins **4 semaines** après l’injection ;
+
+    * pour les personnes sévèrement **immunodéprimées** (*4<sup>e</sup> dose*) : au moins **3 mois** après la dernière injection de vaccin.
+
+    **Dès maintenant**, et si ce délai est respecté, vous pouvez prendre rendez-vous chez un **professionnel de santé** (médecin, pharmacien, infirmier…) ou dans un **centre de vaccination** (*voir ci-dessous*).
 
     Lorsque les délais le permettent, ce rappel pourra avoir lieu en même temps que celui contre la **grippe saisonnière**.
-
-    La vaccination se déroule en **centre de vaccination** ou chez un **professionnel de santé** (médecin, pharmacien, infirmier…).
 
 
 .. question:: Où me faire vacciner ?

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -17,7 +17,7 @@
     * les personnes **sévèrement immunodéprimées**,
     * les personnes vaccinées avec le **vaccin Janssen**.
 
-    Le **rappel est réalisé avec un vaccin à ARN messager (Pfizer ou Moderna)**, quel que soit le type de vaccin utilisé précédemment.
+    Le rappel est réalisé avec un **vaccin à ARN messager (Pfizer ou Moderna)**, quel que soit le type de vaccin utilisé précédemment. En particulier, il est possible de recevoir un rappel avec le vaccin *Pfizer* même si on a été vacciné initialement avec le vaccin *Moderna*, et inversement.
 
 
 .. question:: Quand pourrai-je recevoir la dose de rappel, dite 3<sup>e</sup> dose ?

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -17,6 +17,12 @@
     * les personnes **sévèrement immunodéprimées**,
     * les personnes vaccinées avec le **vaccin Janssen**.
 
+    <div class="conseil conseil-jaune">
+
+    Si vous avez eu la Covid **après votre dernière dose**, alors vous n’êtes **pas éligible** à ce rappel.
+
+    </div>
+
     Le rappel est réalisé avec un **vaccin à ARN messager (Pfizer ou Moderna)**, quel que soit le type de vaccin utilisé précédemment. En particulier, il est possible de recevoir un rappel avec le vaccin *Pfizer* même si on a été vacciné initialement avec le vaccin *Moderna*, et inversement.
 
 

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -40,8 +40,6 @@
 
     **Dès maintenant**, et si ce délai est respecté, vous pouvez prendre rendez-vous chez un **professionnel de santé** (médecin, pharmacien, infirmier…) ou dans un **centre de vaccination** (*voir ci-dessous*).
 
-    Lorsque les délais le permettent, ce rappel pourra avoir lieu en même temps que celui contre la **grippe saisonnière**.
-
 
 .. question:: Où me faire vacciner ?
 

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -22,6 +22,8 @@
 
 .. question:: Quand pourrai-je recevoir la dose de rappel, dite 3<sup>e</sup> dose ?
 
+    La campagne de rappels a commencé le **1<sup>er</sup> septembre 2021**.
+
     Le **délai recommandé** par la Haute autorité de santé (HAS) pour un **rappel vaccinal** (2<sup>e</sup>, 3<sup>e</sup> ou 4<sup>e</sup> dose selon les cas), est le suivant :
 
     * pour les personnes de **65 ans et plus** ou avec des **comorbidités** augmentant le risque de formes graves (*3<sup>e</sup> dose*) : au moins **6 mois** après la dernière injection de vaccin ;


### PR DESCRIPTION
- précise que les personnes ayant eu la Covid après la vaccination ne sont pas éligibles au rappel
- précise que l’on peut alterner entre Pfizer et Moderna
- ajoute la date de début de la campagne de rappels (1er septembre)
- restructure la réponse sur le délai avant le rappel
- ne mentionne pas la grippe saisonnière (la campagne de vaccination ne commencera que mi-octobre)