### PR TITLE
Levée d’isolement au 5e jour après TAG- pour personnes vaccinées

### DIFF
--- a/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_sans_depistage_vaccine.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_sans_depistage_vaccine.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. Faire un **test de dépistage gratuit** (test PCR ou antigénique) **dès que possible** (voir la <a href="https://www.sante.fr/cf/centres-depistage-covid.html">carte des lieux de test</a>).
-    * Si le test est **positif** : isolez-vous pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+    * Si le test est **positif** : isolez-vous pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
     * Si le test est **négatif**, il ne sera **pas nécessaire de vous isoler**, mais restez prudent(e) :
         + respectez les **mesures barrières** au sein de votre foyer ;
         + ayez recours au **télétravail** lorsque c’est possible ;
@@ -12,7 +12,7 @@ Nous vous conseillons de :
     * Si les résultats de ces deux autotests sont **négatifs** : vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale.
     * Si le résultat d’un de ces autotests est **positif** :
         - faites un **test antigénique ou PCR** pour **confirmer** ce résultat positif et restez isolé(e) en attendant ;
-        - si le résultat positif à l’autotest est **confirmé** : maintenez votre isolement pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+        - si le résultat positif à l’autotest est **confirmé** : maintenez votre isolement pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 1. Si vous constatez l’apparition de **symptômes** :
     * Contacter votre médecin et faire un **test de dépistage gratuit** (test PCR ou antigénique) dès que possible.
     * Ne pas prendre d’**anti-inflammatoires** (ibuprofène ou kétoprofène) sans avis médical. Les anti-inflammatoires pourraient **aggraver** l’infection à la Covid. Seul le **paracétamol** est recommandé. En cas de doute, demandez conseil à votre médecin.

--- a/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_vaccine.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie_vaccine.md
@@ -12,7 +12,7 @@ Il n’est **pas nécessaire de vous isoler** mais vous devez :
         - faites un **test antigénique ou PCR** pour **confirmer** ce résultat positif et restez isolé(e) en attendant ;
         - si le résultat positif à l’autotest est **confirmé** :
             * maintenez votre isolement pour une durée de **7 jours** ;
-            * vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+            * vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 1. Si vous constatez l’apparition de **symptômes** :
     * Contacter votre médecin et faire un **test de dépistage gratuit** (test PCR ou antigénique) dès que possible.
     * Ne pas prendre d’**anti-inflammatoires** (ibuprofène ou kétoprofène) sans avis médical. Les anti-inflammatoires pourraient **aggraver** l’infection à la Covid. Seul le **paracétamol** est recommandé. En cas de doute, demandez conseil à votre médecin.

--- a/contenus/conseils/conseils_personnels_contact_à_risque_vaccine.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_vaccine.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
 1. Si ce n’est pas déjà le cas, faire un **test de dépistage gratuit** (test PCR ou antigénique) **dès que possible** (voir la <a href="https://www.sante.fr/cf/centres-depistage-covid.html">carte des lieux de test</a>).
-    * Si le test est **positif** : isolez-vous pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+    * Si le test est **positif** : isolez-vous pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 
     * Si le test est **négatif**, il n’est **pas nécessaire de vous isoler**, mais restez prudent(e) :
         + respectez les **mesures barrières** au sein de votre foyer ;
@@ -13,7 +13,7 @@ Nous vous conseillons de :
     * Si les résultats de ces deux autotests sont **négatifs** : vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale.
     * Si le résultat d’un de ces autotests est **positif** :
         - faites un **test antigénique ou PCR** pour **confirmer** ce résultat positif et restez isolé(e) en attendant ;
-        - si le résultat positif à l’autotest est **confirmé** : maintenez votre isolement pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+        - si le résultat positif à l’autotest est **confirmé** : maintenez votre isolement pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 
 1. Les autres **membres de votre foyer** sont « cas contact d’un cas contact », et n’ont pas à s’isoler ou à faire de test. Si le résultat de votre test est positif, ils deviendront **cas contact** à leur tour.
 

--- a/contenus/thematiques/4-je-suis-vaccine.md
+++ b/contenus/thematiques/4-je-suis-vaccine.md
@@ -31,7 +31,7 @@
     Si vous êtes vacciné(e), en cas de contact à risque avec une personne positive à la Covid :
 
     1. Faites un **test de dépistage gratuit** (test PCR ou antigénique) **dès que possible** (voir la <a href="https://www.sante.fr/cf/centres-depistage-covid.html">carte des lieux de test</a>).
-        * Si le test est **positif** : isolez-vous pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+        * Si le test est **positif** : isolez-vous pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 
         * Si le test est **négatif**, il n’est **pas nécessaire de vous isoler**, mais restez prudent(e) :
             * respectez les **mesures barrières** au sein de votre foyer ;
@@ -43,7 +43,7 @@
         - Si les résultats de ces deux autotests sont **négatifs** : vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale.
         - Si le résultat d’un de ces autotests est **positif** :
             + faites un **test antigénique ou PCR** pour **confirmer** ce résultat positif et restez isolé(e) en attendant ;
-            + si le résultat positif à l’autotest est **confirmé** : maintenez votre isolement pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+            + si le résultat positif à l’autotest est **confirmé** : maintenez votre isolement pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 
     <div class="voir-aussi">
 

--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -97,7 +97,7 @@ Même si vous ne présentez pas de symptômes, faites un **test de dépistage** 
 
 * Si le test est **positif** :
     - isolez-vous pour une durée de **7 jours** ;
-    - vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+    - vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 
 * Si le test est **négatif**, il n’est **pas nécessaire de vous isoler**, mais restez prudent(e) :
     - respectez les **mesures barrières** au sein de votre foyer ;
@@ -122,7 +122,7 @@ Si votre premier test était **négatif**, vous devrez faire **2 autotests de co
 
     - si le résultat positif à l’autotest est **confirmé** :
         + maintenez votre isolement pour une durée de **7 jours** ;
-        + vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+        + vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 
 <div class="conseil conseil-jaune">
 


### PR DESCRIPTION
Source : https://solidarites-sante.gouv.fr/IMG/pdf/reply_dgs_urgent_01_doctrines_isolement_et_40n.pdf