### PR TITLE
Préserve la source lors de la navigation dans les pages thématiques

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -42,8 +42,6 @@ export default class App {
         this.stockage = new StockageLocal()
         this.questionnaire = new Questionnaire()
         this.suiviImages = suiviImages
-
-        this.initStats()
     }
     initStats() {
         this.source = this.initSource()

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -44,13 +44,16 @@ export default class App {
         this.suiviImages = suiviImages
 
         // Source de la visite.
-        const searchParams = new URLSearchParams(window.location.search)
-        this.source = searchParams.get('source') || searchParams.get('utm_source')
+        this.source = this.initSource()
 
         // Statistiques.
         this._plausibleTrackingEvents = []
         this._plausible = registerPlausible(window)
         this.atinternet = registerATInternet()
+    }
+    initSource() {
+        const searchParams = new URLSearchParams(window.location.search)
+        return searchParams.get('source') || searchParams.get('utm_source')
     }
     init() {
         this.router = new Router(this)

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -43,10 +43,10 @@ export default class App {
         this.questionnaire = new Questionnaire()
         this.suiviImages = suiviImages
 
-        // Source de la visite.
+        this.initStats()
+    }
+    initStats() {
         this.source = this.initSource()
-
-        // Statistiques.
         this._plausibleTrackingEvents = []
         this._plausible = registerPlausible(window)
         this.atinternet = registerATInternet()

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -43,13 +43,14 @@ export default class App {
         this.questionnaire = new Questionnaire()
         this.suiviImages = suiviImages
 
+        // Source de la visite.
+        const searchParams = new URLSearchParams(window.location.search)
+        this.source = searchParams.get('source') || searchParams.get('utm_source')
+
         // Statistiques.
         this._plausibleTrackingEvents = []
         this._plausible = registerPlausible(window)
         this.atinternet = registerATInternet()
-
-        const searchParams = new URLSearchParams(window.location.search)
-        this.source = searchParams.get('source') || searchParams.get('utm_source')
     }
     init() {
         this.router = new Router(this)
@@ -270,12 +271,8 @@ export default class App {
     }
     plausible(eventName, props = {}) {
         // Ajoute la source de la visite.
-        const searchParams = new URLSearchParams(window.location.search)
-        if (searchParams.toString().length) {
-            const source = searchParams.get('source') || searchParams.get('utm_source')
-            if (source) {
-                props['source'] = source
-            }
+        if (this.source) {
+            props['source'] = this.source
         }
         // Ajoute l’info sur le profil (pour moi ou pour un proche).
         if (typeof this.profil.nom !== 'undefined') {

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -44,14 +44,24 @@ export default class App {
         this.suiviImages = suiviImages
     }
     initStats() {
-        this.source = this.initSource()
-        this._plausibleTrackingEvents = []
-        this._plausible = registerPlausible(window)
-        this.atinternet = registerATInternet()
+        return this.initSource().then((source) => {
+            this.source = source
+            this._plausibleTrackingEvents = []
+            this._plausible = registerPlausible(window)
+            this.atinternet = registerATInternet()
+        })
     }
     initSource() {
         const searchParams = new URLSearchParams(window.location.search)
-        return searchParams.get('source') || searchParams.get('utm_source')
+        const sourceFromUrl =
+            searchParams.get('source') || searchParams.get('utm_source')
+        if (sourceFromUrl) {
+            // On mémorise la source présente dans l’URL.
+            return this.stockage.setSource(sourceFromUrl)
+        } else {
+            // On se rappelle de la source précédemment stockée.
+            return this.stockage.getSource()
+        }
     }
     init() {
         this.router = new Router(this)

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -269,17 +269,22 @@ export default class App {
         return navigator.languages || [navigator.language || navigator.userLanguage]
     }
     plausible(eventName, props = {}) {
+        // Ajoute la source de la visite.
         const searchParams = new URLSearchParams(window.location.search)
-        const options = {}
-        if (typeof this.profil.nom !== 'undefined') {
-            props['profil'] = this.profil.estMonProfil() ? 'moi' : 'proche'
-        }
         if (searchParams.toString().length) {
             const source = searchParams.get('source') || searchParams.get('utm_source')
             if (source) {
                 props['source'] = source
             }
         }
+        // Ajoute l’info sur le profil (pour moi ou pour un proche).
+        if (typeof this.profil.nom !== 'undefined') {
+            props['profil'] = this.profil.estMonProfil() ? 'moi' : 'proche'
+        }
+        return this._envoieEvenementPlausible(eventName, props)
+    }
+    _envoieEvenementPlausible(eventName, props) {
+        const options = {}
         if (Object.keys(props).length > 0) {
             options['props'] = props
         }

--- a/src/scripts/feedback.js
+++ b/src/scripts/feedback.js
@@ -25,21 +25,15 @@ export function bindFeedback(component, app) {
             const form = component.querySelector('.feedback-form form')
             form.addEventListener('submit', (event) => {
                 event.preventDefault()
-                const feedbackHost = document.body.dataset.statsUrl
-                let message = event.target.elements.message.value
-                const page = estPageThematique()
-                    ? document.location.pathname.slice(1)
-                    : getCurrentPageName()
-                const payload = {
+                envoieLesRemarques({
+                    feedbackHost: document.body.dataset.statsUrl,
                     kind: feedback,
-                    message: message,
-                    page: page,
+                    message: event.target.elements.message.value,
+                    page: estPageThematique()
+                        ? document.location.pathname.slice(1)
+                        : getCurrentPageName(),
                     source: app.source,
-                }
-                const request = new XMLHttpRequest()
-                request.open('POST', feedbackHost + '/feedback', true)
-                request.setRequestHeader('Content-Type', 'application/json')
-                request.send(JSON.stringify(payload))
+                })
 
                 opacityTransition(component, transitionDelay, (component) => {
                     hideElement(component.querySelector('.feedback-form'))
@@ -100,4 +94,26 @@ export function bindFeedback(component, app) {
         hideElement(component.querySelector('.feedback-partager'))
         showElement(component.querySelector('.feedback-question'))
     })
+}
+
+export function envoieLesRemarques({
+    feedbackHost,
+    kind,
+    message,
+    page,
+    question,
+    source,
+}) {
+    const request = new XMLHttpRequest()
+    request.open('POST', feedbackHost + '/feedback', true)
+    request.setRequestHeader('Content-Type', 'application/json')
+    request.send(
+        JSON.stringify({
+            kind,
+            message,
+            page,
+            question,
+            source,
+        })
+    )
 }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -20,15 +20,16 @@ import App from './app'
 var app = new App(SUIVI_IMAGES)
 window.app = app
 ;(function () {
-    app.initStats()
-    if (estPageThematique()) {
-        pageThematique(app)
-    } else {
-        pageQuestionnaire(app)
-        activeLesMisesAJourAuto(app)
-    }
-    initLiensPiedDePage(app)
-    initLiensRoleButton()
+    app.initStats().then(() => {
+        if (estPageThematique()) {
+            pageThematique(app)
+        } else {
+            pageQuestionnaire(app)
+            activeLesMisesAJourAuto(app)
+        }
+        initLiensPiedDePage(app)
+        initLiensRoleButton()
+    })
 })()
 
 function pageQuestionnaire(app) {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -20,6 +20,7 @@ import App from './app'
 var app = new App(SUIVI_IMAGES)
 window.app = app
 ;(function () {
+    app.initStats()
     if (estPageThematique()) {
         pageThematique(app)
     } else {

--- a/src/scripts/page/thematiques/main.js
+++ b/src/scripts/page/thematiques/main.js
@@ -208,6 +208,7 @@ function demandeRemarques(feedbackQuestionForm, choix, question, reponse, label)
             message: message,
             page: page,
             question: question,
+            source: window.app.source,
         }
         const request = new XMLHttpRequest()
         request.open('POST', feedbackHost + '/feedback', true)

--- a/src/scripts/page/thematiques/main.js
+++ b/src/scripts/page/thematiques/main.js
@@ -1,7 +1,7 @@
 import applyDetailsSummaryPolyfill from '../../polyfills/details_polyfill'
 
 import { bindImpression } from '../../actions'
-import { bindFeedback, opacityTransition } from '../../feedback'
+import { bindFeedback, opacityTransition, envoieLesRemarques } from '../../feedback'
 import { navigueVersUneThematique } from './navigation'
 import { dynamiseLeChoixDuTest } from './choixTestDepistage'
 import { dynamiseLeChoixDuPass } from './choixPassSanitaire'
@@ -200,21 +200,14 @@ function demandeRemarques(feedbackQuestionForm, choix, question, reponse, label)
     feedbackQuestionForm.parentNode.replaceChild(formulaire, feedbackQuestionForm)
     formulaire.addEventListener('submit', (event) => {
         event.preventDefault()
-        const feedbackHost = document.body.dataset.statsUrl
-        let message = event.target.elements.message.value
-        const page = document.location.pathname.slice(1)
-        const payload = {
+        envoieLesRemarques({
+            feedbackHost: document.body.dataset.statsUrl,
             kind: choix,
-            message: message,
-            page: page,
+            message: event.target.elements.message.value,
+            page: document.location.pathname.slice(1),
             question: question,
             source: window.app.source,
-        }
-        const request = new XMLHttpRequest()
-        request.open('POST', feedbackHost + '/feedback', true)
-        request.setRequestHeader('Content-Type', 'application/json')
-        request.send(JSON.stringify(payload))
-
+        })
         afficheRemerciements(formulaire, choix, reponse)
     })
 }

--- a/src/scripts/plausible.js
+++ b/src/scripts/plausible.js
@@ -49,9 +49,11 @@ export function registerPlausible(window) {
             location.protocol === 'file:'
         ) {
             ignore('running locally')
-            window.app._plausibleTrackingEvents.push(
-                `${payload.n}:${getLocationPathName().slice(1)}`
-            )
+            let eventSummary = `${payload.n}:${getLocationPathName().slice(1)}`
+            if (options && options.props && options.props.source) {
+                eventSummary = `${eventSummary}:${options.props.source}`
+            }
+            window.app._plausibleTrackingEvents.push(eventSummary)
             console.debug('[Plausible]', JSON.stringify(payload))
             return
         }

--- a/src/scripts/stockage.js
+++ b/src/scripts/stockage.js
@@ -2,6 +2,14 @@
 import localforage from 'localforage'
 
 export default class StockageLocal {
+    getSource() {
+        return localforage.getItem('source')
+    }
+
+    setSource(source) {
+        return localforage.setItem('source', source)
+    }
+
     getProfilActuel() {
         return localforage.getItem('profil')
     }

--- a/src/scripts/tests/integration/helpers.js
+++ b/src/scripts/tests/integration/helpers.js
@@ -39,7 +39,7 @@ export async function waitForPlausibleTrackingEvents(page, names) {
             { timeout: 2000 }
         )
     } catch (e) {
-        assert.deepEqual(names, await getPlausibleTrackingEvents(page))
+        assert.deepEqual(await getPlausibleTrackingEvents(page), names)
     }
 }
 

--- a/src/scripts/tests/integration/test.plausible.js
+++ b/src/scripts/tests/integration/test.plausible.js
@@ -19,6 +19,19 @@ describe('Plausible', function () {
         await waitForPlausibleTrackingEvents(page, ['pageview:introduction'])
     })
 
+    it('accès à une page avec source', async function () {
+        const page = this.test.page
+
+        await page.goto('http://localhost:8080/?source=toto#introduction')
+        await page.waitForSelector('#page.ready')
+        assert.equal(
+            await page.title(),
+            'Mes Conseils Covid — Isolement, tests, vaccins, attestations, contact à risque…'
+        )
+
+        await waitForPlausibleTrackingEvents(page, ['pageview:introduction:toto'])
+    })
+
     it('drapeau sur une page', async function () {
         const page = this.test.page
 

--- a/src/scripts/tests/integration/test.plausible.js
+++ b/src/scripts/tests/integration/test.plausible.js
@@ -32,6 +32,23 @@ describe('Plausible', function () {
         await waitForPlausibleTrackingEvents(page, ['pageview:introduction:toto'])
     })
 
+    it('le changement de page conserve la source', async function () {
+        const page = this.test.page
+
+        await page.goto('http://localhost:8080/?source=toto#introduction')
+        await page.waitForSelector('#page.ready')
+        assert.equal(
+            await page.title(),
+            'Mes Conseils Covid — Isolement, tests, vaccins, attestations, contact à risque…'
+        )
+        await waitForPlausibleTrackingEvents(page, ['pageview:introduction:toto'])
+
+        await page.click('a >> text="Je suis cas contact Covid, que faire ?"')
+        await waitForPlausibleTrackingEvents(page, [
+            'pageview:cas-contact-a-risque.html:toto',
+        ])
+    })
+
     it('drapeau sur une page', async function () {
         const page = this.test.page
 


### PR DESCRIPTION
Le questionnaire étant une single-page app, on pouvait se contenter de conserver la source comme une propriété de l’objet `app`.

Pour préserver cette valeur lors de la navigation de / vers les pages thématiques, on la mémorise dans le stockage local et on la récupère après une transition.

Ah oui, et tant qu’on y est on la passe avec le feedback sur les questions ! :sweat_smile: 