### PR TITLE
L'autotest supervisé n'est plus un pass sanitaire

### DIFF
--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -141,6 +141,5 @@
 
     Ce type de test est utile à condition de le pratiquer régulièrement (plusieurs fois par semaine).
 
-    Pour être valable comme **pass sanitaire**, l’autotest doit être réalisé sous la **supervision d’un pharmacien**.
 
 </div>


### PR DESCRIPTION
Depuis le 29 novembre. 
https://www.gouvernement.fr/info-coronavirus