### PR TITLE
Tente de clarifier la réponse 3e dose

### DIFF
--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -23,7 +23,7 @@
     * les personnes avec des **comorbidités** (voir [la liste ci-dessous](#quels-sont-les-facteurs-de-risque-de-formes-graves-de-covid)) augmentant le risque de formes graves de Covid,
     * les personnes **sévèrement immunodéprimées** et les personnes de plus de 18 ans de leur **entourage**,
     * les **professionnels** et **bénévoles** des secteurs de la santé, du médico-social et du transport sanitaire,
-    * les personnes âgées **d’au moins 18 ans** vaccinées avec le **vaccin Janssen**.
+    * les personnes vaccinées avec le **vaccin Janssen**.
 
     <div class="conseil conseil-jaune">
 

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -16,22 +16,20 @@
 .. question:: Suis-je concerné par la dose de rappel, dite 3<sup>e</sup> dose ?
     :level: 3
 
-    Avec le temps, l’efficacité de la protection du vaccin contre l’infection peut diminuer, en particulier face au variant Delta. Pour « booster » cette protection, la Haute autorité de santé (HAS) recommande un **rappel vaccinal** avec une 2<sup>e</sup>, 3<sup>e</sup> ou 4<sup>e</sup> dose selon les cas, pour :
+    Avec le temps, l’efficacité de la protection du vaccin contre l’infection peut diminuer, en particulier face au variant Delta. Pour « booster » cette protection, la Haute autorité de santé (HAS) recommande une **injection supplémentaire** (2<sup>e</sup>, 3<sup>e</sup> ou 4<sup>e</sup> dose selon les cas) de ***Pfizer,** quelque soit le vaccin reçu initialement **(Moderna, Pfizer, AstraZeneca ou Janssen)** pour :
 
     * les résident(e)s des <abbr title="Établissement d’Hébergement pour Personnes Âgées Dépendantes">**EHPAD**</abbr> et <abbr title="Unités de Soins de Longue Durée">**USLD**</abbr>,
     * les personnes de **65 ans et plus**,
     * les personnes avec des **comorbidités** (voir [la liste ci-dessous](#quels-sont-les-facteurs-de-risque-de-formes-graves-de-covid)) augmentant le risque de formes graves de Covid,
     * les personnes **sévèrement immunodéprimées** et les personnes de plus de 18 ans de leur **entourage**,
     * les **professionnels** et **bénévoles** des secteurs de la santé, du médico-social et du transport sanitaire,
-    * les personnes vaccinées avec le **vaccin Janssen**.
+    * les personnes âgées **d'au moins 18 ans** vaccinées avec le **vaccin Janssen**.
 
     <div class="conseil conseil-jaune">
 
     - Une dose de rappel n’est actuellement **pas prévue** pour le reste de la population.
 
     - Si vous avez eu la Covid **après votre dernière dose**, vous n’êtes **pas éligible** à ce rappel.
-
-    - Ce rappel est valable quel que soit le vaccin initialement reçu.
 
     </div>
 

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -16,14 +16,14 @@
 .. question:: Suis-je concerné par la dose de rappel, dite 3<sup>e</sup> dose ?
     :level: 3
 
-    Avec le temps, l’efficacité de la protection du vaccin contre l’infection peut diminuer, en particulier face au variant Delta. Pour « booster » cette protection, la Haute autorité de santé (HAS) recommande une **injection supplémentaire** (2<sup>e</sup>, 3<sup>e</sup> ou 4<sup>e</sup> dose selon les cas) de ***Pfizer,** quelque soit le vaccin reçu initialement **(Moderna, Pfizer, AstraZeneca ou Janssen)** pour :
+    Avec le temps, l’efficacité de la protection du vaccin contre l’infection peut diminuer, en particulier face au variant Delta. Pour « booster » cette protection, la Haute autorité de santé (HAS) recommande une **injection supplémentaire** (2<sup>e</sup>, 3<sup>e</sup> ou 4<sup>e</sup> dose selon les cas) du vaccin **Pfizer**, quel que soit le vaccin reçu initialement **(Moderna, Pfizer, AstraZeneca ou Janssen)** pour :
 
     * les résident(e)s des <abbr title="Établissement d’Hébergement pour Personnes Âgées Dépendantes">**EHPAD**</abbr> et <abbr title="Unités de Soins de Longue Durée">**USLD**</abbr>,
     * les personnes de **65 ans et plus**,
     * les personnes avec des **comorbidités** (voir [la liste ci-dessous](#quels-sont-les-facteurs-de-risque-de-formes-graves-de-covid)) augmentant le risque de formes graves de Covid,
     * les personnes **sévèrement immunodéprimées** et les personnes de plus de 18 ans de leur **entourage**,
     * les **professionnels** et **bénévoles** des secteurs de la santé, du médico-social et du transport sanitaire,
-    * les personnes âgées **d'au moins 18 ans** vaccinées avec le **vaccin Janssen**.
+    * les personnes âgées **d’au moins 18 ans** vaccinées avec le **vaccin Janssen**.
 
     <div class="conseil conseil-jaune">
 


### PR DESCRIPTION
Tente de clarifier la réponse des personnes et des vaccins concernés par la 3e dose (notamment pour les personnes qui ont été vaccinées avec AstraZeneca et qui ne se retrouvent pas dans la réponse d'origine). 

Le rappel pour les personnes vaccinées avec Janssen n'est possible que pour les + de 18 ans.
https://solidarites-sante.gouv.fr/grands-dossiers/vaccin-covid-19/je-suis-un-particulier/dose-de-rappel-covid19