### PR TITLE
liste pays qui ont l'équivalence du pass sanitaire

### DIFF
--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -605,7 +605,7 @@
 
     <div class="voir-aussi">
 
-    - [Obtenir un passe sanitaire en cas de vaccination à l’étranger]Albanie, Andorre, Arménie, îles Féroé, Islande, Israël, Liechtenstein, Macédoine du Nord, Maroc, Monaco, Norvège, Panama, Royaume-Uni, Saint-Marin, Suisse, Turquie, Ukraine, Vatican. )
+    - [Obtenir un passe sanitaire en cas de vaccination à l’étranger](https://www.sante.fr/obtenir-un-passe-sanitaire-en-cas-de-vaccination-letranger)
 
     </div>
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -601,7 +601,7 @@
 
     Si vous êtes **touriste** de nationalité extra-européenne, vous pouvez vous rendre dans une **pharmacie** pour obtenir un pass sanitaire. Le pharmacien vérifiera la validité de votre certificat de vaccination, et vous fournira un justificatif muni d’un QR code. Ce service pourra vous être facturé jusqu’à **36 €**.
     
-    Si vous avez été vacciné(e) dans l'un des pays suivants : Albanie, Andorre, Arménie, îles Féroé, Islande, Israël, Liechtenstein, Macédoine du Nord, Maroc, Monaco, Norvège, Panama, Royaume-Uni, Saint-Marin, Suisse, Turquie, Ukraine ou Vatican, vous n'avez pas besoin de convertir votre certificat de vaccination.
+    Si vous avez été vacciné(e) dans l’un des pays suivants : Albanie, Andorre, Arménie, îles Féroé, Islande, Israël, Liechtenstein, Macédoine du Nord, Maroc, Monaco, Norvège, Panama, Royaume-Uni, Saint-Marin, Suisse, Turquie, Ukraine ou Vatican, vous n’avez pas besoin de convertir votre certificat de vaccination.
 
     <div class="voir-aussi">
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -600,10 +600,12 @@
     #### Obtenir un QR code : ressortissants non-européens
 
     Si vous êtes **touriste** de nationalité extra-européenne, vous pouvez vous rendre dans une **pharmacie** pour obtenir un pass sanitaire. Le pharmacien vérifiera la validité de votre certificat de vaccination, et vous fournira un justificatif muni d’un QR code. Ce service pourra vous être facturé jusqu’à **36 €**.
+    
+    Si vous avez été vacciné(e) dans l'un des pays suivants : Albanie, Andorre, Arménie, îles Féroé, Islande, Israël, Liechtenstein, Macédoine du Nord, Maroc, Monaco, Norvège, Panama, Royaume-Uni, Saint-Marin, Suisse, Turquie, Ukraine ou Vatican, vous n'avez pas besoin de convertir votre certificat de vaccination.
 
     <div class="voir-aussi">
 
-    - [Obtenir un passe sanitaire en cas de vaccination à l’étranger](https://www.sante.fr/obtenir-un-passe-sanitaire-en-cas-de-vaccination-letranger)
+    - [Obtenir un passe sanitaire en cas de vaccination à l’étranger]Albanie, Andorre, Arménie, îles Féroé, Islande, Israël, Liechtenstein, Macédoine du Nord, Maroc, Monaco, Norvège, Panama, Royaume-Uni, Saint-Marin, Suisse, Turquie, Ukraine, Vatican. )
 
     </div>
 


### PR DESCRIPTION
Suite à un retour utilisateur. 
Source : https://www.sante.fr/obtenir-un-passe-sanitaire-en-cas-de-vaccination-letranger 

Mais du coup, en ajoutant le détail de la liste je suis gênée par la description : " Obtenir un QR code : ressortissants non-européens". Est-ce que c'est clair que non-européens signifie ressortissant d'un Etat non membre de l'UE ?