### PR TITLE
Ajoute la démarche pour le chômage partiel

### DIFF
--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -125,7 +125,7 @@ Le test est **toujours gratuit** quand vous êtes cas contact.
 
 </div>
 
-Si vous devez **garder votre enfant positif** à la Covid mais que vous ne pouvez pas télétravailler, vous pouvez bénéficier du **chômage partiel**. Pour plus d’information sur la démarche, consultez notre [page dédiée aux conseils pour les mineurs]#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid).
+Si vous devez **garder votre enfant** positif à la Covid mais que vous ne pouvez pas télétravailler, vous pouvez bénéficier du **chômage partiel**. Pour plus d’information sur la démarche, consultez notre [page dédiée aux conseils pour les mineurs](/conseils-pour-les-enfants.html#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid).
 
 #### 2. Faites un test de contrôle
 

--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -125,7 +125,7 @@ Le test est **toujours gratuit** quand vous êtes cas contact.
 
 </div>
 
-Si vous ne pouvez pas télétravailler, l’Assurance Maladie pourra vous prescrire un arrêt de travail. Pour plus d’information, rendez-vous sur [declare.ameli.fr](https://declare.ameli.fr/).
+Si vous devez **garder votre enfant positif** à la Covid mais que vous ne pouvez pas télétravailler, vous pouvez bénéficier du **chômage partiel**. Pour plus d’information sur la démarche, consultez notre [page dédiée aux conseils pour les mineurs]#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid).
 
 #### 2. Faites un test de contrôle
 


### PR DESCRIPTION
Les personnes vacciné(e)s vivant avec une personne positive n'ont pas l'obligation de s'isoler (sauf s'ils ont été au contact d'Omicron). Or, jusqu'à présent on leur proposait à tort de se rendre sur declare.ameli pour demander un arrêt de travail s'ils ne pouvaient pas télétravailler. 

Je remplace cette information, par un renvoi vers des infos sur le chômage partiel pour garde d'enfant. Je me dis qu'un parent vacciné(e) vivant avec un enfant positif doit faire une démarche pour pouvoir le garder, puisqu'il n'est pas automatiquement isolé.