### PR TITLE
Complète et reformule la réponse sur le délai de primo-vaccination

### DIFF
--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -94,7 +94,7 @@
     Si vous avez reçu une **dose unique** de **vaccin Janssen**, il y a plusieurs cas possibles.
 
     - Si vous n’avez **pas eu la Covid**, ni avant ni après votre injection, alors :
-        - vous devrez recevoir une **dose supplémentaire** de vaccin à ARN messager (Pfizer ou Moderna, en dose complète) après un délai d’au moins **4 semaines**, afin de **compléter votre schéma vaccinal** ; cette 2<sup>e</sup> injection prolongera la validité de votre **pass sanitaire** ;
+        - vous devrez recevoir une **dose supplémentaire** de vaccin à ARN messager (Pfizer ou Moderna, en dose complète) **4 semaines** après votre injection, afin de **compléter votre schéma vaccinal** ; cette 2<sup>e</sup> injection prolongera la validité de votre **pass sanitaire** ;
 
         - **5 mois** après cette injection supplémentaire, vous serez éligible au **rappel vaccinal**, avec un vaccin Pfizer ou Moderna (demi-dose).
 
@@ -225,16 +225,20 @@
 
 .. question:: Quel est le délai à respecter entre la 1<sup>re</sup> et la 2<sup>e</sup> dose lors de la vaccination initiale (primo-vaccination) ?
     :level: 3
+    
+    Le délai avant la **2<sup>e</sup> injection** dépend du type de vaccin utilisé pour la première injection.
 
-    Pour les vaccins à ARN messager, la 2<sup>e</sup> injection doit être programmée :
-    * entre **21 et 49 jours** après la première, pour le vaccin **Pfizer** ;
-    * entre **28 et 49 jours** après la première, pour le vaccin **Moderna**.
-
-    Il faut donc respecter un délai de **3 à 7 semaines** après la première injection.
-
-    La Haute autorité de santé recommande de recevoir une 2<sup>e</sup> dose de vaccin ARNm (Pfizer-BioNTech ou Moderna) après une première dose de vaccin **AstraZeneca**, en respectant un délai d’au moins **4 semaines**.
-
-
+    * Si vous avez reçu une première dose de vaccin à **ARN messager** (Pfizer ou Moderna), il faut recevoir la **2<sup>e</sup> dose : 
+        * entre **21 et 49 jours** après la première, pour le vaccin **Pfizer** ;
+        * entre **28 et 49 jours** après la première, pour le vaccin **Moderna**.
+    Soit respecter un délai de **3 à 7 semaines**.
+        
+    * Si vous avez reçu une première dose de vaccin à **Janssen**, il faut recevoir la **2<sup>e</sup> dose :
+        * *28 jours** (4 semaines) après la première. Cette injection supplémentaire sera réalisée avec un **vaccin à ARN messager** (Pfizer ou Moderna).
+    
+    * Si vous avez reçu une première dose de vaccin AstraZeneca :  
+        * La Haute autorité de santé recommande de recevoir une 2<sup>e</sup> dose de vaccin ARNm (Pfizer-BioNTech ou Moderna), après un délai de **28 jours** (4 semaines).
+    
 .. question:: Quel vaccin choisir pour ma vaccination initiale (primo-vaccination) ?
     :level: 3
 

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -225,20 +225,18 @@
 
 .. question:: Quel est le délai à respecter entre la 1<sup>re</sup> et la 2<sup>e</sup> dose lors de la vaccination initiale (primo-vaccination) ?
     :level: 3
-    
+
     Le délai avant la **2<sup>e</sup> injection** dépend du type de vaccin utilisé pour la première injection.
 
-    * Si vous avez reçu une première dose de vaccin à **ARN messager** (Pfizer ou Moderna), il faut recevoir la **2<sup>e</sup> dose : 
-        * entre **21 et 49 jours** après la première, pour le vaccin **Pfizer** ;
-        * entre **28 et 49 jours** après la première, pour le vaccin **Moderna**.
-    Soit respecter un délai de **3 à 7 semaines**.
-        
-    * Si vous avez reçu une première dose de vaccin à **Janssen**, il faut recevoir la **2<sup>e</sup> dose :
-        * *28 jours** (4 semaines) après la première. Cette injection supplémentaire sera réalisée avec un **vaccin à ARN messager** (Pfizer ou Moderna).
-    
-    * Si vous avez reçu une première dose de vaccin AstraZeneca :  
-        * La Haute autorité de santé recommande de recevoir une 2<sup>e</sup> dose de vaccin ARNm (Pfizer-BioNTech ou Moderna), après un délai de **28 jours** (4 semaines).
-    
+    * Si vous avez reçu une première dose de vaccin à **ARN messager** (Pfizer ou Moderna), il faut recevoir la **2<sup>e</sup> dose** :
+        * **3 à 7 semaines** après la première, pour le vaccin **Pfizer** ;
+        * **4 à 7 semaines** après la première, pour le vaccin **Moderna**.
+
+    * Si vous avez reçu une première dose de vaccin **Janssen**, il faut recevoir une **dose supplémentaire** avec un **vaccin à ARN messager** (Pfizer ou Moderna) **4 semaines** après la première injection.
+
+    * Si vous avez reçu une première dose de vaccin **AstraZeneca**, la Haute autorité de santé recommande de recevoir une **2<sup>e</sup> dose** d’un **vaccin à ARN messager** (Pfizer ou Moderna), après un délai de **4 semaines**.
+
+
 .. question:: Quel vaccin choisir pour ma vaccination initiale (primo-vaccination) ?
     :level: 3
 


### PR DESCRIPTION
Reformule pour plus de clarté la question sur le délai à respecter entre la 1ère et 2ème dose et complète avec les informations sur le délai  avant l'injection supplémentaire pour les personnes vaccinées avec le vaccin Janssen. 

J'ai aussi corrigé le délai pour recevoir la 2e dose de vaccin ARN messager après 1 injection de Janssen : 4 semaines au lieu de "dès 4 semaines" (cf https://solidarites-sante.gouv.fr/IMG/pdf/dgs_urgent_125_campagne_de_vaccination_contre_le_covid-19.pdf).