### PR TITLE
Passe le délai d’éligibilité au rappel vaccinal à 4 mois

### DIFF
--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -107,7 +107,7 @@
 .. question:: J’ai eu la Covid après ma vaccination complète, comment prolonger mon pass sanitaire ?
     :level: 3
 
-    Si vous êtes âgé de 18 ans ou plus, alors vous serez éligible à une dose de rappel dès **5 mois** après votre **infection**.
+    Si vous êtes âgé de 18 ans ou plus, alors vous serez éligible à une dose de rappel dès **4 mois** après votre **infection**.
 
     En attendant de recevoir cette dose de rappel, vous pouvez utiliser le QR code de votre résultat de **test PCR ou antigénique positif** datant d’au moins 11 jours (aussi appelé *certificat de rétablissement*) comme pass sanitaire, valable pendant **6 mois**.
 

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -69,7 +69,7 @@
 
     * si vous avez été vacciné(e) avec le vaccin **Pfizer**, **Moderna** ou **AstraZeneca** :
 
-        - dès **5 mois** après votre dernière **injection**, ou votre dernière **infection** à la Covid ;
+        - dès **4 mois** après votre dernière **injection**, ou votre dernière **infection** à la Covid ;
 
         - dès **3 mois** après votre dernière injection de vaccin si vous êtes sévèrement **immunodéprimé(e)** (*4<sup>e</sup> dose*).
 
@@ -96,7 +96,7 @@
     - Si vous n’avez **pas eu la Covid**, ni avant ni après votre injection, alors :
         - vous devrez recevoir une **dose supplémentaire** de vaccin à ARN messager (Pfizer ou Moderna, en dose complète) **4 semaines** après votre injection, afin de **compléter votre schéma vaccinal** ; cette 2<sup>e</sup> injection prolongera la validité de votre **pass sanitaire** ;
 
-        - **5 mois** après cette injection supplémentaire, vous serez éligible au **rappel vaccinal**, avec un vaccin Pfizer ou Moderna (demi-dose).
+        - **4 mois** après cette injection supplémentaire, vous serez éligible au **rappel vaccinal**, avec un vaccin Pfizer ou Moderna (demi-dose).
 
     - Si vous **avez eu la Covid avant** votre injection, alors :
         - la dose supplémentaire n’est pas nécessaire ;
@@ -104,7 +104,7 @@
 
     - Si vous **avez eu la Covid après** votre injection, alors :
         - la dose supplémentaire n’est pas nécessaire ;
-        - vous serez éligible au **rappel vaccinal** avec le vaccin Pfizer ou Moderna (demi-dose) dès **5 mois** après votre infection ; ce rappel prolongera la validité de votre pass sanitaire.
+        - vous serez éligible au **rappel vaccinal** avec le vaccin Pfizer ou Moderna (demi-dose) dès **4 mois** après votre infection ; ce rappel prolongera la validité de votre pass sanitaire.
 
 
 .. injection:: pass-sanitaire-qr-code-voyages.html#avant-quelle-date-dois-je-recevoir-la-dose-de-rappel-dite-3-e-dose-pour-conserver-mon-pass-sanitaire
@@ -364,7 +364,7 @@
     * **une personne qui a déjà eu la Covid** avant sa première injection n’aura besoin que d’une seule dose de vaccin pour être complètement vaccinée (hors éventuel rappel) ;
     * **une personne fortement immunodéprimée** recevra une troisième dose de vaccin, 4 semaines après la deuxième, de façon à être protégée plus efficacement. Si vous êtes concerné(e) par ce cas de figure, nous vous conseillons de prendre contact avec votre médecin traitant. L’assurance maladie prendra directement contact avec les personnes concernées dont elle a connaissance pour organiser ce rendez-vous. Pour plus d’informations à ce sujet, consultez [la page dédiée sur ameli.fr](https://www.ameli.fr/hauts-de-seine/etablissement/actualites/vaccin-contre-la-covid-19-une-3e-injection-recommandee-pour-les-personnes-immunodeprimees).
 
-    L’immunité conférée par la vaccination initiale diminue avec le temps. C’est pourquoi une **dose de rappel** est maintenant recommandée **après 5 mois** pour toutes les personnes de 18 ans et plus (voir « [Suis-je concerné par la dose de rappel, dite 3e dose ?](#suis-je-concerne-par-la-dose-de-rappel-dite-3-e-dose) »).
+    L’immunité conférée par la vaccination initiale diminue avec le temps. C’est pourquoi une **dose de rappel** est maintenant recommandée **après 4 mois** pour toutes les personnes de 18 ans et plus (voir « [Suis-je concerné par la dose de rappel, dite 3e dose ?](#suis-je-concerne-par-la-dose-de-rappel-dite-3-e-dose) »).
 
 
 .. question:: Est-ce que je peux attraper la Covid si je suis vacciné(e) ?

--- a/src/scripts/page/thematiques/prolongationPassSanitaire.js
+++ b/src/scripts/page/thematiques/prolongationPassSanitaire.js
@@ -25,7 +25,7 @@ import { Formulaire } from './formulaire'
 // par mois, puis d’arrondir à l’entier supérieur.
 const JOURS_DANS_1_MOIS = 31
 const JOURS_DANS_2_MOIS = 61
-const JOURS_DANS_5_MOIS = 153
+const JOURS_DANS_4_MOIS = 122
 const JOURS_DANS_7_MOIS = 214
 
 export function dynamiseLaProlongationDuPass(prefixe) {
@@ -164,7 +164,7 @@ class FormulaireProlongationPassSanitaire extends Formulaire {
                     // À partir de quelle date faire le rappel ?
                     const delaiEligibiliteEnJours = this.janssen
                         ? JOURS_DANS_1_MOIS
-                        : JOURS_DANS_5_MOIS
+                        : JOURS_DANS_4_MOIS
                     const dateEligibiliteRappel = dayjs.max(
                         debutCampagneRappel,
                         dateDerniereDose.add(delaiEligibiliteEnJours, 'day')

--- a/src/scripts/tests/integration/test.rappel.js
+++ b/src/scripts/tests/integration/test.rappel.js
@@ -99,8 +99,8 @@ describe('Mini-questionnaire dose de rappel', function () {
             assert.include(statut, 'Votre dernière injection date du 17 avril 2021.')
             assert.include(
                 statut,
-                'Vous pourrez recevoir votre dose de rappel à partir du 17 septembre 2021.'
-            )
+                'Vous pourrez recevoir votre dose de rappel à partir du 1 septembre 2021.'
+            ) // début de la campagne de rappel
             assert.include(
                 statut,
                 'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 15 décembre 2021.'
@@ -124,7 +124,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             assert.include(statut, 'Votre dernière injection date du 17 mai 2021.')
             assert.include(
                 statut,
-                'Vous pourrez recevoir votre dose de rappel à partir du 17 octobre 2021.'
+                'Vous pourrez recevoir votre dose de rappel à partir du 16 septembre 2021.'
             )
             assert.include(
                 statut,
@@ -149,7 +149,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             assert.include(statut, 'Votre dernière injection date du 17 juin 2021.')
             assert.include(
                 statut,
-                'Vous pourrez recevoir votre dose de rappel à partir du 17 novembre 2021.'
+                'Vous pourrez recevoir votre dose de rappel à partir du 17 octobre 2021.'
             )
             assert.include(
                 statut,
@@ -174,7 +174,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             assert.include(statut, 'Votre dernière injection date du 17 juillet 2021.')
             assert.include(
                 statut,
-                'Vous pourrez recevoir votre dose de rappel à partir du 17 décembre 2021.'
+                'Vous pourrez recevoir votre dose de rappel à partir du 16 novembre 2021.'
             )
             assert.include(
                 statut,
@@ -252,7 +252,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             assert.include(
                 statut,
                 'Vous pourrez recevoir votre dose de rappel à partir du 27 novembre 2021.'
-            )
+            ) // début de la campagne de rappel pour les moins de 65 ans
             assert.include(
                 statut,
                 'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 15 janvier 2022.'
@@ -276,7 +276,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             assert.include(
                 statut,
                 'Vous pourrez recevoir votre dose de rappel à partir du 27 novembre 2021.'
-            )
+            ) // début de la campagne de rappel pour les moins de 65 ans
             assert.include(
                 statut,
                 'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 17 janvier 2022.'
@@ -299,11 +299,35 @@ describe('Mini-questionnaire dose de rappel', function () {
             assert.include(statut, 'Votre dernière injection date du 17 juillet 2021.')
             assert.include(
                 statut,
+                'Vous pourrez recevoir votre dose de rappel à partir du 27 novembre 2021.'
+            ) // début de la campagne de rappel pour les moins de 65 ans
+            assert.include(
+                statut,
+                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 16 février 2022.'
+            )
+        })
+        it('18 à 65 ans, 17 août', async function () {
+            const questionnaire = new Questionnaire(
+                this.test.page,
+                'pass-sanitaire-qr-code-voyages.html',
+                'avant-quelle-date-dois-je-recevoir-la-dose-de-rappel-dite-3-e-dose-pour-conserver-mon-pass-sanitaire'
+            )
+            await questionnaire.cEstParti()
+            await questionnaire.remplirAge('moins65')
+            await questionnaire.remplirVaccinationInitiale('autre')
+            await questionnaire.remplirDateDerniereDose('2021-08-17')
+
+            const statut = await questionnaire.recuperationStatut('rappel-et-pass')
+            assert.include(statut, 'Vous avez entre 18 et 64 ans')
+            assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
+            assert.include(statut, 'Votre dernière injection date du 17 août 2021.')
+            assert.include(
+                statut,
                 'Vous pourrez recevoir votre dose de rappel à partir du 17 décembre 2021.'
             )
             assert.include(
                 statut,
-                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 16 février 2022.'
+                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 19 mars 2022.'
             )
         })
     })
@@ -327,7 +351,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             assert.include(statut, 'Votre dernière injection date du 17 mai 2021.')
             assert.include(
                 statut,
-                'Vous pourrez recevoir votre dose de rappel à partir du 17 octobre 2021.'
+                'Vous pourrez recevoir votre dose de rappel à partir du 16 septembre 2021.'
             )
             assert.include(
                 statut,
@@ -352,7 +376,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             assert.include(statut, 'Votre dernière injection date du 17 juin 2021.')
             assert.include(
                 statut,
-                'Vous pourrez recevoir votre dose de rappel à partir du 17 novembre 2021.'
+                'Vous pourrez recevoir votre dose de rappel à partir du 17 octobre 2021.'
             )
             assert.include(
                 statut,
@@ -377,7 +401,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             assert.include(statut, 'Votre dernière injection date du 17 juin 2021.')
             assert.include(
                 statut,
-                'Vous pourrez recevoir votre dose de rappel à partir du 17 novembre 2021.'
+                'Vous pourrez recevoir votre dose de rappel à partir du 17 octobre 2021.'
             )
             assert.include(
                 statut,


### PR DESCRIPTION
Source : https://solidarites-sante.gouv.fr/IMG/pdf/dgs-urgent_135_raccourcissement_rappels_4_mois-2.pdf