### PR TITLE
Renomme la page « mineurs » en « enfants et adolescents »

### DIFF
--- a/contenus/conseils/conseils_activité_pro_santé.md
+++ b/contenus/conseils/conseils_activité_pro_santé.md
@@ -2,7 +2,7 @@
     * la protection des [professionnels **de santé**](https://solidarites-sante.gouv.fr/soins-et-maladies/maladies/maladies-infectieuses/coronavirus/professionnels-de-sante/distrilog-sante),
     * la protection des [professionnels **du médico-social**](https://solidarites-sante.gouv.fr/soins-et-maladies/maladies/maladies-infectieuses/coronavirus/professionnels-du-social-et-medico-social/),
     * les [aides logistiques et psychologiques](https://solidarites-sante.gouv.fr/soins-et-maladies/maladies/maladies-infectieuses/coronavirus/professionnels-de-sante/article/aides-logistiques-et-psychologiques-aux-professionnels) pour tous les professionnels de santé.
-* Nos [conseils pour les mineurs](/conseils-pour-les-enfants.html), si vous travaillez auprès d’enfants et/ou devez conseiller des parents.
+* Nos [conseils pour les enfants et adolescents](/conseils-pour-les-enfants.html), si vous travaillez auprès de mineurs et/ou devez conseiller des parents.
 * [L’espace dédié pour les professionnels](https://www.gouvernement.fr/info-coronavirus/espace-pour-les-professionnels) sur le site du gouvernement.
 
 Vous êtes disponible et vous souhaitez vous porter volontaire ? Inscrivez-vous sur la [plateforme Renfort-RH](https://renfortrh.solidarites-sante.gouv.fr/).

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -190,7 +190,7 @@
 
     <div class="voir-aussi">
 
-    - Consultez notre [page de conseils pour les mineurs](/conseils-pour-les-enfants.html) pour plus d’informations sur leur vaccination et sur le protocole sanitaire dans les établissements scolaires.
+    - Consultez notre page de [conseils pour les enfants et adolescents](/conseils-pour-les-enfants.html) pour plus d’informations sur leur vaccination et sur le protocole sanitaire dans les établissements scolaires.
 
     </div>
 
@@ -216,7 +216,7 @@
 
     <div class="voir-aussi">
 
-    - Consultez notre page « [Conseils pour les mineurs : vaccination et scolarité](/conseils-pour-les-enfants.html) ».
+    - Consultez notre page « [Enfants et adolescents : vaccination et scolarité](/conseils-pour-les-enfants.html) ».
 
     - Consultez notre page « [Je souhaite me faire vacciner, que faut-il savoir ?](/je-veux-me-faire-vacciner.html) ».
 

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -223,7 +223,7 @@
 
  <div class="voir-aussi">
 
-- [Je veux des informations sur la vaccination des mineurs](/conseils-pour-les-enfants.html#la-vaccination-contre-la-covid)
+- [Je veux des informations sur la vaccination des enfants et adolescents](/conseils-pour-les-enfants.html#la-vaccination-contre-la-covid)
 
  </div>
 

--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -105,7 +105,7 @@ Même si vous ne présentez pas de symptômes, faites un **test de dépistage** 
     - **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal) ;
     - portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
 
-Si vous devez **garder votre enfant** positif à la Covid mais que vous ne pouvez pas télétravailler, vous pouvez bénéficier du **chômage partiel**. Pour plus d’information sur la démarche, consultez notre [page dédiée aux conseils pour les mineurs](/conseils-pour-les-enfants.html#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid).
+Si vous devez **garder votre enfant** positif à la Covid mais que vous ne pouvez pas télétravailler, vous pouvez bénéficier du **chômage partiel**. Pour plus d’information sur la démarche, consultez notre page dédiée aux [conseils pour les enfants et adolescents](/conseils-pour-les-enfants.html#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid).
 
 #### 2. Faites 2 autotests après la guérison ou la fin d’isolement de la personne positive
 

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -1,4 +1,4 @@
-# Conseils pour les mineurs : vaccination et scolarité
+# Enfants et adolescents : vaccination et scolarité
 
 <img src="illustrations/pediatriegeneral.svg">
 
@@ -256,7 +256,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     <div class="voir-aussi">
 
-    - Notre rubrique sur la [vaccination des mineurs de plus de 12 ans](#la-vaccination-contre-la-covid) ci-dessous
+    - Notre rubrique sur la [vaccination des enfants et adolescents](#la-vaccination-contre-la-covid) ci-dessous
 
     - Notre autre page sur le [pass sanitaire](/pass-sanitaire-qr-code-voyages.html)
 

--- a/contenus/thematiques/9-covid-et-travail.md
+++ b/contenus/thematiques/9-covid-et-travail.md
@@ -202,10 +202,8 @@
     **Non**. Si vous avez eu la Covid et que vous avez respecté la durée de votre isolement (10 jours au moins après le début de vos symptômes ou de votre test positif et que vous ne présentez plus de fièvre), alors vous pouvez retourner au travail sans présenter de certificat ou de nouveau test de dépistage.
 
 
-.. question:: Je ne peux pas télétravailler, puis-je obtenir un arrêt de travail pour garder mon enfant qui ne peut pas aller à l’école à cause de la Covid ?
+.. renvoi:: conseils-pour-les-enfants.html#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid
     :level: 3
-
-    [Consulter la réponse sur notre page dédiée aux conseils pour les mineurs](/conseils-pour-les-enfants.html#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid)
 
 
 .. question:: Quel dispositif est prévu pour les personnes particulièrement vulnérables à la Covid et qui ne peuvent pas télétravailler ?

--- a/src/scripts/tests/integration/test.pages.js
+++ b/src/scripts/tests/integration/test.pages.js
@@ -64,7 +64,7 @@ describe('Pages', function () {
 
         assert.equal(
             await page.title(),
-            'Conseils pour les mineurs : vaccination et scolarité — Mes Conseils Covid'
+            'Enfants et adolescents : vaccination et scolarité — Mes Conseils Covid'
         )
     })
 

--- a/src/scripts/tests/integration/test.thematiques.js
+++ b/src/scripts/tests/integration/test.thematiques.js
@@ -9,7 +9,7 @@ describe('Thématiques', function () {
 
         assert.equal(
             await page.title(),
-            'Conseils pour les mineurs : vaccination et scolarité — Mes Conseils Covid'
+            'Enfants et adolescents : vaccination et scolarité — Mes Conseils Covid'
         )
     })
 


### PR DESCRIPTION
Pour la rendre plus identifiable (suite à suggestion dans #1921)