### PR TITLE
Tech: Formatte tous les CSS et JS dans src

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,10 @@ jargon.dic: jargon.dic.txt
 
 lint:  ## Run ESLint + check code style.
 	npm run-script lint
-	./node_modules/.bin/prettier src/*.js src/**/*.js src/**/**/*.js src/**/**/**/*.js src/style.css --check
+	./node_modules/.bin/prettier "src/**/*.{js,css}" --check
 
 pretty:  ## Run PrettierJS.
-	./node_modules/.bin/prettier src/*.js src/**/*.js src/**/**/*.js src/**/**/**/*.js src/style.css --write
+	./node_modules/.bin/prettier "src/**/*.{js,css}" --write
 
 optimize-images:
 	find diagrammes src static -type f -iname "*.png" -print0 | xargs -I {} -0 zopflipng -y "{}" "{}"


### PR DESCRIPTION
> Don’t forget the **quotes** around the globs! The quotes make sure that Prettier CLI expands the globs rather than your shell, which is important for cross-platform usage.
>
> -- <cite>[Prettier docs](https://prettier.io/docs/en/cli.html)</cite>