### PR TITLE
La date de référence pour les autotests est maintenant celle du test immédiat

### DIFF
--- a/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_sans_depistage_vaccine.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_sans_depistage_vaccine.md
@@ -8,7 +8,7 @@ Nous vous conseillons de :
         + **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal) ;
         + portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
 
-1. Faire **2 autotests de contrôle** (délivrés **gratuitement** en pharmacie) au **2<sup>e</sup> jour** et au **4<sup>e</sup> jour** suivant la guérison ou la fin d’isolement de la personne positive.
+1. Faire **2 autotests de contrôle** (délivrés **gratuitement** en pharmacie) au **2<sup>e</sup> jour** et au **4<sup>e</sup> jour** après la date du **premier test**.
     * Si les résultats de ces deux autotests sont **négatifs** : vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale.
     * Si le résultat d’un de ces autotests est **positif** :
         - faites un **test antigénique ou PCR** pour **confirmer** ce résultat positif et restez isolé(e) en attendant ;

--- a/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_vaccine.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_vaccine.md
@@ -6,7 +6,7 @@ Il n’est **pas nécessaire de vous isoler** mais vous devez :
     * **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal) ;
     * portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
 
-1. Faire **2 autotests de contrôle** (délivrés **gratuitement** en pharmacie) au **2<sup>e</sup> jour** et au **4<sup>e</sup> jour** suivant la guérison ou la fin d’isolement de la personne positive.
+1. Faire **2 autotests de contrôle** (délivrés **gratuitement** en pharmacie) au **2<sup>e</sup> jour** et au **4<sup>e</sup> jour** après la date du **premier test**.
     * Si les résultats de ces deux autotests sont **négatifs** : vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale.
     * Si le résultat d’un de ces autotests est **positif** :
         - faites un **test antigénique ou PCR** pour **confirmer** ce résultat positif et restez isolé(e) en attendant ;

--- a/contenus/conseils/conseils_personnels_contact_à_risque_vaccine.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_vaccine.md
@@ -9,7 +9,7 @@ Nous vous conseillons de :
         + **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal) ;
         + portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
 
-1. Faire **2 autotests de contrôle**, 2 jours après et 4 jours après le **dernier contact** avec la personne positive.
+1. Faire **2 autotests de contrôle**, 2 jours après et 4 jours après la date du **premier test**.
     * Si les résultats de ces deux autotests sont **négatifs** : vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale.
     * Si le résultat d’un de ces autotests est **positif** :
         - faites un **test antigénique ou PCR** pour **confirmer** ce résultat positif et restez isolé(e) en attendant ;

--- a/contenus/statuts/statut_contact_a_risque_meme_lieu_de_vie_sans_depistage_vaccine.md
+++ b/contenus/statuts/statut_contact_a_risque_meme_lieu_de_vie_sans_depistage_vaccine.md
@@ -1,1 +1,1 @@
-Si vous ne l’avez pas déjà fait, faites un **test de dépistage** (PCR ou antigénique) **dès que possible**, puis **2 autotests de contrôle** au 2<sup>e</sup> jour et au 4<sup>e</sup> jour après la guérison ou la fin d’isolement de la personne positive.
+Si vous ne l’avez pas déjà fait, faites un **test de dépistage** (PCR ou antigénique) **dès que possible**, puis **2 autotests de contrôle** au 2<sup>e</sup> jour et au 4<sup>e</sup> jour après la date du **premier test**.

--- a/contenus/statuts/statut_contact_a_risque_meme_lieu_de_vie_vaccine.md
+++ b/contenus/statuts/statut_contact_a_risque_meme_lieu_de_vie_vaccine.md
@@ -1,1 +1,1 @@
-Faites **2 autotests de contrôle** au 2<sup>e</sup> jour et au 4<sup>e</sup> jour après la guérison ou la fin d’isolement de la personne positive.
+Faites **2 autotests de contrôle** au 2<sup>e</sup> jour et au 4<sup>e</sup> jour après la date du **premier test**.

--- a/contenus/thematiques/1-cas-contact-a-risque.md
+++ b/contenus/thematiques/1-cas-contact-a-risque.md
@@ -57,8 +57,8 @@ Le test est toujours **gratuit** quand vous êtes cas contact.
 
 ##### Si le test est négatif 👇
 
-* vous devrez faire **deux autotests** de contrôle (voir plus bas) :
-    - **2 jours** après et **4 jours** après le **dernier contact** avec la personne positive,
+* vous devrez faire **2 autotests** de contrôle (voir plus bas) :
+    - **2 jours** après et **4 jours** après la date du **premier test**,
     - ces autotests vous seront délivrés **gratuitement** en pharmacie ;
 * comme vous êtes complètement vacciné(e), on considère que vous avez un **risque modéré**, et qu’il n’est **pas nécessaire de vous isoler** ;
 * en attendant, restez quand même prudent(e) :
@@ -82,10 +82,9 @@ Le test est toujours **gratuit** quand vous êtes cas contact.
 
 <div class="conseil">
 
-Si votre premier test était **négatif**, vous devrez faire **2 autotests de contrôle**, qui vous seront délivrés **gratuitement** en pharmacie :
-
-* le premier : **2 jours** après votre **dernier contact** avec la personne positive (après sa guérison ou la fin de son isolement si vous habitez avec elle) ;
-* le deuxième : **4 jours** après ce dernier contact.
+Si votre premier test était **négatif**, vous devrez faire **2 autotests** de contrôle :
+    - **2 jours** après et **4 jours** après la date du **premier test**,
+    - ces autotests vous seront délivrés **gratuitement** en pharmacie.
 
 </div>
 

--- a/contenus/thematiques/4-je-suis-vaccine.md
+++ b/contenus/thematiques/4-je-suis-vaccine.md
@@ -39,7 +39,7 @@
             * **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal) ;
             * portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
 
-    1. Faites **2 autotests de contrôle**, 2 jours après et 4 jours après le **dernier contact** avec la personne positive (après sa guérison ou la fin de son isolement si vous habitez avec elle).
+    1. Faites **2 autotests de contrôle**, 2 jours après et 4 jours après la date du **premier test**.
         - Si les résultats de ces deux autotests sont **négatifs** : vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale.
         - Si le résultat d’un de ces autotests est **positif** :
             + faites un **test antigénique ou PCR** pour **confirmer** ce résultat positif et restez isolé(e) en attendant ;

--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -107,11 +107,11 @@ Même si vous ne présentez pas de symptômes, faites un **test de dépistage** 
 
 Si vous devez **garder votre enfant** positif à la Covid mais que vous ne pouvez pas télétravailler, vous pouvez bénéficier du **chômage partiel**. Pour plus d’information sur la démarche, consultez notre page dédiée aux [conseils pour les enfants et adolescents](/conseils-pour-les-enfants.html#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid).
 
-#### 2. Faites 2 autotests après la guérison ou la fin d’isolement de la personne positive
+#### 2. Faites 2 autotests à J+2 et J+4
 
 <div class="conseil">
 
-Si votre premier test était **négatif**, vous devrez faire **2 autotests de contrôle** (délivrés **gratuitement** en pharmacie) au **2<sup>e</sup> jour** et au **4<sup>e</sup> jour** suivant la guérison ou la fin d’isolement de la personne positive.
+Si votre premier test était **négatif**, vous devrez faire **2 autotests de contrôle** (délivrés **gratuitement** en pharmacie) au **2<sup>e</sup> jour** et au **4<sup>e</sup> jour** après la date du **premier test**.
 
 </div>
 

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -45,7 +45,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
     * Pour les élèves de **moins de 12 ans** (quel que soit leur statut vaccinal), lorsqu’**un cas positif** est confirmé dans la classe :
 
       * les élèves seront invités à réaliser au plus tôt un **test de dépistage** gratuit (test PCR nasopharyngé, PCR salivaire, ou antigénique nasopharyngé) : si le résultat du test est **négatif**, ils pourront poursuivre les enseignements en **présentiel** ;
-      * ils devront ensuite réaliser à la maison **2 autotests** (délivrés **gratuitement** en pharmacie) **2 jours** après et **4 jours** après leur **dernier contact** avec la personne positive (en cas de difficultés pour obtenir des autotests, la surveillance peut aussi se faire par test antigénique ou PCR).
+      * ils devront ensuite réaliser à la maison **2 autotests** (délivrés **gratuitement** en pharmacie) **2 jours** après et **4 jours** après la date du **premier test** (en cas de difficultés pour obtenir des autotests, la surveillance peut aussi se faire par test antigénique ou PCR).
 
         *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, votre enfant n’aura pas à recommencer ce parcours de trois tests.*
 
@@ -53,7 +53,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
       * s’ils sont **complètement vaccinés** :
         - ils seront invités à réaliser au plus tôt un **test de dépistage** gratuit (test PCR nasopharyngé, PCR salivaire, ou antigénique nasopharyngé) : si le résultat du test est **négatif**, ils pourront poursuivre les enseignements en **présentiel**,
-        - ils devront ensuite réaliser à la maison **2 autotests** (délivrés **gratuitement** en pharmacie) **2 jours** après et **4 jours** après leur **dernier contact** avec la personne positive (en cas de difficultés pour obtenir des autotests, la surveillance peut aussi se faire par test antigénique ou PCR).
+        - ils devront ensuite réaliser à la maison **2 autotests** (délivrés **gratuitement** en pharmacie) **2 jours** après et **4 jours** après la date du **premier test** (en cas de difficultés pour obtenir des autotests, la surveillance peut aussi se faire par test antigénique ou PCR).
 
           *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, votre enfant n’aura pas à recommencer ce parcours de trois tests.*
 
@@ -104,10 +104,9 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     #### 3. Autotests de contrôle
 
-    Si le 1<sup>er</sup> test de votre enfant était négatif, alors il devra faire **2 autotests** de contrôle (délivrés **gratuitement** en pharmacie) :
-
-    - **2 jours après** son **dernier contact** avec la personne positive, pour vérifier qu’il ou elle n’a pas été contaminé(e) ;
-    - **4 jours après** son **dernier contact** avec la personne positive, pour confirmer qu’il ou elle n’a pas été contaminé(e).
+    Si le 1<sup>er</sup> test de votre enfant était négatif, alors il devra faire **2 autotests** de contrôle :
+    - **2 jours** après et **4 jours** après la date du **premier test**,
+    - ces autotests vous seront délivrés **gratuitement** en pharmacie.
 
     En cas de difficultés pour obtenir des autotests, la surveillance peut aussi se faire par test antigénique ou PCR.
 
@@ -155,10 +154,9 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     #### 3. Autotests de contrôle
 
-    Si le 1<sup>er</sup> test de votre enfant était négatif, alors il devra faire **2 autotests** de contrôle (délivrés **gratuitement** en pharmacie) :
-
-    - **2 jours après** son **dernier contact** avec la personne positive, pour vérifier qu’il ou elle n’a pas été contaminé(e) ;
-    - **4 jours après** son **dernier contact** avec la personne positive, pour confirmer qu’il ou elle n’a pas été contaminé(e).
+    Si le 1<sup>er</sup> test de votre enfant était négatif, alors il devra faire **2 autotests** de contrôle :
+    - **2 jours** après et **4 jours** après la date du **premier test**,
+    - ces autotests vous seront délivrés **gratuitement** en pharmacie.
 
     En cas de difficultés pour obtenir des autotests, la surveillance peut aussi se faire par test antigénique ou PCR.
 


### PR DESCRIPTION
Dans la version précédente de la doctrine, c’était celle du dernier contact avec la personne positive.

Le cas où l’on partage le foyer de la personne positive n’est pas traité différemment.

Source : https://solidarites-sante.gouv.fr/IMG/pdf/reply_dgs_urgent_01_doctrines_isolement_et_40n.pdf