### PR TITLE
Précise les cas de désactivation du pass sanitaire au 15/12

### DIFF
--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -342,9 +342,13 @@
 .. question:: Est-ce que la dose de rappel, dite 3<sup>e</sup> dose, est obligatoire pour le pass sanitaire ?
     :level: 3
 
-    À partir du **15 décembre**, si vous avez plus de **65 ans** et que votre dernière dose date de plus de **6 mois et 5 semaines**, alors votre pass sanitaire sera désactivé. Pour prolonger sa validité, vous devrez recevoir votre rappel vaccinal (dit 3<sup>e</sup> dose).
+    - À partir du **15 décembre**, si vous avez plus de **65 ans** et que votre dernière dose date de plus de **6 mois et 5 semaines**, alors votre pass sanitaire sera désactivé. Pour prolonger sa validité, vous devrez recevoir votre rappel vaccinal (dit 3<sup>e</sup> dose).
 
-    <i>Par exemple : si vous avez reçu votre 2<sup>e</sup> dose le 17 juillet 2021, vous serez éligible à la dose de rappel dès le 17 janvier 2022. Sans cette dose de rappel, vous ne pourrez plus utiliser votre pass sanitaire à partir du 21 février 2022.</i>
+      <i>Par exemple : si vous avez reçu votre 2<sup>e</sup> dose le 17 juillet 2021, vous serez éligible à la dose de rappel dès le 17 janvier 2022. Sans cette dose de rappel, vous ne pourrez plus utiliser votre pass sanitaire à partir du 21 février 2022.</i>
+
+    - Si vous avez **moins de 65 ans**, et que vous êtes éligible au rappel vaccinal en raison d’une comorbidité, de votre profession, alors vous n’êtes **pas concerné** par cette désactivation du pass sanitaire.
+
+    - Quele que soit votre âge, si vous avez reçu le **vaccin Janssen**, alors vous devrez recevoir une dose de rappel pour prolonger la validité de votre pass sanitaire après le **15 décembre**.
 
     <div class="voir-aussi">
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -346,9 +346,11 @@
 
       <i>Par exemple : si vous avez reçu votre 2<sup>e</sup> dose le 17 juillet 2021, vous serez éligible à la dose de rappel dès le 17 janvier 2022. Sans cette dose de rappel, vous ne pourrez plus utiliser votre pass sanitaire à partir du 21 février 2022.</i>
 
+    - Quel que soit votre âge, si vous avez reçu le **vaccin Janssen**, alors vous devrez recevoir une dose de rappel pour prolonger la validité de votre pass sanitaire après le **15 décembre**.
+    
     - Si vous avez **moins de 65 ans**, et que vous êtes éligible au rappel vaccinal en raison d’une comorbidité, de votre profession, alors vous n’êtes **pas concerné** par cette désactivation du pass sanitaire.
 
-    - Quele que soit votre âge, si vous avez reçu le **vaccin Janssen**, alors vous devrez recevoir une dose de rappel pour prolonger la validité de votre pass sanitaire après le **15 décembre**.
+
 
     <div class="voir-aussi">
 


### PR DESCRIPTION
En plus des personnes de 65 ans et plus, les personnes ayant reçu le vaccin Janssen sont effectivement concernées :

https://www.gouvernement.fr/info-coronavirus/pass-sanitaire

> à compter du 15 décembre, les personnes âgées de plus de 65 ans et les personnes ayant été vaccinées avec le vaccin Janssen devront avoir fait leur rappel pour que leur pass sanitaire reste valide ;

On précise que les autres cas (comorbités et professionnels de santé de moins de 65 ans) ne seront pas concernés.