### PR TITLE
Ajoute une question sur la vaccination des 5-11 ans

### DIFF
--- a/construction/tests/test_typographie.py
+++ b/construction/tests/test_typographie.py
@@ -29,6 +29,7 @@ import pytest
         ("150 g de farine", "150&#8239;g de farine"),
         ("150 gibbons", "150&nbsp;gibbons"),
         ("200 mg", "200&#8239;mg"),
+        ("200 µg", "200&#8239;µg"),
         ("à 10 000 kilomètres", "à 10&#8239;000&nbsp;kilomètres"),
         ("100&nbsp;%", "100&#8239;%"),
         ("pour&nbsp;100&nbsp;% des cas", "pour&nbsp;100&#8239;% des cas"),

--- a/construction/typographie.py
+++ b/construction/typographie.py
@@ -22,7 +22,7 @@ def build_regex(avant, apres):
 RE_ESPACE_FINE_INSECABLE = regex.compile(
     assemble_regexes(
         build_regex(r"\w?", r"[;\?!]"),  # Ponctuations doubles.
-        build_regex(r"\d", r"([ghj]|mg|°C)(\b|$)"),  # Unités.
+        build_regex(r"\d", r"([ghj]|µg|mg|°C)(\b|$)"),  # Unités.
         build_regex(r"\d", r"%"),  # Pourcentages.
         build_regex(r"\d", r"€"),  # Symboles monétaires.
         build_regex(r"\d", r"\d"),  # Séparateurs de milliers.

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -248,19 +248,21 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     </div>
 
+
 .. question:: Les enfants de moins de 12 ans peuvent-ils être vaccinés ?
     :level: 3
-    
+
     La Haute Autorité de Santé (HAS) **recommande** de vacciner contre la Covid les enfants âgés de **5 à 11 ans** qui :
-    
+
     * ont des **comorbidités** les mettant à risque de faire une forme grave (notamment, de développer des « syndromes inflammatoires multi-systémiques pédiatriques » (PIMS)) ;
     * *ou* ont dans leur **entourage** proche une **personne fortement immunodéprimée** ou **vulnérable** qui ne peut pas bénéficier de la protection vaccinale.
-    
-    La vaccination est **facultative** et se fera avec une dose pédiatrique (10 µg) de **Pfizer**.
-    
-    La campagne de vaccination devrait débuter vers la mi-décembre.
-    
-    Pour l’instant, la vaccination n’est pas élargie à l’ensemble des enfants de cette catégorie d’âge.
+
+    La campagne de vaccination pour les enfants concernés devrait débuter à partir de la mi-décembre.
+
+    La vaccination sera **facultative** et se fera avec une dose pédiatrique (10 µg) de vaccin **Pfizer**.
+
+    Pour l’instant, il n’est pas prévu d’élargir la vaccination à tous les enfants de cette catégorie d’âge.
+
 
 .. question:: Les mineurs reçoivent-ils le même nombre de doses que les adultes ?
     :level: 3

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -248,20 +248,19 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     </div>
 
-.. question:: Les enfants de moins de 12 ans peuvent-ils être vaccinés ?
+.. question:: Les enfants de moins de 12 ans peuvent-ils être vaccinés ?
     :level: 3
     
-    La Haute Autorité de Santé (HAS) **recommande** de vacciner contre la Covid les enfants âgés de **5 à 11 ans** qui :
+    La Haute Autorité de Santé (HAS) **recommande** de vacciner contre la Covid les enfants âgés de **5 à 11 ans** qui :
     
-    * ont des **comorbidités** les mettant à risque de faire une forme grave (notamment, de développer des « syndromes inflammatoires multi-systémiques pédiatriques » (PIMS));
-    ou
-    * ont dans leur **entourage** proche une **personne fortement immunodéprimée** ou **vulnérable** qui ne peut pas bénéficier de la protection vaccinale.
+    * ont des **comorbidités** les mettant à risque de faire une forme grave (notamment, de développer des « syndromes inflammatoires multi-systémiques pédiatriques » (PIMS)) ;
+    * *ou* ont dans leur **entourage** proche une **personne fortement immunodéprimée** ou **vulnérable** qui ne peut pas bénéficier de la protection vaccinale.
     
-    La vaccination est **facultative** et se fera avec une dose pédiatrique (10µg) de **Pfizer**.
+    La vaccination est **facultative** et se fera avec une dose pédiatrique (10 µg) de **Pfizer**.
     
     La campagne de vaccination devrait débuter vers la mi-décembre.
     
-    Pour l'instant, la vaccination n'est pas élargie à l'ensemble des enfants de cette catégorie d'âge.
+    Pour l’instant, la vaccination n’est pas élargie à l’ensemble des enfants de cette catégorie d’âge.
 
 .. question:: Les mineurs reçoivent-ils le même nombre de doses que les adultes ?
     :level: 3

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -207,7 +207,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
 
 .. section:: La vaccination contre la Covid
-    :tags: 12 à 18 ans
+    :tags: 4 à 11 ans, 12 à 18 ans
 
 .. question:: Faut-il une autorisation parentale pour vacciner un mineur ?
     :level: 3
@@ -248,6 +248,20 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     </div>
 
+.. question:: Les enfants de moins de 12 ans peuvent-ils être vaccinés ?
+    :level: 3
+    
+    La Haute Autorité de Santé (HAS) **recommande** de vacciner contre la Covid les enfants âgés de **5 à 11 ans** qui :
+    
+    * ont des **comorbidités** les mettant à risque de faire une forme grave (notamment, de développer des « syndromes inflammatoires multi-systémiques pédiatriques » (PIMS));
+    ou
+    * ont dans leur **entourage** proche une **personne fortement immunodéprimée** ou **vulnérable** qui ne peut pas bénéficier de la protection vaccinale.
+    
+    La vaccination est **facultative** et se fera avec une dose pédiatrique (10µg) de **Pfizer**.
+    
+    La campagne de vaccination devrait débuter vers la mi-décembre.
+    
+    Pour l'instant, la vaccination n'est pas élargie à l'ensemble des enfants de cette catégorie d'âge.
 
 .. question:: Les mineurs reçoivent-ils le même nombre de doses que les adultes ?
     :level: 3


### PR DESCRIPTION
+ La HAS recommande de vacciner les enfants âgés de 5 à 11 ans et qui ont des comorbidités ou vivent dans l'entourage d'une personne qui ne peut pas profiter de la vaccination (immunodéprimé...). 
+ j'ai ajouté le tag 4 à 11 ans sur la rubrique vaccination. 
Je n'ai pas trouvé que les chiffres  mentionnés dans l'avis  sont très parlant, donc je ne les ai pas repris. Qu'est-ce que vous en pensez ? 

https://www.has-sante.fr/jcms/p_3302411/fr/covid-19-la-has-recommande-la-vaccination-des-enfants-fragiles