### PR TITLE
Passage de la validité d'un test de 72 à 24 heures

### DIFF
--- a/contenus/actualites/2021-11-05-touristes-certificat-vaccination.toml
+++ b/contenus/actualites/2021-11-05-touristes-certificat-vaccination.toml
@@ -1,4 +1,0 @@
-date = 2021-11-05
-texte = "les touristes extra-européens pourront convertir leur certificat de vaccination en pharmacie pour obtenir un pass sanitaire"
-lien = "/pass-sanitaire-qr-code-voyages.html#j-ai-ete-vaccine-a-l-etranger-avec-un-vaccin-reconnu-en-france-comment-obtenir-un-qr-code-valable-en-france"
-emoji = "🌍"

--- a/contenus/actualites/2021-11-29-validite-test-negatif-24h.toml
+++ b/contenus/actualites/2021-11-29-validite-test-negatif-24h.toml
@@ -1,0 +1,4 @@
+date = 2021-11-29
+texte = "la durée de validité des tests PCR et antigéniques négatifs est réduite à 24 h pour le pass sanitaire"
+lien = "pass-sanitaire-qr-code-voyages.html#qu-est-ce-que-le-pass-sanitaire"
+emoji = "🛂"

--- a/contenus/thematiques/11-covid-in-france.md
+++ b/contenus/thematiques/11-covid-in-france.md
@@ -38,7 +38,7 @@
 
    Foreign **students** studying in France can [request the conversion](https://www.demarches-simplifiees.fr/commencer/passe-sanitaire-etudiants?locale=en) of their vaccination certificate.
 
-   While your request is being processed, a **negative PCR or antigenic test result** will be your temporary health pass (valid for 72h). To find out where to get tested, please click on [this link](https://www.sante.fr/cf/centres-depistage-covid.html) (in French).
+   While your request is being processed, a **negative PCR or antigenic test result** will be your temporary health pass (valid for 24h). To find out where to get tested, please click on [this link](https://www.sante.fr/cf/centres-depistage-covid.html) (in French).
 
    If you were vaccinated in one of the following countries, you do not need to convert your vaccination certificate: Albania, Andorra, Armenia, Faroe Islands, Iceland, Israel, Liechtenstein, North Macedonia, Morocco, Monaco, Norway, Panama, United-Kingdom, San Marino, Switzerland, Turkey, Ukraine, Vatican. 
 
@@ -53,7 +53,7 @@
 
    In France, **3 documents** can be used as a health pass, as long as they include a valid European **QR code**:
 
-      * a **negative test result** (PCR, antigenic or supervised self-test): valid for 72h after the test,
+      * a **negative test result** (PCR, antigenic or supervised self-test): valid for 24h after the test,
       * a **positive test result** (PCR or antigenic): valid between 11 days and 6 months after the illness,
       * a certificate of **full vaccination** with Pfizer, Moderna, AstraZeneca or Janssen.
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -19,7 +19,7 @@
 
     En France, le pass sanitaire peut être, **selon votre situation** :
 
-    - un [test de dépistage négatif](#comment-obtenir-un-certificat-de-depistage-avec-qr-code) : **test PCR** ou **test antigénique** ou **autotest supervisé** par un **pharmacien**, datant de moins de **72 h** (**sauf** pour les voyages en **Corse** et **Dom-Tom** : les autotests ne sont pas acceptés et le test antigénique est valable **48 h**) ;
+    - un [test de dépistage négatif](#comment-obtenir-un-certificat-de-depistage-avec-qr-code) : **test PCR** ou **test antigénique**, datant de moins de **24 h** ;
 
     - un [certificat de rétablissement](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code) : un test de dépistage **positif**, **PCR** ou **antigénique** de **plus de 11 jours** et **moins de 6 mois** ;
 
@@ -64,7 +64,7 @@
 
     **Non**. La vaccination n’est pas la seule façon d’obtenir un pass sanitaire.
 
-    Si vous n’êtes pas encore complètement vacciné, vous pouvez présenter soit un **test de dépistage négatif** de **moins de 72 h**, soit un **test de dépistage positif** de plus de **11 jours** et de moins de **6 mois**.
+    Si vous n’êtes pas encore complètement vacciné, vous pouvez présenter soit un **test de dépistage négatif** de **moins de 24 h**, soit un **test de dépistage positif** de plus de **11 jours** et de moins de **6 mois**.
 
     Si vous ne [pouvez-pas vous faire vacciner](#je-ne-peux-pas-me-faire-vacciner-comment-obtenir-un-pass-sanitaire) (en raison d’une **contre-indication médicale**), vous pouvez faire une demande de pass sanitaire auprès de l’Assurance Maladie, sur la base du **certificat médical** (formulaire Cerfa n°16183*01) établi par votre médecin.
 
@@ -132,7 +132,7 @@
 
     Il n’est **pas obligatoire d’être vacciné(e)** pour se rendre à un rendez-vous médical en milieu hospitalier. En revanche, un **pass sanitaire est exigé**. Si vous n’êtes pas vacciné(e), vous pouvez présenter :
 
-    - un **test de dépistage négatif** datant de moins de 72h ;
+    - un **test de dépistage négatif** datant de moins de 24 h ;
     - ou un **certificat de rétablissement** (test de dépistage positif de plus de 7 jours et moins de 6 mois).
 
     Dans ce cas, vous pouvez obtenir la **prise en charge** de votre **test de dépistage** en présentant au professionnel de santé qui réalisera votre test :
@@ -193,7 +193,7 @@
 
     <div class="exemple">
 
-    Par exemple, une personne non vaccinée devra présenter un test de dépistage négatif de moins de 72 h réalisé par un professionnel de santé ou un certificat de rétablissement pour voyager en car de Bordeaux à Toulouse.
+    Par exemple, une personne non vaccinée devra présenter un test de dépistage négatif de moins de 24 h réalisé par un professionnel de santé ou un certificat de rétablissement pour voyager en car de Bordeaux à Toulouse.
 
     </div>
 
@@ -223,7 +223,7 @@
 
     Par exemple, un chef cuisinier ne participant pas au service du restaurant et travaillant dans une cuisine fermée, non accessible au public, n’est pas dans l’obligation de présenter un pass sanitaire.
 
-    En revanche, si la cuisine est ouverte ou s’il participe au service, alors il devra présenter à son employeur : un test de dépistage négatif toutes les 72 h **ou** un certificat de rétablissement de plus de 11 jours et moins de 6 mois **ou** une attestation de vaccination complète.
+    En revanche, si la cuisine est ouverte ou s’il participe au service, alors il devra présenter à son employeur : un test de dépistage négatif toutes les 24 h **ou** un certificat de rétablissement de plus de 11 jours et moins de 6 mois **ou** une attestation de vaccination complète.
 
     </div>
 
@@ -248,7 +248,7 @@
 
     Les mêmes 3 **preuves sanitaires** qui font office de pass sanitaire français peuvent aussi servir de **pass sanitaire européen**, à quelques détails près :
 
-    - un **test de dépistage négatif** : **test PCR** de moins de **72 h** ou **test antigénique** de moins de **48 h** ;
+    - un **test de dépistage négatif** : **test PCR** ou **test antigénique** de moins de **24 h** ;
     - un **test de dépistage positif** : **test PCR** ou **test antigénique** daté de **plus de 11 jours** et moins de **6 mois**, appelé [certificat de rétablissement](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code) ;
     - une **attestation de vaccination complète**, soit **14 jours** (*Pfizer*, *Moderna*, *AstraZeneca*) ou **28 jours** (*Janssen*) après la dernière dose nécessaire.
 
@@ -396,7 +396,7 @@
 
     Si vous êtes **étudiant étranger** inscrit dans un établissement d’enseignement supérieur français pour la rentrée 2021-2022 et que vous possédez un visa d’études, l’administration a mis en place une démarche en ligne pour demander la [conversion votre certificat de vaccination étranger](https://www.demarches-simplifiees.fr/commencer/passe-sanitaire-etudiants) en pass sanitaire français.
 
-    En attendant, un **test de dépistage négatif de moins de 72 h** pourra faire office de pass sanitaire.
+    En attendant, un **test de dépistage négatif de moins de 24 h** pourra faire office de pass sanitaire.
 
 
 
@@ -432,7 +432,7 @@
 
     La vaccination sera considérée comme complète **7 jours** après votre dernière injection de vaccin à ARNm, et le **QR code** de l’attestation de vaccination sera alors valable comme **pass sanitaire**.
 
-    En attendant, un **test de dépistage négatif de moins de 72 h** pourra faire office de pass sanitaire.
+    En attendant, un **test de dépistage négatif de moins de 24 h** pourra faire office de pass sanitaire.
 
     <div class="conseil conseil-jaune">
 

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -292,7 +292,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
     **Non**. Comme pour les adultes non-vacciné(e)s, plusieurs justificatifs, au choix, font office de « pass sanitaire » utilisable en France et pour les voyages en Union européenne :
 
     * l’**attestation de vaccination complète** (toutes les doses et respect du délai de 7 jours après la dernière dose en France, ou 14 jours pour voyager à l’étranger) ;
-    * un **test PCR ou antigénique négatif**, ou un **autotest négatif** réalisé sous la supervision d’un professionnel de santé, de moins de 72 h (ou 48 h pour les voyages en Corse et DOM-TOM) ;
+    * un **test PCR ou antigénique négatif** de moins de 24 h ;
     * un **test PCR positif** de plus de 11 jours et moins de 6 mois.
 
     Par ailleurs, le ou la mineur(e) non-vacciné(e) accompagnant ses parents vaccinés lors d’un voyage bénéficiera des mêmes facilités qu’eux. Par exemple, un(e) mineur(e) non-vacciné(e) pourra accompagner ses parents vaccinés lors d’un voyage dans un [pays classé orange](https://www.gouvernement.fr/voyager-depuis-et-vers-l-etranger-mode-d-emploi) sans justifier d’un motif impérieux pour s’y rendre.

--- a/contenus/thematiques/formulaires/pass-sanitaire.md
+++ b/contenus/thematiques/formulaires/pass-sanitaire.md
@@ -200,9 +200,7 @@ Votre **attestation de vaccination**, munie d’un QR code, fait office de pass 
 
 Vous devez **attendre 7 jours** après votre injection pour que votre schéma vaccinal soit complet. Vous ne pourrez donc pas faire valoir votre attestation de vaccination comme pass sanitaire pour l’instant.
 
-En attendant, vous pouvez présenter soit un **test de dépistage négatif** de **moins de 72 h**, soit un **test de dépistage positif** de plus de **11 jours** et de moins de **6 mois**.
-
-*Attention : pour voyager vers la Corse ou l’Outre-mer, un test négatif datant de moins de 48 h sera demandé.*
+En attendant, vous pouvez présenter soit un **test de dépistage négatif** de **moins de 24 h**, soit un **test de dépistage positif** de plus de **11 jours** et de moins de **6 mois**.
 
 </div>
 
@@ -210,9 +208,7 @@ En attendant, vous pouvez présenter soit un **test de dépistage négatif** de 
 
 Vous devez **attendre 28 jours** (4 semaines) après votre injection pour que votre schéma vaccinal soit complet. Vous ne pourrez donc pas faire valoir votre attestation de vaccination comme pass sanitaire pour l’instant.
 
-En attendant, un **test de dépistage négatif** (test PCR, antigénique ou autotest supervisé par un pharmacien) datant de **moins de 72 h** fera office de pass sanitaire.
-
-*Attention : pour voyager vers la Corse ou l’Outre-mer, les autotests ne seront pas acceptés et le test antigénique négatif devra dater de moins de 48 h.*
+En attendant, un **test de dépistage négatif** (test PCR ou antigénique) datant de **moins de 24 h** fera office de pass sanitaire.
 
 </div>
 
@@ -220,9 +216,7 @@ En attendant, un **test de dépistage négatif** (test PCR, antigénique ou auto
 
 Votre schéma vaccinal est **incomplet** tant que vous n’avez pas reçu la dose de rappel (2<sup>e</sup> dose). Vous ne pourrez donc pas le faire valoir comme pass sanitaire pour l’instant.
 
-En attendant, un **test de dépistage négatif** (test PCR, antigénique ou autotest supervisé par un pharmacien) datant de **moins de 72 h** fera office de pass sanitaire.
-
-*Attention : pour voyager vers la Corse ou l’Outre-mer, les autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h.*
+En attendant, un **test de dépistage négatif** (test PCR ou antigénique) datant de **moins de 24 h** fera office de pass sanitaire.
 
 </div>
 
@@ -230,7 +224,7 @@ En attendant, un **test de dépistage négatif** (test PCR, antigénique ou auto
 
 Vous avez **2 possibilités** pour obtenir un pass sanitaire :
 
-1. présenter un **test de dépistage négatif** (test PCR, antigénique ou autotest supervisé par un pharmacien) de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, les autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h*) ;
+1. présenter un **test de dépistage négatif** (test PCR ou antigénique) de moins de **24 h** ;
 
 2. vous faire **vacciner** : l’attestation de vaccination fera office de pass sanitaire **7 jours après la 2<sup>e</sup> dose**.
 
@@ -243,7 +237,7 @@ Vous avez **3 possibilités** pour obtenir un pass sanitaire :
 
 1. présenter votre **test de dépistage positif** (aussi appelé *certificat de rétablissement*), datant de plus de **11 jours** et de moins de **6 mois**, et comportant un QR code ;
 
-2. présenter un **test de dépistage négatif** de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, les autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h*) ;
+2. présenter un **test de dépistage négatif** de moins de **24 h** ;
 
 3. vous faire **vacciner** (comme vous avez déjà eu la Covid, **une seule dose** sera nécessaire, mais il est recommandé d’attendre 2 mois minimum après la guérison, idéalement jusqu’à 6 mois) : l’attestation de vaccination fera office de pass sanitaire **7 jours** après cette dose.
 
@@ -253,7 +247,7 @@ Vous avez **3 possibilités** pour obtenir un pass sanitaire :
 
 Vous avez **2 possibilités** pour obtenir un pass sanitaire :
 
-1. présenter un **test de dépistage négatif** de moins de **72 h** (*pour voyager vers la Corse ou l’Outre-mer, les autotests ne seront pas acceptés et le test antigénique devra dater de moins de 48 h*) ;
+1. présenter un **test de dépistage négatif** de moins de **24 h** ;
 
 2. vous faire **vacciner** (comme vous avez déjà eu la Covid, **une seule dose** sera nécessaire) : l’attestation de vaccination fera office de pass sanitaire **7 jours** après cette dose.
 

--- a/contenus/thematiques/formulaires/tests-de-depistage.md
+++ b/contenus/thematiques/formulaires/tests-de-depistage.md
@@ -119,7 +119,7 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pa
 
 Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes pas cas contact :
 
-* Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **PCR nasopharyngé**, **antigénique** ou un **autotest supervisé** par un professionnel de santé, réalisé il y a moins de **72 h ou 48 h** (selon les cas) est nécessaire.
+* Si vous souhaitez obtenir un « [pass sanitaire](/pass-sanitaire-qr-code-voyages.html) », un test négatif **PCR nasopharyngé** ou **antigénique**, réalisé il y a moins de **24 h** est nécessaire.
 * Si vous rendez visite à des personnes vulnérables, un test **antigénique** ou **PCR nasopharyngé** est indiqué.
 * Si vous travaillez régulièrement avec des personnes fragiles, il est recommandé de vous tester régulièrement avec les **autotests** vendus en pharmacie (les professionnels exerçant à domicile auprès de personnes vulnérables peuvent obtenir la prise en charge de 10 autotests par mois en présentant leur carte professionnelle au pharmacien).
 

--- a/src/scripts/tests/integration/test.passsanitaire.js
+++ b/src/scripts/tests/integration/test.passsanitaire.js
@@ -188,7 +188,7 @@ describe('Pass sanitaire', function () {
         )
         assert.include(
             await questionnaire.recuperationStatut('test-positif-moins-de-6-mois'),
-            'présenter un test de dépistage négatif de moins de 72 h'
+            'présenter un test de dépistage négatif de moins de 24 h'
         )
         assert.include(
             await questionnaire.recuperationStatut('test-positif-moins-de-6-mois'),
@@ -213,7 +213,7 @@ describe('Pass sanitaire', function () {
         // On donne les possibilités.
         assert.include(
             await questionnaire.recuperationStatut('test-positif-plus-de-6-mois'),
-            'présenter un test de dépistage négatif de moins de 72 h'
+            'présenter un test de dépistage négatif de moins de 24 h'
         )
         assert.include(
             await questionnaire.recuperationStatut('test-positif-plus-de-6-mois'),

--- a/src/scripts/tests/integration/test.tests.js
+++ b/src/scripts/tests/integration/test.tests.js
@@ -192,11 +192,8 @@ describe('Tests', function () {
         const statut = await questionnaire.recuperationStatut(
             'pas-symptomes-pas-cas-contact-auto-test-non'
         )
-        // On propose différents tests pour le pass sanitaire.
-        assert.include(
-            statut,
-            'un test négatif PCR nasopharyngé, antigénique ou un autotest supervisé'
-        )
+        // On propose un test PCR ou antigénique pour le pass sanitaire.
+        assert.include(statut, 'un test négatif PCR nasopharyngé ou antigénique')
         // On propose un test PCR ou antigénique pour visiter des personnes vulnérables.
         assert.include(
             statut,


### PR DESCRIPTION
Hypothèses :

* les voyages vers la Corse et l'Outre-mer s'alignent sur la durée de 24h
* les auto-tests supervisés ne sont plus valides