### PR TITLE
Ajoute des boutons explicites pour les sections de la page « cas contact »

### DIFF
--- a/contenus/thematiques/1-cas-contact-a-risque.md
+++ b/contenus/thematiques/1-cas-contact-a-risque.md
@@ -42,6 +42,8 @@ Si vous avez **déjà eu la Covid** il y a **moins de 2 mois**, alors vous n’�
 
 </div>
 
+<div class="lire-la-suite"><button class="button">Lire la suite</button></div>
+
 </summary>
 
 #### 1. Faites un test
@@ -119,6 +121,8 @@ Si votre premier test était **négatif**, vous devez faire un test de contrôle
 * **ou** vous souffrez d’une **forte immunodépression** qui réduit l’efficacité du vaccin.
 
 </div>
+
+<div class="lire-la-suite"><button class="button">Lire la suite</button></div>
 
 </summary>
 

--- a/src/scripts/page/thematiques/main.js
+++ b/src/scripts/page/thematiques/main.js
@@ -16,10 +16,7 @@ export function pageThematique(app) {
             boutonBasculeVersMonProfil(lienVersProfil, app)
         }
     )
-    applyDetailsSummaryPolyfill(document)
-    ouvreDetailsSiFragment()
-    window.addEventListener('hashchange', ouvreDetailsSiFragment)
-    scrolleAuSummary()
+    initDetailsSummary()
     partagePageEnCours()
     feedbackPageEnCours(app)
 
@@ -29,6 +26,13 @@ export function pageThematique(app) {
         app,
         'Navigue vers une thématique depuis une autre thématique'
     )
+}
+
+function initDetailsSummary() {
+    applyDetailsSummaryPolyfill(document)
+    ouvreDetailsSiFragment()
+    window.addEventListener('hashchange', ouvreDetailsSiFragment)
+    scrolleAuSummary()
 }
 
 function ouvreDetailsSiFragment() {

--- a/src/scripts/page/thematiques/main.js
+++ b/src/scripts/page/thematiques/main.js
@@ -38,21 +38,26 @@ function initDetailsSummary() {
 function ouvreDetailsSiFragment() {
     const currentAnchor = document.location.hash ? document.location.hash.slice(1) : ''
     if (currentAnchor) {
-        let elem = document.querySelector(`#${currentAnchor}`)
-        while (elem) {
-            if (elem.tagName.toLowerCase() === 'details') {
-                elem.setAttribute('open', '')
-                break
-            }
-            elem = elem.parentElement
-        }
-        if (elem) {
+        const elem = document.querySelector(`#${currentAnchor}`)
+        const details = trouveDetailsParent(elem)
+        if (details) {
+            details.setAttribute('open', '')
+
             // Even with an event, we need to wait for the next few
             // ticks to be able to scroll to the collapsed element.
             setTimeout(() => {
                 elem.scrollIntoView({ behavior: getAnimationBehavior() })
             }, 100)
         }
+    }
+}
+
+function trouveDetailsParent(elem) {
+    while (elem) {
+        if (elem.tagName.toLowerCase() === 'details') {
+            return elem
+        }
+        elem = elem.parentElement
     }
 }
 

--- a/src/scripts/page/thematiques/main.js
+++ b/src/scripts/page/thematiques/main.js
@@ -30,9 +30,23 @@ export function pageThematique(app) {
 
 function initDetailsSummary() {
     applyDetailsSummaryPolyfill(document)
+    ouvreDetailsSiBouton()
     ouvreDetailsSiFragment()
     window.addEventListener('hashchange', ouvreDetailsSiFragment)
     scrolleAuSummary()
+}
+
+function ouvreDetailsSiBouton() {
+    const boutons = document.querySelectorAll('summary .lire-la-suite .button')
+    Array.from(boutons).forEach((bouton) => {
+        bouton.addEventListener('click', (event) => {
+            event.preventDefault()
+            const details = trouveDetailsParent(event.target)
+            if (details) {
+                details.setAttribute('open', '')
+            }
+        })
+    })
 }
 
 function ouvreDetailsSiFragment() {

--- a/src/style.css
+++ b/src/style.css
@@ -365,11 +365,20 @@ legend h1 {
 }
 .page-thematique .conseils details .explications {
     margin: 0.75rem;
-    background: #eff3ff;
     padding: 0.5rem 1rem;
+    background: #eff3ff;
     border-left: 4px solid #a5baff;
 }
-.page-thematique .conseils details[open] .explications {
+.page-thematique .conseils details .lire-la-suite {
+    margin: 0 0.75rem 0.75rem 0.75rem;
+    text-align: right;
+}
+.page-thematique .conseils details .lire-la-suite .button {
+    display: inline-block;
+    margin: 0;
+}
+.page-thematique .conseils details[open] .explications,
+.page-thematique .conseils details[open] .lire-la-suite {
     display: none;
 }
 .page-thematique [itemprop='url'] {


### PR DESCRIPTION
Le fait qu’il faille cliquer pour déplier les sections semble ne pas être évident pour certains utilisateurs. On ajoute des boutons explicites.