### PR TITLE
Clarifie la réponse pour les personnes qui ne peuvent pas se faire vacciner

### DIFF
--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -338,7 +338,7 @@
 
     En cas de **contre-indication médicale** (voir la [liste des contre-indications à la vaccination](/je-veux-me-faire-vacciner.html#y-a-t-il-des-contre-indications-a-la-vaccination)), vous pouvez demander à votre médecin de vous faire un **certificat médical**, qui fera office de **pass sanitaire**.
     
-    Attention, si vous ne pouvez pas vous faire vacciner parce que **vous avez eu la Covid** il y a moins de **6 mois,** votre [**certificat de rétablissement**](#comment-obtenir-un-certificat-de-rétablissement-avec-QR-code-?) (test de dépistage positif) avec **QR code** fera office de pass sanitaire. 
+    Attention, si vous ne pouvez pas vous faire vacciner parce que **vous avez eu la Covid** il y a moins de **6 mois**, votre [**certificat de rétablissement**](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code) (test de dépistage positif) avec **QR code** fera office de pass sanitaire.
 
 
 .. question:: Où le pass sanitaire est-il obligatoire ?

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -337,6 +337,8 @@
     :level: 3
 
     En cas de **contre-indication médicale** (voir la [liste des contre-indications à la vaccination](/je-veux-me-faire-vacciner.html#y-a-t-il-des-contre-indications-a-la-vaccination)), vous pouvez demander à votre médecin de vous faire un **certificat médical**, qui fera office de **pass sanitaire**.
+    
+    Attention, si vous ne pouvez pas vous faire vacciner parce que **vous avez eu la Covid** il y a moins de **6 mois,** votre [**certificat de rétablissement**](#comment-obtenir-un-certificat-de-rétablissement-avec-QR-code-?) (test de dépistage positif) avec **QR code** fera office de pass sanitaire. 
 
 
 .. question:: Où le pass sanitaire est-il obligatoire ?


### PR DESCRIPTION
Suite à des retours sur Covibot qui montrent une confusion entre certificat médical de contre-indication à la vaccination et certificat de rétablissement (test de dépistage positif).

Ex: :(pass-sanitaire-qr-code-voyages.html → Je ne peux pas me faire vacciner, comment obtenir un pass sanitaire ?): Le certificat médical ne fait pas office de pass sanitaire. Seul le QR code est valable
Mon fils a contracté le PIMS covid il ne me. Pas être vacciné. Vous devriez proposer un pass sanitaire officiel temporaire pour que ses enfants ne soient pas exclus du système. Après ce qu’ils ont vécu c’est de votre responsabilité de les aider à ne pas être marginalisé. Aucune information à la sécurité sociale, à votre numéro dédié, même à
L’hôpital où mon fils est suivi. 
Des semaines que j’appelle, que j’envoie des mails, aucune réponse ne nous est fournie. C’est honteux