### PR TITLE
Reprend la doctrine cas contact à la lettre pour les non vaccinés

### DIFF
--- a/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie.md
+++ b/contenus/conseils/conseils_personnels_contact_à_risque_meme_lieu_de_vie.md
@@ -2,7 +2,7 @@ Nous vous conseillons de :
 
 1. Vous maintenir **en isolement**.
 1. Mettre en place des **mesures d’hygiène renforcée** dans votre foyer (voir la section **Isolement** plus bas).
-1. Faire un **test de dépistage gratuit** (test PCR ou antigénique) **7 jours** après la guérison ou la fin d’isolement de la personne positive :
+1. Faire un **test de dépistage gratuit** (test PCR ou antigénique) **7 jours** après le dernier contact avec la personne positive :
     * Si le test est **négatif**, vous pourrez lever votre isolement ;
     * Si le test est **positif** : maintenez votre isolement pour une durée de **10 jours** ; vous pourrez lever l’isolement **dès le 7<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 1. Si vous constatez l’apparition de **symptômes** :

--- a/contenus/statuts/statut_contact_a_risque_meme_lieu_de_vie.md
+++ b/contenus/statuts/statut_contact_a_risque_meme_lieu_de_vie.md
@@ -1,1 +1,1 @@
-Restez **en isolement**, puis **faites un test** 7 jours après la guérison ou la fin d’isolement de la personne positive.
+Restez **en isolement**, puis **faites un test** 7 jours après le dernier contact avec la personne positive.

--- a/contenus/thematiques/1-cas-contact-a-risque.md
+++ b/contenus/thematiques/1-cas-contact-a-risque.md
@@ -149,7 +149,7 @@ Si vous ne pouvez pas **télétravailler**, vous pouvez [**demander un arrêt de
 
 Vous devez faire un test de dépistage (PCR ou antigénique)  gratuit :
 
-* **7 jours** après votre **dernier contact** avec la personne positive (après sa guérison ou la fin de son isolement si vous habitez avec elle) ;
+* **7 jours** après votre **dernier contact** avec la personne positive ;
 * ou **dès que possible** en cas d’apparition de symptômes évocateurs de la Covid.
 
 NB : le test est **toujours gratuit** quand vous êtes cas contact.

--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -39,18 +39,18 @@
 
 <div class="conseil">
 
-Il faut **vous isoler dès maintenant**, et ce jusqu’au **7<sup>e</sup> jour** suivant la guérison ou la fin d’isolement de la personne positive.
+Il faut **vous isoler dès maintenant**, et ce jusqu’au **7<sup>e</sup> jour** suivant votre dernier contact avec la personne positive.
 
 </div>
 
 Si vous ne pouvez pas **télétravailler**, l’Assurance Maladie pourra vous prescrire un arrêt de travail. Pour plus d’information, rendez-vous sur [declare.ameli.fr](https://declare.ameli.fr/).
 
 
-#### 2. Faites un test 7 jours après la guérison ou la fin d’isolement de la personne positive
+#### 2. Faites un test 7 jours après votre dernier contact avec la personne positive
 
 <div class="conseil">
 
-- Faites un **test de dépistage gratuit** (test PCR ou antigénique) au **7<sup>e</sup> jour** suivant la guérison ou la fin d’isolement de la personne positive.
+- Faites un **test de dépistage gratuit** (test PCR ou antigénique) au **7<sup>e</sup> jour** suivant votre dernier contact avec la personne positive.
 
 - Si des **symptômes** se déclarent avant cette date, faites-vous tester sans attendre.
 

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -210,10 +210,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     #### 3. Test de contrôle
 
-    Si le 1<sup>er</sup> test de votre enfant était négatif, alors il devra faire un **test de contrôle** (PCR ou antigénique) avant de retourner à l’école :
-
-    - **7 jours** après son **dernier contact** avec la personne positive, pour confirmer qu’il ou elle n’a pas été contaminé(e) ;
-    - ou **7 jours** après la guérison ou la fin d’isolement de la personne positive, s’il est en en contact régulier avec elle.
+    Si le 1<sup>er</sup> test de votre enfant était négatif, alors il devra faire un **test de contrôle** (PCR ou antigénique) **7 jours** après son **dernier contact** avec la personne positive avant de pouvoir retourner à l’école.
 
     <div class="voir-aussi">
 


### PR DESCRIPTION
Précédemment, une partie de la doctrine traitait spécifiquement de la conduite à tenir en cas de contact à risque avec une personne du même foyer. L’approche était que dans ce contexte, le dernier contact à risque, et donc le point de départ pour les 7 jours d’isolement, était le moment de la guérison ou de la fin d’isolement de la personne positive, reconnaissant la difficulté pour beaucoup de gens de s’isoler complètement au sein du foyer, par exemple si un enfant en bas âge est malade.

La nouvelle doctrine s’en tient à la phrase générale « après la date du dernier contact avec le cas » et ne précise plus la conduite spécifique à tenir ou la manière d’interpréter la consigne dans le cas où l’on partage le foyer.

Par soucis de cohérence, et notamment pour éviter de donner une interprétation qui serait différente de celle de l’Assurance maladie, on s’en tiendra à la lettre de la consigne, en regrettant de ne pouvoir être plus précis et en espérant une future clarification officielle sur cette question.

Source : https://solidarites-sante.gouv.fr/IMG/pdf/20220102_-_dgs-urgent_01-doctrines-isolement40n.pdf