### PR TITLE
Ajoute la possibilité d'une 3e dose pour un schéma complet

### DIFF
--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -365,7 +365,7 @@
 
     En cas de **contre-indication médicale** (voir la [liste des contre-indications à la vaccination](/je-veux-me-faire-vacciner.html#y-a-t-il-des-contre-indications-a-la-vaccination)), vous pouvez demander à votre médecin d’établir un **certificat médical** (formulaire Cerfa n°16183*01). Il faudra envoyer le premier volet du certificat à votre **caisse d’Assurance Maladie**. Après vérifications, elle vous adressera votre **certificat de contre-indication à la vaccination** avec **QR code**, valable comme pass sanitaire en **France uniquement**. Ce certificat restera valable après le 15 décembre.
     
- Il n'existe pas de contre-indication spécifique à la **dose de rappel.** Si vous aviez complété votre schéma vaccinal initial, et que vous êtes maintenant éligible au rappel vaccinal (3e dose <sup>e</sup>), vous ne pouvez pas faire valoir une contre-indication à la vaccination afin de ne pas recevoir cette injection supplémentaire tout en conservant votre pass sanitaire après le 15 décembre. 
+ Il n’existe pas de contre-indication spécifique à la **dose de rappel**. Si vous aviez complété votre schéma vaccinal initial, et que vous êtes maintenant éligible au rappel vaccinal (3<sup>e</sup> dose), vous ne pouvez pas faire valoir une contre-indication à la vaccination afin de ne pas recevoir cette injection supplémentaire tout en conservant votre pass sanitaire après le 15 décembre. 
 
     Attention, si vous ne pouvez pas vous faire vacciner parce que **vous avez eu la Covid** il y a moins de **6 mois**, votre [**certificat de rétablissement**](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code) (test de dépistage positif) avec **QR code** fera office de pass sanitaire.
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -363,7 +363,9 @@
 .. question:: Je ne peux pas me faire vacciner, comment obtenir un pass sanitaire ?
     :level: 3
 
-    En cas de **contre-indication médicale** (voir la [liste des contre-indications à la vaccination](/je-veux-me-faire-vacciner.html#y-a-t-il-des-contre-indications-a-la-vaccination)), vous pouvez demander à votre médecin d’établir un **certificat médical** (formulaire Cerfa n°16183*01). Il faudra envoyer le premier volet du certificat à votre **caisse d’Assurance Maladie**. Après vérifications, elle vous adressera votre **certificat de contre-indication à la vaccination** avec **QR code**, valable comme pass sanitaire en **France uniquement**.
+    En cas de **contre-indication médicale** (voir la [liste des contre-indications à la vaccination](/je-veux-me-faire-vacciner.html#y-a-t-il-des-contre-indications-a-la-vaccination)), vous pouvez demander à votre médecin d’établir un **certificat médical** (formulaire Cerfa n°16183*01). Il faudra envoyer le premier volet du certificat à votre **caisse d’Assurance Maladie**. Après vérifications, elle vous adressera votre **certificat de contre-indication à la vaccination** avec **QR code**, valable comme pass sanitaire en **France uniquement**. Ce certificat restera valable après le 15 décembre.
+    
+ Il n'existe pas de contre-indication spécifique à la **dose de rappel.** Si vous aviez complété votre schéma vaccinal initial, et que vous êtes maintenant éligible au rappel vaccinal (3e dose <sup>e</sup>), vous ne pouvez pas faire valoir une contre-indication à la vaccination afin de ne pas recevoir cette injection supplémentaire tout en conservant votre pass sanitaire après le 15 décembre. 
 
     Attention, si vous ne pouvez pas vous faire vacciner parce que **vous avez eu la Covid** il y a moins de **6 mois**, votre [**certificat de rétablissement**](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code) (test de dépistage positif) avec **QR code** fera office de pass sanitaire.
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -23,7 +23,7 @@
 
     - un [certificat de rétablissement](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code) : un test de dépistage **positif**, **PCR** ou **antigénique** de **plus de 11 jours** et **moins de 6 mois** ;
 
-    - une [attestation de vaccination complète](#comment-obtenir-une-attestation-de-vaccination-complete-avec-un-qr-code) : qui indique que votre **schéma vaccinal est complet** (après 1 ou 2 doses [selon les cas](/je-veux-me-faire-vacciner.html#suis-je-immunise-e-apres-une-seule-dose-de-vaccin)).
+    - une [attestation de vaccination complète](#comment-obtenir-une-attestation-de-vaccination-complete-avec-un-qr-code) : qui indique que votre **schéma vaccinal est complet** (après 1, 2 ou 3 doses [selon les cas](/je-veux-me-faire-vacciner.html#suis-je-concerne-par-la-dose-de-rappel-dite-3-e-dose).
 
     <div class="conseil conseil-jaune">
 


### PR DESCRIPTION
La 3e dose est obligatoire pour compléter le schéma vaccinal des plus de 65 ans (et sera bientôt étendue au plus de 50 ans).