### PR TITLE
Au 15 février, la validité du pass sans rappel passe à 4 mois

### DIFF
--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -86,13 +86,16 @@
 
     {{ formulaire('rappel', 'date-limite-pass') }}
 
-    - À partir du **15 décembre 2021** :
+    - Depuis le **15 décembre 2021** :
         * si vous avez **65 ans ou plus** et que votre dernière **injection** (ou votre dernière **infection** à la Covid) date de plus de **7 mois**, alors votre pass sanitaire sera désactivé. Pour prolonger sa validité, vous devrez recevoir votre rappel vaccinal (dit 3<sup>e</sup> dose).
 
-        * quel que soit votre âge, si vous avez reçu le **vaccin Janssen** depuis plus de **1 mois et 4 semaines,** alors votre pass sanitaire sera désactivé. Pour prolonger sa validité, vous devrez recevoir votre rappel vaccinal.
+        * quel que soit votre âge, si vous avez reçu le **vaccin Janssen** depuis plus de **2 mois**, alors votre pass sanitaire sera désactivé. Pour prolonger sa validité, vous devrez recevoir votre rappel vaccinal.
 
-    - À partir du **15 janvier 2022** :
+    - Depuis le **15 janvier 2022** :
         * si vous avez entre **18 et 64 ans** et que votre dernière **injection** (ou votre dernière **infection** à la Covid) date de plus de **7 mois**, alors votre pass sanitaire sera désactivé. Pour prolonger sa validité, vous devrez recevoir votre rappel vaccinal (dit 3<sup>e</sup> dose).
+
+    - À partir du **15 février 2022** :
+        * si vous avez **18 ans ou plus** et que votre dernière **injection** (ou votre dernière **infection** à la Covid) date de plus de **4 mois**, alors votre pass sanitaire sera désactivé. Pour prolonger sa validité, vous devrez recevoir votre rappel vaccinal (dit 3<sup>e</sup> dose).
 
 
     <div class="voir-aussi">

--- a/src/scripts/tests/integration/test.rappel.js
+++ b/src/scripts/tests/integration/test.rappel.js
@@ -178,7 +178,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             )
             assert.include(
                 statut,
-                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 16 février 2022.'
+                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 15 février 2022.'
             )
         })
 
@@ -282,6 +282,8 @@ describe('Mini-questionnaire dose de rappel', function () {
                 'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 17 janvier 2022.'
             )
         })
+    })
+    describe('Éligible au rappel et pass sanitaire au 15 février', function () {
         it('18 à 65 ans, 17 juillet', async function () {
             const questionnaire = new Questionnaire(
                 this.test.page,
@@ -303,7 +305,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             ) // début de la campagne de rappel pour les moins de 65 ans
             assert.include(
                 statut,
-                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 16 février 2022.'
+                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 15 février 2022.'
             )
         })
         it('18 à 65 ans, 17 août', async function () {
@@ -327,7 +329,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             ) // début de la campagne de rappel pour les moins de 65 ans
             assert.include(
                 statut,
-                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 19 mars 2022.'
+                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 15 février 2022.'
             )
         })
         it('18 à 65 ans, 17 septembre', async function () {
@@ -354,7 +356,55 @@ describe('Mini-questionnaire dose de rappel', function () {
             )
             assert.include(
                 statut,
-                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 19 avril 2022.'
+                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 15 février 2022.'
+            )
+        })
+        it('18 à 65 ans, 17 octobre', async function () {
+            const questionnaire = new Questionnaire(
+                this.test.page,
+                'pass-sanitaire-qr-code-voyages.html',
+                'avant-quelle-date-dois-je-recevoir-la-dose-de-rappel-dite-3-e-dose-pour-conserver-mon-pass-sanitaire'
+            )
+            await questionnaire.cEstParti()
+            await questionnaire.remplirAge('moins65')
+            await questionnaire.remplirVaccinationInitiale('autre')
+            await questionnaire.remplirDateDerniereDose('2021-10-17')
+
+            const statut = await questionnaire.recuperationStatut('rappel-et-pass')
+            assert.include(statut, 'Vous avez entre 18 et 64 ans')
+            assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
+            assert.include(statut, 'Votre dernière injection date du 17 octobre 2021.')
+            assert.include(
+                statut,
+                'Vous pourrez recevoir votre dose de rappel à partir du 17 janvier 2022.'
+            )
+            assert.include(
+                statut,
+                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 16 février 2022.'
+            )
+        })
+        it('18 à 65 ans, 10 février', async function () {
+            const questionnaire = new Questionnaire(
+                this.test.page,
+                'pass-sanitaire-qr-code-voyages.html',
+                'avant-quelle-date-dois-je-recevoir-la-dose-de-rappel-dite-3-e-dose-pour-conserver-mon-pass-sanitaire'
+            )
+            await questionnaire.cEstParti()
+            await questionnaire.remplirAge('moins65')
+            await questionnaire.remplirVaccinationInitiale('autre')
+            await questionnaire.remplirDateDerniereDose('2022-02-10')
+
+            const statut = await questionnaire.recuperationStatut('rappel-et-pass')
+            assert.include(statut, 'Vous avez entre 18 et 64 ans')
+            assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
+            assert.include(statut, 'Votre dernière injection date du 10 février 2022.')
+            assert.include(
+                statut,
+                'Vous pourrez recevoir votre dose de rappel à partir du 13 mai 2022.'
+            )
+            assert.include(
+                statut,
+                'En l’absence de cette injection, votre pass sanitaire actuel ne sera plus valide à partir du 12 juin 2022.'
             )
         })
     })


### PR DESCRIPTION
La date ne semble donc pas « confidentielle » 😅

Source : https://solidarites-sante.gouv.fr/grands-dossiers/vaccin-covid-19/je-suis-un-particulier/dose-de-rappel-covid19

> À partir du 15 février 2022, le délai de validité du certificat de vaccination sans dose de rappel passe à 4 mois au lieu de 7 mois.