### PR TITLE
Suppression de l'ancre par defaut sur la page d'accueil

### DIFF
--- a/src/scripts/router.js
+++ b/src/scripts/router.js
@@ -248,9 +248,8 @@ export class Router {
             // so that we don’t break the back button.
             window.history.replaceState({}, '', `#${target}`)
             this.navigo.resolve()
-        } else 
-            {
+        } else {
             this.navigo.navigate(target)
-        } 
+        }
     }
 }

--- a/src/scripts/router.js
+++ b/src/scripts/router.js
@@ -233,13 +233,14 @@ export class Router {
 
         // Par défaut on retourne à la page d’accueil.
         this.navigo.notFound(() => {
-            this.redirectTo('')
+            this.redirectTo('#')
         })
     }
 
     redirectTo(target) {
         if (
             typeof window !== 'undefined' &&
+            document.referrer &&
             window.history &&
             window.history.replaceState
         ) {
@@ -247,8 +248,9 @@ export class Router {
             // so that we don’t break the back button.
             window.history.replaceState({}, '', `#${target}`)
             this.navigo.resolve()
-        } else {
+        } else 
+            {
             this.navigo.navigate(target)
-        }
+        } 
     }
 }

--- a/src/scripts/router.js
+++ b/src/scripts/router.js
@@ -233,7 +233,7 @@ export class Router {
 
         // Par défaut on retourne à la page d’accueil.
         this.navigo.notFound(() => {
-            this.redirectTo('introduction')
+            this.redirectTo('')
         })
     }
 

--- a/src/scripts/tests/integration/test.pages.js
+++ b/src/scripts/tests/integration/test.pages.js
@@ -5,7 +5,7 @@ describe('Pages', function () {
     it('titre de la page', async function () {
         const page = this.test.page
 
-        // On est redirigé vers l’introduction.
+        // On est redirigé vers la page d'accueil.
         await Promise.all([
             page.goto('http://localhost:8080/'),
             page.waitForNavigation({ url: '**/#' }),
@@ -37,12 +37,12 @@ describe('Pages', function () {
         })
         assert.include(messages[1], {
             n: 'pageview',
-            u: 'http://localhost/introduction',
+            u: 'http://localhost/#',
         })
         assert.include(messages[2], {
             n: 'Navigue vers une thématique depuis l’accueil',
-            p: '{"chemin":"/introduction → /pass-sanitaire-qr-code-voyages.html"}',
-            u: 'http://localhost/introduction',
+            p: '{"chemin":"/ → /pass-sanitaire-qr-code-voyages.html"}',
+            u: 'http://localhost/#',
         })
         assert.include(messages[3], {
             n: 'pageview',

--- a/src/scripts/tests/integration/test.pages.js
+++ b/src/scripts/tests/integration/test.pages.js
@@ -8,7 +8,7 @@ describe('Pages', function () {
         // On est redirigé vers l’introduction.
         await Promise.all([
             page.goto('http://localhost:8080/'),
-            page.waitForNavigation({ url: '**/#introduction' }),
+            page.waitForNavigation({ url: '**/#' }),
         ])
 
         assert.equal(

--- a/src/scripts/tests/test.router.js
+++ b/src/scripts/tests/test.router.js
@@ -52,7 +52,7 @@ describe('Routeur', function () {
         this.router = null
     })
 
-    it('La racine redirige vers la page introduction', function () {
+    it('La racine redirige vers la page d\'accueil', function () {
         require('jsdom-global')(fakeHTML, {
             url: 'https://test/',
         })
@@ -62,10 +62,10 @@ describe('Routeur', function () {
 
         this.router.resolve()
 
-        assert.strictEqual(window.location.href, 'https://test/#introduction')
+        assert.strictEqual(window.location.href, 'https://test/#')
     })
 
-    it('Une page inconnue redirige vers la page introduction', function () {
+    it('Une page inconnue redirige vers la page d\'accueil', function () {
         require('jsdom-global')(fakeHTML, {
             url: 'https://test/#inconnue',
         })
@@ -75,7 +75,7 @@ describe('Routeur', function () {
 
         this.router.resolve()
 
-        assert.strictEqual(window.location.href, 'https://test/#introduction')
+        assert.strictEqual(window.location.href, 'https://test/#')
     })
 
     it('La redirection conserve la source', function () {
@@ -90,7 +90,7 @@ describe('Routeur', function () {
 
         assert.strictEqual(
             window.location.href,
-            'https://test/?source=foo#introduction'
+            'https://test/?source=foo#'
         )
     })
 

--- a/src/scripts/tests/test.router.js
+++ b/src/scripts/tests/test.router.js
@@ -52,7 +52,7 @@ describe('Routeur', function () {
         this.router = null
     })
 
-    it('La racine redirige vers la page d\'accueil', function () {
+    it("La racine redirige vers la page d'accueil", function () {
         require('jsdom-global')(fakeHTML, {
             url: 'https://test/',
         })
@@ -65,7 +65,7 @@ describe('Routeur', function () {
         assert.strictEqual(window.location.href, 'https://test/#')
     })
 
-    it('Une page inconnue redirige vers la page d\'accueil', function () {
+    it("Une page inconnue redirige vers la page d'accueil", function () {
         require('jsdom-global')(fakeHTML, {
             url: 'https://test/#inconnue',
         })
@@ -88,10 +88,7 @@ describe('Routeur', function () {
 
         this.router.resolve()
 
-        assert.strictEqual(
-            window.location.href,
-            'https://test/?source=foo#'
-        )
+        assert.strictEqual(window.location.href, 'https://test/?source=foo#')
     })
 
     it('Le contenu de la page cible est chargé', function () {


### PR DESCRIPTION
Depuis que le questionnaire d'auto diagnostique n'est plus sur la page d'accueil, il semble inutile de renvoyer 
par defaut sur /#introduction  quand on arrive sur le site. D'autant plus que cela est vu comme une deuxieme page vue par l'outil de statistique, alors que ce n'est pas le cas. 