### PR TITLE
Prend en compte Omicron pour le cas contact foyer

### DIFF
--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -11,9 +11,9 @@
 
 <div class="conseil conseil-jaune">
 
-    Si vous vivez avec une personne positive au **nouveau variant**, **Omicron** il faut **vous isoler** et suivre les mêmes recommandations que les personnes **non vaccinées** ([voir ci-dessous](#personne-positive-schema-vaccinal-incomplet)), même si vous êtes vacciné(e).
+Si vous vivez avec une personne positive au nouveau **variant Omicron**, il faut **vous isoler** et suivre les mêmes recommandations que les personnes **non vaccinées** ([voir ci-dessous](#personne-positive-schema-vaccinal-incomplet)), même si vous êtes vacciné(e).
 
-    </div>
+</div>
 
 ## Vous vivez avec une personne positive à la Covid et…
 
@@ -29,8 +29,8 @@
 
 * vous n’avez **pas encore** reçu les doses nécessaires (1 ou 2 doses) ;
 * **ou** vous avez reçu votre dernière dose depuis **moins de 7 jours** (*Pfizer, Moderna, AstraZeneca*) ou moins de 28 jours (*Janssen*) ;
-* **ou** vous souffrez d’une **forte immunodépression** qui réduit l’efficacité du vaccin ;
-* **ou** vous vivez avec une personne positive au **nouveau variant**, **Omicron**.
+* **ou** vous souffrez d’une **forte immunodépression** qui réduit l’efficacité du vaccin ;
+* **ou** vous vivez avec une personne positive au nouveau **variant Omicron**.
 
 </div>
 
@@ -88,8 +88,8 @@ Voici un schéma illustrant la conduite à tenir dans votre situation :
 
 * vous avez reçu **toutes les doses** nécessaires (1 ou 2 doses) ;
 * **et** vous avez reçu la dernière dose prévue depuis **plus de 7 jours** (*Pfizer*, *Moderna*, *AstraZeneca*) ou plus de 28 jours (*Janssen*) ;
-* **et** vous ne souffrez pas d’immunodépression ;
-* **et** vous ne vivez **pas** avec une personne positive au **nouveau variant**, **Omicron**.
+* **et** vous ne souffrez pas d’immunodépression ;
+* **et** vous ne vivez **pas** avec une personne positive au nouveau **variant Omicron**.
 
 </div>
 
@@ -101,10 +101,10 @@ Voici un schéma illustrant la conduite à tenir dans votre situation :
 
 <div class="conseil conseil-jaune">
 
-    Attention, si vous vivez avec une personne positive au **nouveau variant**, **Omicron** suivez les mêmes recommandations que les personnes **non vaccinées** ([voir ci-dessus]](#personne-positive-schema-vaccinal-incomplet)).
+Attention, si vous vivez avec une personne positive au nouveau **variant Omicron**, suivez les mêmes recommandations que les personnes **non vaccinées** ([voir ci-dessus](#personne-positive-schema-vaccinal-incomplet)).
 
-    </div>
-    
+</div>
+
 <div class="conseil">
 
 Même si vous ne présentez pas de symptômes, il faut vous faire tester dès que possible en laboratoire ou en pharmacie :

--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -9,6 +9,12 @@
 .. toc:: Sommaire
     :depth: 3
 
+<div class="conseil conseil-jaune">
+
+    Si vous vivez avec une personne positive au **nouveau variant**, **Omicron** il faut **vous isoler** et suivre les mêmes recommandations que les personnes **non vaccinées** ([voir ci-dessous](#personne-positive-schema-vaccinal-incomplet)), même si vous êtes vacciné(e).
+
+    </div>
+
 ## Vous vivez avec une personne positive à la Covid et…
 
 <details id="personne-positive-schema-vaccinal-incomplet">
@@ -23,7 +29,8 @@
 
 * vous n’avez **pas encore** reçu les doses nécessaires (1 ou 2 doses) ;
 * **ou** vous avez reçu votre dernière dose depuis **moins de 7 jours** (*Pfizer, Moderna, AstraZeneca*) ou moins de 28 jours (*Janssen*) ;
-* **ou** vous souffrez d’une **forte immunodépression** qui réduit l’efficacité du vaccin.
+* **ou** vous souffrez d’une **forte immunodépression** qui réduit l’efficacité du vaccin ;
+* **ou** vous vivez avec une personne positive au **nouveau variant**, **Omicron**.
 
 </div>
 
@@ -81,7 +88,8 @@ Voici un schéma illustrant la conduite à tenir dans votre situation :
 
 * vous avez reçu **toutes les doses** nécessaires (1 ou 2 doses) ;
 * **et** vous avez reçu la dernière dose prévue depuis **plus de 7 jours** (*Pfizer*, *Moderna*, *AstraZeneca*) ou plus de 28 jours (*Janssen*) ;
-* **et** vous ne souffrez pas d’immunodépression.
+* **et** vous ne souffrez pas d’immunodépression ;
+* **et** vous ne vivez **pas** avec une personne positive au **nouveau variant**, **Omicron**.
 
 </div>
 
@@ -91,6 +99,12 @@ Voici un schéma illustrant la conduite à tenir dans votre situation :
 
 #### 1. Faites un test
 
+<div class="conseil conseil-jaune">
+
+    Attention, si vous vivez avec une personne positive au **nouveau variant**, **Omicron** suivez les mêmes recommandations que les personnes **non vaccinées** ([voir ci-dessus]](#personne-positive-schema-vaccinal-incomplet)).
+
+    </div>
+    
 <div class="conseil">
 
 Même si vous ne présentez pas de symptômes, il faut vous faire tester dès que possible en laboratoire ou en pharmacie :


### PR DESCRIPTION
Si une personne vaccinée vit avec une personne positive au nouveau variant Omicron, il faut qu'elle s'isole et suive les mêmes recommandations que les personnes non vaccinées.

Source : https://www.ameli.fr/hauts-de-seine/assure/covid-19/comprendre-le-covid-19-se-proteger/en-cas-de-contact-avec-une-personne-malade-du-covid-19