### PR TITLE
Déplace une question pour la rendre plus visible

### DIFF
--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -59,6 +59,9 @@
     </div>
 
 
+.. injection:: pass-sanitaire-qr-code-voyages.html#j-ai-eu-la-covid-apres-ma-vaccination-complete-comment-prolonger-mon-pass-sanitaire
+
+    
 .. question:: À partir de quand pourrai-je recevoir la dose de rappel, dite 3<sup>e</sup> dose ?
     :level: 3
 
@@ -84,9 +87,6 @@
 
 
 .. injection:: pass-sanitaire-qr-code-voyages.html#avant-quelle-date-dois-je-recevoir-la-dose-de-rappel-dite-3-e-dose-pour-conserver-mon-pass-sanitaire
-
-
-.. injection:: pass-sanitaire-qr-code-voyages.html#j-ai-eu-la-covid-apres-ma-vaccination-complete-comment-prolonger-mon-pass-sanitaire
 
 
 .. question:: Quels sont les facteurs de risque de formes graves de Covid ?


### PR DESCRIPTION
Peut-être que les utilisateurs verront mieux la question "J'ai eu la Covid après ma vaccination complète ..." si elle suit "J'ai eu la covid avant ma vaccination...". 
Par la même occasion ça pourrait réduire la décéption des utilisateurs qui ne trouvent pas cette information dans le questionnaire "à partir de quand pourrai-je recevoir la dose de rappel ...".