### PR TITLE
Ouverture des détails pour un lien dans la même page

### DIFF
--- a/src/scripts/page/thematiques/main.js
+++ b/src/scripts/page/thematiques/main.js
@@ -19,6 +19,7 @@ export function pageThematique(app) {
         }
     )
     ouvreDetailsSiFragment()
+    window.addEventListener('hashchange', ouvreDetailsSiFragment)
     scrolleAuSummary()
     partagePageEnCours()
     feedbackPageEnCours(app)


### PR DESCRIPTION
Lorsqu'on faisait un lien au sein de la même page on se retrouvait sur le titre de la question non dépliée.