### PR TITLE
Enlève la mention de Moderna pour la 3e dose

### DIFF
--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -33,7 +33,9 @@
 
     </div>
 
-    Le rappel est réalisé avec le **vaccin à ARN messager Pfizer**, quel que soit le type de vaccin utilisé précédemment. Par exemple, il est possible de recevoir un rappel avec le vaccin *Pfizer* même si on a été vacciné initialement avec le vaccin *Moderna* ou *AstraZeneca*. L'utilisation du vaccin Moderna pour la 3<sup>e</sup> dose est en attente de validation par l'Agence européeenne du médicament (EMA).
+    Le rappel est actuellement réalisé avec le **vaccin Pfizer** uniquement. Il pourra également être réalisé avec un vaccin *Moderna* « demi-dose » après validation par l’EMA (agence européenne du médicament) attendue autour du 25 octobre.
+
+    Le vaccin utilisé pour le rappel n’a **pas besoin d’être le même** que celui utilisé pour la vaccination initiale. Par exemple, il est possible de recevoir un rappel avec le vaccin *Pfizer* même si on a été vacciné initialement avec le vaccin *Moderna* ou *AstraZeneca*.
 
     <div class="voir-aussi">
 


### PR DESCRIPTION
Si jamais on veut mettre à jour la page pour refléter la doctrine, en attendant la validation de la l'AEM (attendu pour le 25 octobre), j'ai enlevé les mention de Moderna dans les questions sur la 3e dose. On a notamment un retour de médecin sur Frontapp qui nous signale qu'il faut l'enlever. 

NB : ça veut aussi dire que je l'ai dans la question "où me faire vacciner ?". Mais comme cette question est surtout liée à la 3e dose ces derniers temps, ça me semblait cohérent.

Source : 
https://solidarites-sante.gouv.fr/IMG/pdf/dgs-urgent_108_suspension_moderna.pdf