### PR TITLE
Montrer le focus des h2 dans summary

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1500,6 +1500,13 @@ a.no-type::after {
     outline: 0;
     list-style: none;
 }
+.conseils details > summary > :first-child {
+    border: 3px solid transparent;
+    border-radius: 0.35rem;
+}
+.conseils details > summary:focus > :first-child {
+    border-color: #9a9aff;
+}
 .conseils details:not([open]) > :not(summary) {
     display: none;
 }
@@ -1512,10 +1519,6 @@ a.no-type::after {
 .conseils details:hover,
 .conseils details[open] {
     outline: 0;
-}
-.conseils details > summary:focus h3 {
-    outline: 0;
-    border: 3px solid #9a9aff;
 }
 .conseils details[open] > summary svg {
     transform: rotate(540deg);


### PR DESCRIPTION
La navigation clavier pouvait être difficile sans indicateur.
De plus, le focus ne déclenche plus de déplacement de contenu lié au changement de la largeur de la bordure pour les h3.

Testé sur /cas-contact-a-risque.html et /j-ai-des-symptomes-covid.html