### PR TITLE
Tentative pour une indexation plus rapide des nouvelles pages

### DIFF
--- a/templates/sitemap.html
+++ b/templates/sitemap.html
@@ -10,7 +10,7 @@
     <url>
         <loc>https://mesconseilscovid.sante.gouv.fr/{{ thematique.name }}.html</loc>
         <lastmod>{{ thematique.last_modified.date() }}</lastmod>
-        <changefreq>weekly</changefreq>
+        <changefreq>daily</changefreq>
         <priority>1.0</priority>
     </url>
     {% endfor %}


### PR DESCRIPTION
Il peut y avoir un décalage important entre l'ajout d'une nouvelle page et son indexation par Google .

Par exemple, 5 jours dans ce cas : 
<img width="1255" alt="Capture d’écran 2021-11-19 à 15 13 43" src="https://user-images.githubusercontent.com/3593868/142637345-e02df0b9-abc4-4c76-962e-6140eb5a1712.png">

