### PR TITLE
Supprime le lien vers la démarche qui n'existe plus pour les touristes étrangers

### DIFF
--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -598,7 +598,7 @@
 
     * si vous êtes **étudiant étranger** inscrit dans un établissement d’enseignement supérieur français pour la rentrée 2021-2022 et que vous possédez un visa d’études, [rendez-vous sur cette démarche en ligne](https://www.demarches-simplifiees.fr/commencer/passe-sanitaire-etudiants) ;
 
-    * si vous êtes **touriste** de nationalité extra-européenne, âgé de plus de 18 ans, [rendez-vous sur cette démarche en ligne](https://www.demarches-simplifiees.fr/commencer/passe-sanitaire-etrangers).
+    * si vous êtes **touriste** de nationalité extra-européenne, âgé de plus de 18 ans, nous vous invitons à vous renseigner en écrivant à l'adresse suivante : help.covid-pass@diplomatie.gouv.fr.
 
     En attendant, un **test de dépistage négatif de moins de 72 h** pourra faire office de pass sanitaire.
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -598,7 +598,7 @@
 
     * si vous êtes **étudiant étranger** inscrit dans un établissement d’enseignement supérieur français pour la rentrée 2021-2022 et que vous possédez un visa d’études, [rendez-vous sur cette démarche en ligne](https://www.demarches-simplifiees.fr/commencer/passe-sanitaire-etudiants) ;
 
-    * si vous êtes **touriste** de nationalité extra-européenne, âgé de plus de 18 ans, nous vous invitons à vous renseigner en écrivant à l'adresse suivante : help.covid-pass@diplomatie.gouv.fr.
+    * si vous êtes **touriste** de nationalité extra-européenne, âgé de plus de 18 ans, nous vous invitons à vous renseigner en écrivant à l’adresse suivante : <a href="mailto:help.covid-pass@diplomatie.gouv.fr">help.covid-pass@diplomatie.gouv.fr</a>.
 
     En attendant, un **test de dépistage négatif de moins de 72 h** pourra faire office de pass sanitaire.
 


### PR DESCRIPTION
La démarche en ligne qui permettait aux touristes étrangers d'obtenir un QR code n'existe apparement plus. En attendant je propose de renvoyer vers l'adresse mail indiquée par service-public.fr pour obtenir des renseignements. 
https://www.service-public.fr/particuliers/actualites/A15093