### PR TITLE
Autotest n'est plus un pass sanitaire

### DIFF
--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -249,6 +249,4 @@
 
     Ce type de test est utile à condition de le pratiquer régulièrement (plusieurs fois par semaine).
 
-    Pour obtenir un pass sanitaire, l'autotest doit être réalisé sous la supervision d'un professionnel de santé.
-
 </div>


### PR DESCRIPTION
On avait mis un "conseil jaune", mais on avait oublié de mettre à jour le contenu du paragraphe 😅