### PR TITLE
Tentative de remodeler la page du questionnaire personnalisé

### DIFF
--- a/contenus/thematiques/2-j-ai-des-symptomes-covid.md
+++ b/contenus/thematiques/2-j-ai-des-symptomes-covid.md
@@ -2,23 +2,32 @@
 
 <img src="illustrations/symptomesactuels.svg">
 
-Vous vous demandez ce qu'il faut faire en cas de test de dépistage **positif** ou de **symptômes** qui évoquent la Covid-19 ? **Répondez** à quelques questions pour obtenir des **réponses personnalisées** pour vous, ou pour un proche.
-<div class="cta">
-    <a class="button button-arrow"
-        href="/#vaccins"
-        data-set-profil="mes_infos"
-        >Je réponds pour moi</a>
-    <a class="button button-outline button-arrow"
-        href="/#nom"
-        >Je réponds pour un proche</a>
-</div>
-
-[Quels sont les symptômes de la Covid ?](#quels-sont-les-symptomes-de-la-covid-?)  
-[Je suis vacciné(e), est-ce que je peux être positif ou positive à la Covid ?](#je-suis-vacciné(e)-est-ce-que-je-peux-être-positif-à-la-covid-?)
+<header></header>
 
 <div itemscope itemtype="https://schema.org/FAQPage">
 
-    
+.. question:: Que faire si j’ai des symptômes et/ou que je suis positif ?
+    :feedback: remove
+
+    <form>
+        <fieldset>
+            <legend>
+                <p>
+                    Répondez à quelques questions sur votre <strong>situation actuelle</strong> pour obtenir des <strong>réponses personnalisées</strong> :</p>
+            </legend>
+        </fieldset>
+        <div class="cta">
+            <a class="button button-arrow"
+                href="/#vaccins"
+                data-set-profil="mes_infos"
+                >Je réponds pour moi</a>
+            <a class="button button-outline button-arrow"
+                href="/#nom"
+                >Je réponds pour un proche</a>
+        </div>
+    </form>
+
+
 .. question:: Quels sont les symptômes de la Covid ?
 
     <div class="conseil conseil-jaune">

--- a/contenus/thematiques/2-j-ai-des-symptomes-covid.md
+++ b/contenus/thematiques/2-j-ai-des-symptomes-covid.md
@@ -2,14 +2,23 @@
 
 <img src="illustrations/symptomesactuels.svg">
 
-<header>
-    <p class="big">
-        Vous avez des <strong>symptômes</strong> qui vous inquiètent ? Vous avez de la <strong>fièvre</strong> ? Une <strong>fatigue</strong> intense ? Des difficulés à <strong>respirer</strong> ? Une <strong>toux</strong> persistante ? Votre test est <strong>positif</strong> ?
-    </p>
-</header>
+Vous vous demandez ce qu'il faut faire en cas de test de dépistage **positif** ou de **symptômes** qui évoquent la Covid-19 ? **Répondez** à quelques questions pour obtenir des **réponses personnalisées** pour vous, ou pour un proche.
+<div class="cta">
+    <a class="button button-arrow"
+        href="/#vaccins"
+        data-set-profil="mes_infos"
+        >Je réponds pour moi</a>
+    <a class="button button-outline button-arrow"
+        href="/#nom"
+        >Je réponds pour un proche</a>
+</div>
+
+[Quels sont les symptômes de la Covid ?](#quels-sont-les-symptomes-de-la-covid-?)  
+[Je suis vacciné(e), est-ce que je peux être positif ou positive à la Covid ?](#je-suis-vacciné(e)-est-ce-que-je-peux-être-positif-à-la-covid-?)
 
 <div itemscope itemtype="https://schema.org/FAQPage">
 
+    
 .. question:: Quels sont les symptômes de la Covid ?
 
     <div class="conseil conseil-jaune">
@@ -47,19 +56,9 @@
 
     Les vaccins contre la Covid vous protègent contre la maladie en réduisant le risque de l’attraper et de faire une forme grave. Ces vaccins sont très efficaces, mais **aucun vaccin ne protège à 100 %** et cette efficacité peut varier selon les personnes.
 
-    **Si votre test est positif**, nous vous encourageons à vous isoler et à [décrire votre situation](/#symptomes) pour obtenir des conseils personnalisés sur la conduite à tenir.
+    **Si votre test est positif**, nous vous encourageons à vous isoler et à [faire notre questionnaire rapide](/#symptomes) pour obtenir des conseils personnalisés sur la conduite à tenir.
 
 </div>
 
 
-## Obtenez des conseils adaptés à votre situation en quelques clics
 
-<div class="cta">
-    <a class="button button-arrow"
-        href="/#vaccins"
-        data-set-profil="mes_infos"
-        >J’ai des symptômes ou mon test est positif</a>
-    <a class="button button-outline button-arrow"
-        href="/#nom"
-        >Ça concerne un(e) proche</a>
-</div>

--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -4,140 +4,141 @@
 
 <header></header>
 
-## Quel est le test adapté à ma situation ?
-
-<form id="tests-de-depistage-demarrage-form">
-    <fieldset>
-        <legend>
-            <h3>Pass sanitaire, symptômes, cas contact ?</h3>
-            En quelques clics, découvrez quel test de dépistage est le plus adapté à votre situation.
-        </legend>
-    </fieldset>
-    <div class="form-controls">
-        <div class="button-with-progress">
-            <p></p>
-            <input type="submit" class="button button-arrow" value=" C’est parti !   ">
-        </div>
-    </div>
-</form>
-
-<form id="tests-de-depistage-symptomes-form" hidden>
-    <a href="#" data-precedent="demarrage" class="back-button">Retour</a>
-    <fieldset class="required">
-        <legend><h3 id="tests-de-depistage-symptomes-label">Avez-vous des symptômes qui peuvent évoquer la Covid ?</h3></legend>
-        <div role="radiogroup" aria-labelledby="tests-de-depistage-symptomes-label">
-            <input id="tests_de_depistage_symptomes_radio_oui" type="radio" required name="tests_de_depistage_symptomes_radio" value="oui">
-            <label for="tests_de_depistage_symptomes_radio_oui">Oui</label>
-            <input id="tests_de_depistage_symptomes_radio_non" type="radio" required name="tests_de_depistage_symptomes_radio" value="non">
-            <label for="tests_de_depistage_symptomes_radio_non">Non</label>
-        </div>
-    </fieldset>
-    <div class="form-controls">
-        <div class="button-with-progress">
-            <p id="aria-description-progress-tests-de-depistage-symptomes" class="progress">Il vous reste moins de 2 étapes</p>
-            <input type="submit" class="button button-arrow" value="Continuer" aria-describedby="aria-description-progress-tests-de-depistage-symptomes">
-        </div>
-    </div>
-</form>
-
-<form id="tests-de-depistage-depuis-quand-form" hidden>
-    <a href="#" data-precedent="symptomes" class="back-button">Retour</a>
-    <fieldset class="required" id="tests-de-depistage-depuis-quand">
-        <legend><h3 id="tests-de-depistage-depuis-quand-label">Depuis quand avez-vous des symptômes ?</h3></legend>
-        <div role="radiogroup" aria-labelledby="tests-de-depistage-depuis-quand-label">
-            <input id="tests_de_depistage_depuis_quand_radio_moins_4_jours" type="radio" required name="tests_de_depistage_depuis_quand_radio" value="moins-4-jours">
-            <label for="tests_de_depistage_depuis_quand_radio_moins_4_jours">depuis 4 jours ou moins</label>
-            <input id="tests_de_depistage_depuis_quand_radio_plus_4_jours" type="radio" required name="tests_de_depistage_depuis_quand_radio" value="plus-4-jours">
-            <label for="tests_de_depistage_depuis_quand_radio_plus_4_jours">depuis 5 jours ou plus</label>
-        </div>
-    </fieldset>
-    <div class="form-controls">
-        <div class="button-with-progress">
-            <p id="aria-description-progress-tests-de-depistage-depuis-quand" class="progress">C’est la dernière étape !</p>
-            <input type="submit" class="button" value="Terminer" aria-describedby="aria-description-progress-tests-de-depistage-depuis-quand">
-        </div>
-    </div>
-</form>
-
-<form id="tests-de-depistage-cas-contact-form" hidden>
-    <a href="#" data-precedent="symptomes" class="back-button">Retour</a>
-    <fieldset class="required" id="tests-de-depistage-cas-contact">
-        <legend><h3 id="tests-de-depistage-cas-contact-label">Êtes-vous cas contact ?</h3></legend>
-        <div role="radiogroup" aria-labelledby="tests-de-depistage-cas-contact-label">
-            <input id="tests_de_depistage_cas_contact_radio_oui" type="radio" required name="tests_de_depistage_cas_contact_radio" value="oui">
-            <label for="tests_de_depistage_cas_contact_radio_oui">Oui</label>
-            <input id="tests_de_depistage_cas_contact_radio_non" type="radio" required name="tests_de_depistage_cas_contact_radio" value="non">
-            <label for="tests_de_depistage_cas_contact_radio_non">Non</label>
-        </div>
-    </fieldset>
-    <div class="form-controls">
-        <div class="button-with-progress">
-            <p id="aria-description-progress-tests-de-depistage-cas-contact" class="progress">Plus qu’une étape</p>
-            <input type="submit" class="button" value="Continuer" aria-describedby="aria-description-progress-tests-de-depistage-cas-contact">
-        </div>
-    </div>
-</form>
-
-<form id="tests-de-depistage-auto-test-form" hidden>
-    <a href="#" data-precedent="cas-contact" class="back-button">Retour</a>
-    <fieldset id="tests-de-depistage-auto-test">
-        <legend><h3 id="tests-de-depistage-auto-test-label">Je veux faire un test pour…</h3></legend>
-        <div role="radiogroup" aria-labelledby="tests-de-depistage-auto-test-label">
-            <input id="tests_de_depistage_auto_test_radio_oui" type="radio" required name="tests_de_depistage_auto_test_radio" value="oui">
-            <label for="tests_de_depistage_auto_test_radio_oui">confirmer un autotest positif</label>
-            <input id="tests_de_depistage_auto_test_radio_non" type="radio" required name="tests_de_depistage_auto_test_radio" value="non">
-            <label for="tests_de_depistage_auto_test_radio_non">obtenir un « pass sanitaire », rendre visite à une personne vulnérable, etc.</label>
-        </div>
-    </fieldset>
-    <div class="form-controls">
-        <div class="button-with-progress">
-            <p id="aria-description-progress-tests-de-depistage-auto-test" class="progress">C’est la dernière étape !</p>
-            <input type="submit" class="button" value="Terminer" aria-describedby="aria-description-progress-tests-de-depistage-auto-test">
-        </div>
-    </div>
-</form>
-
-<div id="tests-de-depistage-symptomes-moins-4-jours-reponse" class="statut statut-bleu" hidden>
-
-Vous avez des symptômes qui peuvent évoquer la Covid depuis moins de 4 jours, nous vous recommandons de faire un test **antigénique** ou **PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
-
-</div>
-
-<div id="tests-de-depistage-symptomes-plus-4-jours-reponse" class="statut statut-bleu" hidden>
-
-Vous avez des symptômes qui peuvent évoquer la Covid depuis plus de 4 jours, nous vous recommandons de faire un **test PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
-
-</div>
-
-<div id="tests-de-depistage-pas-symptomes-cas-contact-oui-reponse" class="statut statut-bleu" hidden>
-
-Vous n’avez pas de symptômes qui peuvent évoquer la Covid mais vous êtes cas contact, nous vous recommandons de faire un **test antigénique** si vous venez de l’apprendre.
-
-Pour un test de contrôle (7 jours après votre contact à risque ), les tests **antigénique** ou **PCR nasopharyngé** sont indiqués.  Consultez notre page thématique [« Je suis cas contact Covid, que faire ? »](/cas-contact-a-risque.html).
-
-</div>
-
-<div id="tests-de-depistage-pas-symptomes-pas-cas-contact-auto-test-oui-reponse" class="statut statut-bleu" hidden>
-
-Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pas cas contact mais votre auto-test est positif. Vous devez confirmer ce résultat avec un test **PCR nasopharyngé** et rester en isolement le temps d’obtenir cette confirmation.
-
-</div>
-
-<div id="tests-de-depistage-pas-symptomes-pas-cas-contact-auto-test-non-reponse" class="statut statut-bleu" hidden>
-
-Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes pas cas contact :
-
-* Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **PCR nasopharyngé**, **antigénique** ou **autotest supervisé** par un professionnel de santé réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
-* Si vous rendez visite à des personnes vulnérables, un test **antigénique** ou **PCR nasopharyngé** est indiqué.
-* Si vous travaillez régulièrement avec des personnes fragiles, il est recommandé de vous tester régulièrement avec les **autotests** vendus en pharmacie (les professionnels exerçant à domicile auprès de personnes vulnérables peuvent obtenir la prise en charge de 10 auto-tests par mois en présentant leur carte professionnelle au pharmacien).
-
-</div>
-
-<p id="tests-de-depistage-refaire" hidden>
-<a href="#" role="button" class="button button-outline button-half-width">Recommencer le questionnaire</a>
-</p>
-
 <div itemscope itemtype="https://schema.org/FAQPage">
+
+.. question:: Quel est le test adapté à ma situation ?
+
+    <form id="tests-de-depistage-demarrage-form">
+        <fieldset>
+            <legend>
+                <h3>Pass sanitaire, symptômes, cas contact ?</h3>
+                En quelques clics, découvrez quel test de dépistage est le plus adapté à votre situation.
+            </legend>
+        </fieldset>
+        <div class="form-controls">
+            <div class="button-with-progress">
+                <p></p>
+                <input type="submit" class="button button-arrow" value=" C’est parti !   ">
+            </div>
+        </div>
+    </form>
+
+    <form id="tests-de-depistage-symptomes-form" hidden>
+        <a href="#" data-precedent="demarrage" class="back-button">Retour</a>
+        <fieldset class="required">
+            <legend><h3 id="tests-de-depistage-symptomes-label">Avez-vous des symptômes qui peuvent évoquer la Covid ?</h3></legend>
+            <div role="radiogroup" aria-labelledby="tests-de-depistage-symptomes-label">
+                <input id="tests_de_depistage_symptomes_radio_oui" type="radio" required name="tests_de_depistage_symptomes_radio" value="oui">
+                <label for="tests_de_depistage_symptomes_radio_oui">Oui</label>
+                <input id="tests_de_depistage_symptomes_radio_non" type="radio" required name="tests_de_depistage_symptomes_radio" value="non">
+                <label for="tests_de_depistage_symptomes_radio_non">Non</label>
+            </div>
+        </fieldset>
+        <div class="form-controls">
+            <div class="button-with-progress">
+                <p id="aria-description-progress-tests-de-depistage-symptomes" class="progress">Il vous reste moins de 2 étapes</p>
+                <input type="submit" class="button button-arrow" value="Continuer" aria-describedby="aria-description-progress-tests-de-depistage-symptomes">
+            </div>
+        </div>
+    </form>
+
+    <form id="tests-de-depistage-depuis-quand-form" hidden>
+        <a href="#" data-precedent="symptomes" class="back-button">Retour</a>
+        <fieldset class="required" id="tests-de-depistage-depuis-quand">
+            <legend><h3 id="tests-de-depistage-depuis-quand-label">Depuis quand avez-vous des symptômes ?</h3></legend>
+            <div role="radiogroup" aria-labelledby="tests-de-depistage-depuis-quand-label">
+                <input id="tests_de_depistage_depuis_quand_radio_moins_4_jours" type="radio" required name="tests_de_depistage_depuis_quand_radio" value="moins-4-jours">
+                <label for="tests_de_depistage_depuis_quand_radio_moins_4_jours">depuis 4 jours ou moins</label>
+                <input id="tests_de_depistage_depuis_quand_radio_plus_4_jours" type="radio" required name="tests_de_depistage_depuis_quand_radio" value="plus-4-jours">
+                <label for="tests_de_depistage_depuis_quand_radio_plus_4_jours">depuis 5 jours ou plus</label>
+            </div>
+        </fieldset>
+        <div class="form-controls">
+            <div class="button-with-progress">
+                <p id="aria-description-progress-tests-de-depistage-depuis-quand" class="progress">C’est la dernière étape !</p>
+                <input type="submit" class="button" value="Terminer" aria-describedby="aria-description-progress-tests-de-depistage-depuis-quand">
+            </div>
+        </div>
+    </form>
+
+    <form id="tests-de-depistage-cas-contact-form" hidden>
+        <a href="#" data-precedent="symptomes" class="back-button">Retour</a>
+        <fieldset class="required" id="tests-de-depistage-cas-contact">
+            <legend><h3 id="tests-de-depistage-cas-contact-label">Êtes-vous cas contact ?</h3></legend>
+            <div role="radiogroup" aria-labelledby="tests-de-depistage-cas-contact-label">
+                <input id="tests_de_depistage_cas_contact_radio_oui" type="radio" required name="tests_de_depistage_cas_contact_radio" value="oui">
+                <label for="tests_de_depistage_cas_contact_radio_oui">Oui</label>
+                <input id="tests_de_depistage_cas_contact_radio_non" type="radio" required name="tests_de_depistage_cas_contact_radio" value="non">
+                <label for="tests_de_depistage_cas_contact_radio_non">Non</label>
+            </div>
+        </fieldset>
+        <div class="form-controls">
+            <div class="button-with-progress">
+                <p id="aria-description-progress-tests-de-depistage-cas-contact" class="progress">Plus qu’une étape</p>
+                <input type="submit" class="button" value="Continuer" aria-describedby="aria-description-progress-tests-de-depistage-cas-contact">
+            </div>
+        </div>
+    </form>
+
+    <form id="tests-de-depistage-auto-test-form" hidden>
+        <a href="#" data-precedent="cas-contact" class="back-button">Retour</a>
+        <fieldset id="tests-de-depistage-auto-test">
+            <legend><h3 id="tests-de-depistage-auto-test-label">Je veux faire un test pour…</h3></legend>
+            <div role="radiogroup" aria-labelledby="tests-de-depistage-auto-test-label">
+                <input id="tests_de_depistage_auto_test_radio_oui" type="radio" required name="tests_de_depistage_auto_test_radio" value="oui">
+                <label for="tests_de_depistage_auto_test_radio_oui">confirmer un autotest positif</label>
+                <input id="tests_de_depistage_auto_test_radio_non" type="radio" required name="tests_de_depistage_auto_test_radio" value="non">
+                <label for="tests_de_depistage_auto_test_radio_non">obtenir un « pass sanitaire », rendre visite à une personne vulnérable, etc.</label>
+            </div>
+        </fieldset>
+        <div class="form-controls">
+            <div class="button-with-progress">
+                <p id="aria-description-progress-tests-de-depistage-auto-test" class="progress">C’est la dernière étape !</p>
+                <input type="submit" class="button" value="Terminer" aria-describedby="aria-description-progress-tests-de-depistage-auto-test">
+            </div>
+        </div>
+    </form>
+
+    <div id="tests-de-depistage-symptomes-moins-4-jours-reponse" class="statut statut-bleu" hidden>
+
+    Vous avez des symptômes qui peuvent évoquer la Covid depuis moins de 4 jours, nous vous recommandons de faire un test **antigénique** ou **PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
+
+    </div>
+
+    <div id="tests-de-depistage-symptomes-plus-4-jours-reponse" class="statut statut-bleu" hidden>
+
+    Vous avez des symptômes qui peuvent évoquer la Covid depuis plus de 4 jours, nous vous recommandons de faire un **test PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
+
+    </div>
+
+    <div id="tests-de-depistage-pas-symptomes-cas-contact-oui-reponse" class="statut statut-bleu" hidden>
+
+    Vous n’avez pas de symptômes qui peuvent évoquer la Covid mais vous êtes cas contact, nous vous recommandons de faire un **test antigénique** si vous venez de l’apprendre.
+
+    Pour un test de contrôle (7 jours après votre contact à risque ), les tests **antigénique** ou **PCR nasopharyngé** sont indiqués.  Consultez notre page thématique [« Je suis cas contact Covid, que faire ? »](/cas-contact-a-risque.html).
+
+    </div>
+
+    <div id="tests-de-depistage-pas-symptomes-pas-cas-contact-auto-test-oui-reponse" class="statut statut-bleu" hidden>
+
+    Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pas cas contact mais votre auto-test est positif. Vous devez confirmer ce résultat avec un test **PCR nasopharyngé** et rester en isolement le temps d’obtenir cette confirmation.
+
+    </div>
+
+    <div id="tests-de-depistage-pas-symptomes-pas-cas-contact-auto-test-non-reponse" class="statut statut-bleu" hidden>
+
+    Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes pas cas contact :
+
+    * Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **PCR nasopharyngé**, **antigénique** ou **autotest supervisé** par un professionnel de santé réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
+    * Si vous rendez visite à des personnes vulnérables, un test **antigénique** ou **PCR nasopharyngé** est indiqué.
+    * Si vous travaillez régulièrement avec des personnes fragiles, il est recommandé de vous tester régulièrement avec les **autotests** vendus en pharmacie (les professionnels exerçant à domicile auprès de personnes vulnérables peuvent obtenir la prise en charge de 10 auto-tests par mois en présentant leur carte professionnelle au pharmacien).
+
+    </div>
+
+    <p id="tests-de-depistage-refaire" hidden>
+    <a href="#" role="button" class="button button-outline button-half-width">Recommencer le questionnaire</a>
+    </p>
+
 
 .. question:: Où puis-je faire un test de dépistage Covid-19 ?
 

--- a/src/scripts/tests/integration/test.parcours.js
+++ b/src/scripts/tests/integration/test.parcours.js
@@ -15,7 +15,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -117,7 +117,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -163,7 +163,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -209,7 +209,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -244,7 +244,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -281,7 +281,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -328,7 +328,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -376,7 +376,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -424,7 +424,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -474,7 +474,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -522,7 +522,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -558,7 +558,7 @@ describe('Parcours', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),

--- a/src/scripts/tests/integration/test.plausible.js
+++ b/src/scripts/tests/integration/test.plausible.js
@@ -27,7 +27,7 @@ describe('Plausible', function () {
 
         // On clique sur le bouton pour avoir des conseils.
         const bouton = await page.waitForSelector(
-            'a.button >> text="J’ai des symptômes ou mon test est positif"'
+            'a.button >> text="Je réponds pour moi"'
         )
 
         await Promise.all([
@@ -62,7 +62,7 @@ describe('Plausible', function () {
 
         // On clique sur le bouton pour avoir des conseils.
         let bouton = await page.waitForSelector(
-            'a.button >> text="J’ai des symptômes ou mon test est positif"'
+            'a.button >> text="Je réponds pour moi"'
         )
 
         await Promise.all([
@@ -125,7 +125,7 @@ describe('Plausible', function () {
 
         // On clique sur le bouton pour un ou une proche.
         let bouton = await page.waitForSelector(
-            'a.button >> text="Ça concerne un(e) proche"'
+            'a.button >> text="Je réponds pour un proche"'
         )
         await Promise.all([bouton.click(), page.waitForNavigation({ url: '**/#nom' })])
 
@@ -186,7 +186,7 @@ describe('Plausible', function () {
 
         // On clique sur le bouton pour avoir des conseils.
         let bouton = await page.waitForSelector(
-            'a.button >> text="J’ai des symptômes ou mon test est positif"'
+            'a.button >> text="Je réponds pour moi"'
         )
         await Promise.all([
             bouton.click(),
@@ -247,7 +247,7 @@ describe('Plausible', function () {
 
         // On clique sur le bouton pour un ou une proche.
         let bouton = await page.waitForSelector(
-            'a.button >> text="Ça concerne un(e) proche"'
+            'a.button >> text="Je réponds pour un proche"'
         )
         await Promise.all([bouton.click(), page.waitForNavigation({ url: '**/#nom' })])
         await remplirQuestionnaire(page, {
@@ -307,7 +307,7 @@ describe('Plausible', function () {
 
         // On clique sur le bouton pour avoir des conseils.
         let bouton = await page.waitForSelector(
-            'a.button >> text="J’ai des symptômes ou mon test est positif"'
+            'a.button >> text="Je réponds pour moi"'
         )
         await Promise.all([
             bouton.click(),

--- a/src/scripts/tests/integration/test.profils.js
+++ b/src/scripts/tests/integration/test.profils.js
@@ -11,7 +11,7 @@ describe('Profils', function () {
         // On clique sur le bouton pour un ou une proche.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="Ça concerne un(e) proche"'
+                'a.button >> text="Je réponds pour un proche"'
             )
             await Promise.all([
                 bouton.click(),

--- a/src/scripts/tests/integration/test.suivi.js
+++ b/src/scripts/tests/integration/test.suivi.js
@@ -15,7 +15,7 @@ describe('Suivi', function () {
         // On clique sur le bouton pour des conseils pour moi.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="J’ai des symptômes ou mon test est positif"'
+                'a.button >> text="Je réponds pour moi"'
             )
             await Promise.all([
                 bouton.click(),
@@ -220,7 +220,7 @@ describe('Suivi', function () {
         // On clique sur le bouton pour un ou une proche.
         {
             let bouton = await page.waitForSelector(
-                'a.button >> text="Ça concerne un(e) proche"'
+                'a.button >> text="Je réponds pour un proche"'
             )
             await Promise.all([
                 bouton.click(),

--- a/src/style.css
+++ b/src/style.css
@@ -1093,6 +1093,13 @@ input[type='submit'].button-arrow {
     background-position: 95% center;
     background-repeat: no-repeat;
 }
+@media only screen and (max-width: 680px) {
+    .button-arrow,
+    a.button-arrow,
+    input[type='submit'].button-arrow {
+        padding: 6px 36px 8px 24px;
+    }
+}
 input.button-outline,
 button.button-outline,
 a.button-outline {
@@ -1573,6 +1580,9 @@ a.no-type::after {
     margin-bottom: 1.2rem;
     margin-top: 4rem;
     font-size: 175%;
+}
+.thematique #conseils-block h2:first-of-type {
+    margin-top: 1rem;
 }
 .thematique #conseils-block h3 {
     padding-top: 1rem;

--- a/templates/index.html
+++ b/templates/index.html
@@ -122,15 +122,15 @@
     </div>
     <div class="block">
         <div class="cta">
-            <h2>Obtenez des conseils personnalisés</h2>
-            <p>En répondant à quelques questions, vous obtiendrez en moins de 3 minutes des conseils personnalisés en fonction de votre situation.</p>
+            <h2>Que faire si j’ai des symptômes et/ou que je suis positif ?</h2>
+            <p>Répondez à quelques questions sur votre <strong>situation actuelle</strong> pour obtenir des <strong>réponses personnalisées</strong> :</p>
             <a class="button button-arrow"
                 href="/#vaccins"
                 data-set-profil="mes_infos"
-                >Je remplis le questionnaire pour moi</a>
+                >Je réponds pour moi</a>
             <a class="button button-outline button-arrow"
                 href="/#nom"
-                >Ça concerne un(e) proche</a>
+                >Je réponds pour un proche</a>
         </div>
     </div>
 </section>

--- a/test_markdown.py
+++ b/test_markdown.py
@@ -157,8 +157,7 @@ class TestQuestionDirective:
                 """\
                 <div id="quand-pourrai-je-me-faire-vacciner" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
                 <h2 itemprop="name">
-                    Quand pourrai-je me faire vacciner&#8239;?
-                    <a href="#quand-pourrai-je-me-faire-vacciner" itemprop="url" title="Lien vers cette question" aria-hidden="true">#</a>
+                    Quand pourrai-je me faire vacciner&#8239;? <a href="#quand-pourrai-je-me-faire-vacciner" itemprop="url" title="Lien vers cette question" aria-hidden="true">#</a>
                 </h2>
                 <div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
                 <div itemprop="text">
@@ -207,8 +206,7 @@ class TestQuestionDirective:
                 """\
                 <div id="quand-pourrai-je-me-faire-vacciner" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
                 <h3 itemprop="name">
-                    Quand pourrai-je me faire vacciner&#8239;?
-                    <a href="#quand-pourrai-je-me-faire-vacciner" itemprop="url" title="Lien vers cette question" aria-hidden="true">#</a>
+                    Quand pourrai-je me faire vacciner&#8239;? <a href="#quand-pourrai-je-me-faire-vacciner" itemprop="url" title="Lien vers cette question" aria-hidden="true">#</a>
                 </h3>
                 <div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
                 <div itemprop="text">


### PR DESCRIPTION
- Suggestion de remonter le questionnaire en haut de la page, et proposition de nouveau call to action (inspiré de celui des tests de dépistage et du pass sanitaire) pour expliciter la présence du questionnaire et ce qu'il y a au bout. 
 
- Faire des liens vers les Q/R sur les symptômes et positivité post-vaccinale et mettre le contenu plus bas. pour ne pas cacher le questionnaire.

On s'en parle de vive voix ? (PS : j'espère que la page reste lisible après mes copier/coller/déplacements)