### PR TITLE
Renvoie vers la nouvelle version de la liste des lieux de dépistage

### DIFF
--- a/src/scripts/injection.js
+++ b/src/scripts/injection.js
@@ -59,10 +59,7 @@ export function lienDepistage(element, departement) {
 }
 
 export function _lienDepistage(departement) {
-    if (departement === '00' /* Autre. */) {
-        return 'https://www.sante.fr/cf/centres-depistage-covid.html'
-    }
-    return `https://www.sante.fr/cf/centres-depistage-covid/departement-${departement}.html`
+    return _lienSantePointFr('depistage', departement)
 }
 
 export function lienVaccination(element, departement) {

--- a/src/scripts/tests/test.injection.js
+++ b/src/scripts/tests/test.injection.js
@@ -152,7 +152,7 @@ describe('Injection', function () {
 
         assert.strictEqual(
             element.innerHTML,
-            '<a href="https://www.sante.fr/cf/centres-depistage-covid/departement-01.html" class="lien-depistage">Site</a>'
+            '<a href="https://www.sante.fr/cf/centres-depistage-covid/departement-01-ain.html" class="lien-depistage">Site</a>'
         )
     })
 
@@ -165,7 +165,7 @@ describe('Injection', function () {
 
         assert.strictEqual(
             element.innerHTML,
-            '<a href="https://www.sante.fr/cf/centres-depistage-covid/departement-2A.html" class="lien-depistage">Site</a>'
+            '<a href="https://www.sante.fr/cf/centres-depistage-covid/departement-20A-corse-du-sud.html" class="lien-depistage">Site</a>'
         )
     })
 


### PR DESCRIPTION
Avant : https://www.sante.fr/cf/centres-depistage-covid/departement-2A.html

Après : https://www.sante.fr/cf/centres-depistage-covid/departement-2A-corse-du-sud.html