### PR TITLE
Tech: envoie les langues du navigateur à Plausible

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -224,8 +224,15 @@ export default class App {
         this.enregistrerProfilActuel()
     }
     trackPageView(pageName) {
-        this.plausible('pageview')
+        this.plausible('pageview', {
+            lang: this._preferedLanguages(),
+        })
         this.atinternet(pageName)
+    }
+    _preferedLanguages() {
+        // cf. https://stackoverflow.com/a/25603630
+        // eslint-disable-next-line compat/compat
+        return navigator.languages || [navigator.language || navigator.userLanguage]
     }
     plausible(eventName, props = {}) {
         const searchParams = new URLSearchParams(window.location.search)


### PR DESCRIPTION
L’intention est de mesurer la proportion de visiteurs ne parlant pas français, et de proposer le cas échéant des contenus dans d’autres langues.

L’info ne sera pas exploitée par l’interface web de Plausible, mais on pourra normalement faire des requêtes via l’API pour l’analyser.
