### PR TITLE
Rajoute les autotests supervisés

### DIFF
--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -19,7 +19,7 @@
 
     En France, le pass sanitaire peut être, **selon votre situation** :
 
-    - un [test de dépistage négatif](#comment-obtenir-un-certificat-de-depistage-avec-qr-code) : **test PCR** ou **test antigénique** datant de moins de **72 h** (**sauf** pour les voyages en **Corse** et **Dom-Tom** : le test antigénique est valable **48 h**) ;
+    - un [test de dépistage négatif](#comment-obtenir-un-certificat-de-depistage-avec-qr-code) : **test PCR** ou **test antigénique** ou **autotest supervisé** par un **professionnel de santé,** datant de moins de **72 h** (**sauf** pour les voyages en **Corse** et **Dom-Tom** : les autotests ne sont pas acceptés et le test antigénique est valable **48 h**) ;
 
     - un [certificat de rétablissement](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code) : un test de dépistage **positif**, **PCR** ou **antigénique** de **plus de 11 jours** et **moins de 6 mois** ;
 
@@ -28,8 +28,6 @@
     <div class="conseil conseil-jaune">
 
     - Ces documents sont valables **à condition qu’ils comportent un QR code**.
-
-    - À compter du **15 octobre 2021**, un **autotest** réalisé sous la supervision d’un professionnel de santé ne pourra **plus** tenir lieu de pass sanitaire.
 
     - Les **tests sérologiques** ne sont **pas** des pass sanitaires.
 
@@ -264,9 +262,9 @@
 
     Vous devez **attendre 28 jours** (4 semaines) après votre injection pour que votre schéma vaccinal soit complet. Vous ne pourrez donc pas faire valoir votre attestation de vaccination comme pass sanitaire pour l’instant.
 
-    En attendant, un **test de dépistage négatif** (test PCR ou antigénique) datant de **moins de 72 h** fera office de pass sanitaire.
+    En attendant, un **test de dépistage négatif** (test PCR, antigénique ou autotest supervisé par un professionnel de santé) datant de **moins de 72 h** fera office de pass sanitaire.
 
-    *Attention : pour voyager vers la Corse ou l’Outre-mer, un test négatif datant de moins de 48 h sera demandé.*
+    *Attention : pour voyager vers la Corse ou l’Outre-mer, les autotests ne seront pas acceptés et le test antigénique négatif devra dater de moins de 48 h.*
 
     </div>
 
@@ -274,9 +272,9 @@
 
     Votre schéma vaccinal est **incomplet** tant que vous n’avez pas reçu la dose de rappel (2<sup>e</sup> dose). Vous ne pourrez donc pas le faire valoir comme pass sanitaire pour l’instant.
 
-    En attendant, un **test de dépistage négatif** (test PCR ou antigénique) datant de **moins de 72 h** fera office de pass sanitaire.
+    En attendant, un **test de dépistage négatif** (test PCR, antigénique ou autotest supervisé par un professionnel de santé) datant de **moins de 72 h** fera office de pass sanitaire.
 
-    *Attention : pour voyager vers la Corse ou l’Outre-mer, un test négatif datant de moins de 48 h sera demandé.*
+    *Attention : pour voyager vers la Corse ou l’Outre-mer, les autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h.*
 
     </div>
 
@@ -284,7 +282,7 @@
 
     Vous avez **2 possibilités** pour obtenir un pass sanitaire :
 
-    1. présenter un **test de dépistage négatif** (test PCR ou antigénique) de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, il devra dater de moins de 48 h*) ;
+    1. présenter un **test de dépistage négatif** (test PCR, antigénique ou autotest supervisé par un professionnel de santé) de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, mes autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h.*) ;
 
     2. vous faire **vacciner** : l’attestation de vaccination fera office de pass sanitaire **7 jours après la 2<sup>e</sup> dose**.
 
@@ -297,7 +295,7 @@
 
     1. présenter votre **test de dépistage positif** (aussi appelé *certificat de rétablissement*), datant de plus de **11 jours** et de moins de **6 mois**, et comportant un QR code ;
 
-    2. présenter un **test de dépistage négatif** de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, il devra dater de moins de 48 h*) ;
+    2. présenter un **test de dépistage négatif** de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, es autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h.*) ;
 
     3. vous faire **vacciner** (comme vous avez déjà eu la Covid, **une seule dose** sera nécessaire, mais il est recommandé d’attendre 2 mois minimum après la guérison, idéalement jusqu’à 6 mois) : l’attestation de vaccination fera office de pass sanitaire **7 jours** après cette dose.
 
@@ -307,7 +305,7 @@
 
     Vous avez **2 possibilités** pour obtenir un pass sanitaire :
 
-    1. présenter un **test de dépistage négatif** de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, il devra dater de moins de 48 h*) ;
+    1. présenter un **test de dépistage négatif** de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, es autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h.*) ;
 
     2. vous faire **vacciner** (comme vous avez déjà eu la Covid, **une seule dose** sera nécessaire) : l’attestation de vaccination fera office de pass sanitaire **7 jours** après cette dose.
 
@@ -528,7 +526,7 @@
 .. question:: Comment obtenir un certificat de dépistage avec QR code ?
     :level: 3
 
-    Suite à un test **PCR** ou **antigénique**, un courriel (*e-mail*) ou un SMS vous est adressé pour vous inviter à **télécharger le certificat de dépistage** avec QR code sur le [**portail SI-DEP**](https://sidep.gouv.fr/cyberlab/patientviewer.jsp).
+    Suite à un test de dépistage, un courriel (*e-mail*) ou un SMS vous est adressé pour vous inviter à **télécharger le certificat de dépistage** avec QR code sur le [**portail SI-DEP**](https://sidep.gouv.fr/cyberlab/patientviewer.jsp).
 
     Nous vous conseillons de **le télécharger immédiatement** pour le conserver aussi longtemps que nécessaire.
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -282,7 +282,7 @@
 
     Vous avez **2 possibilités** pour obtenir un pass sanitaire :
 
-    1. présenter un **test de dépistage négatif** (test PCR, antigénique ou autotest supervisé par un professionnel de santé) de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, mes autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h.*) ;
+    1. présenter un **test de dépistage négatif** (test PCR, antigénique ou autotest supervisé par un professionnel de santé) de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, les autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h*) ;
 
     2. vous faire **vacciner** : l’attestation de vaccination fera office de pass sanitaire **7 jours après la 2<sup>e</sup> dose**.
 
@@ -295,7 +295,7 @@
 
     1. présenter votre **test de dépistage positif** (aussi appelé *certificat de rétablissement*), datant de plus de **11 jours** et de moins de **6 mois**, et comportant un QR code ;
 
-    2. présenter un **test de dépistage négatif** de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, es autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h.*) ;
+    2. présenter un **test de dépistage négatif** de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, les autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h*) ;
 
     3. vous faire **vacciner** (comme vous avez déjà eu la Covid, **une seule dose** sera nécessaire, mais il est recommandé d’attendre 2 mois minimum après la guérison, idéalement jusqu’à 6 mois) : l’attestation de vaccination fera office de pass sanitaire **7 jours** après cette dose.
 
@@ -305,7 +305,7 @@
 
     Vous avez **2 possibilités** pour obtenir un pass sanitaire :
 
-    1. présenter un **test de dépistage négatif** de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, es autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h.*) ;
+    1. présenter un **test de dépistage négatif** de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, les autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h*) ;
 
     2. vous faire **vacciner** (comme vous avez déjà eu la Covid, **une seule dose** sera nécessaire) : l’attestation de vaccination fera office de pass sanitaire **7 jours** après cette dose.
 

--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -137,7 +137,7 @@
 
     Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes pas cas contact :
 
-    * Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **PCR nasopharyngé** ou **antigénique** réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
+    * Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **PCR nasopharyngé**, **antigénique** ou un **autotest supervisé,** réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
     * Si vous rendez visite à des personnes vulnérables, un test **antigénique** ou **PCR nasopharyngé** est indiqué.
     * Si vous travaillez régulièrement avec des personnes fragiles, il est recommandé de vous tester régulièrement avec les **autotests** vendus en pharmacie (les professionnels exerçant à domicile auprès de personnes vulnérables peuvent obtenir la prise en charge de 10 auto-tests par mois en présentant leur carte professionnelle au pharmacien).
 

--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -129,7 +129,7 @@
 
     <div id="tests-de-depistage-pas-symptomes-pas-cas-contact-auto-test-oui-reponse" class="statut statut-bleu" hidden>
 
-    Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pas cas contact mais votre auto-test est positif. Vous devez confirmer ce résultat avec un test **PCR nasopharyngé** et rester en isolement le temps d’obtenir cette confirmation.
+    Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pas cas contact mais votre autotest est positif. Vous devez confirmer ce résultat avec un test **PCR nasopharyngé** et rester en isolement le temps d’obtenir cette confirmation.
 
     </div>
 
@@ -137,9 +137,9 @@
 
     Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes pas cas contact :
 
-    * Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **PCR nasopharyngé**, **antigénique** ou un **autotest supervisé,** réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
+    * Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **PCR nasopharyngé**, **antigénique** ou un **autotest supervisé** par un professionnel de santé, réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
     * Si vous rendez visite à des personnes vulnérables, un test **antigénique** ou **PCR nasopharyngé** est indiqué.
-    * Si vous travaillez régulièrement avec des personnes fragiles, il est recommandé de vous tester régulièrement avec les **autotests** vendus en pharmacie (les professionnels exerçant à domicile auprès de personnes vulnérables peuvent obtenir la prise en charge de 10 auto-tests par mois en présentant leur carte professionnelle au pharmacien).
+    * Si vous travaillez régulièrement avec des personnes fragiles, il est recommandé de vous tester régulièrement avec les **autotests** vendus en pharmacie (les professionnels exerçant à domicile auprès de personnes vulnérables peuvent obtenir la prise en charge de 10 autotests par mois en présentant leur carte professionnelle au pharmacien).
 
     </div>
 
@@ -242,7 +242,7 @@
     - on a eu un contact à risque récent (cas contact).
 
     Ce type de test est utile à condition de le pratiquer régulièrement (plusieurs fois par semaine).
-    
-    Pour être valable comme **pass sanitaire,** l'autotest doit être réalisé sous la **supervision d'un professionnel de santé.**
+
+    Pour être valable comme **pass sanitaire**, l’autotest doit être réalisé sous la **supervision d’un professionnel de santé**.
 
 </div>

--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -234,12 +234,6 @@
 .. question:: Qu’est-ce qu’un autotest ?
     :level: 4
 
-    <div class="conseil conseil-jaune">
-
-    À compter du **15 octobre 2021**, un autotest réalisé sous la supervision d’un professionnel de santé ne pourra plus tenir lieu de pass sanitaire.
-
-    </div>
-
     Des autotests sont disponibles en pharmacie. Ce test est un prélèvement nasal à réaliser chez soi. Ils ne sont pas pris en charge par l’Assurance maladie sauf dans le cas des professionnels exerçant auprès de personnes vulnérables (âgées, handicapées…) et dans la limite de 10 par mois.
 
     Il ne faut pas y avoir recours lorsque :
@@ -248,5 +242,7 @@
     - on a eu un contact à risque récent (cas contact).
 
     Ce type de test est utile à condition de le pratiquer régulièrement (plusieurs fois par semaine).
+    
+    Pour être valable comme **pass sanitaire,** l'autotest doit être réalisé sous la **supervision d'un professionnel de santé.**
 
 </div>

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -434,7 +434,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
     **Non.** Comme pour les adultes non-vacciné(e)s, plusieurs justificatifs, au choix, font office de « pass sanitaire » utilisable en France et pour les voyages en Union européenne :
 
     * l’**attestation de vaccination complète** (toutes les doses et respect du délai de 7 jours après la dernière dose en France, ou 14 jours pour voyager à l’étranger) ;
-    * un **test PCR ou antigénique négatif** de moins de 72 h (ou 48 h pour les voyages en Corse et DOM-TOM) ;
+    * un **test PCR ou antigénique négatif**, ou un **auto-test négatif** réalisé sous la supervision d’un professionnel de santé, de moins de 72 h (ou 48 h pour les voyages en Corse et DOM-TOM) ;
     * un **test PCR positif** de plus de 11 jours et moins de 6 mois.
 
     Par ailleurs, le ou la mineur(e) non-vacciné(e) accompagnant ses parents vaccinés lors d’un voyage bénéficiera des mêmes facilités qu’eux. Par exemple, un(e) mineur(e) non-vacciné(e) pourra accompagner ses parents vaccinés lors d’un voyage dans un [pays classé orange](https://www.gouvernement.fr/voyager-depuis-et-vers-l-etranger-mode-d-emploi) sans justifier d’un motif impérieux pour s’y rendre.

--- a/src/scripts/tests/integration/test.tests.js
+++ b/src/scripts/tests/integration/test.tests.js
@@ -172,7 +172,10 @@ describe('Tests', function () {
             'pas-symptomes-pas-cas-contact-auto-test-non'
         )
         // On propose différents tests pour le pass sanitaire.
-        assert.include(statut, 'un test négatif PCR nasopharyngé ou antigénique')
+        assert.include(
+            statut,
+            'un test négatif PCR nasopharyngé, antigénique ou un autotest supervisé'
+        )
         // On propose un test PCR ou antigénique pour visiter des personnes vulnérables.
         assert.include(
             statut,


### PR DESCRIPTION
Le Conseil d'Etat à suspendu le décret selon lequel les autotests supervisés par des professionnels de santé n'étaient plus considérés comme des pass sanitaire.
https://www.lemonde.fr/planete/article/2021/10/29/covid-19-le-conseil-d-etat-valide-la-fin-de-la-gratuite-des-tests-de-confort_6100396_3244.html. 

J'ai rajouté les autotests dans la liste des justificatifs valables et dans le questionnaire. 
Dans le questionnaire, j'ai aussi précisé que les autotests ne sont pas acceptés pour les voyages en Corse ou en Outre-Mer et que ce sont les antigéniques qui ne sont valables que 48h (les PCR sont valables 72h).
https://www.aircaraibes.com/modalites-pour-les-voyages-entre-les-outre-mer-et-la-metropole
https://www.aircorsica.com/test-pcr-antigenique-covid-19.html