### PR TITLE
Ouverture du rappel vaccinal aux adolescent(e)s de 12 à 17 ans le 24/01/2022

### DIFF
--- a/contenus/actualites/2021-12-28-rappel-des-3-mois.toml
+++ b/contenus/actualites/2021-12-28-rappel-des-3-mois.toml
@@ -1,4 +1,0 @@
-date = 2021-12-28
-texte = "le rappel vaccinal est possible dès 3 mois après la dernière injection ou la dernière infection à la Covid"
-lien = "je-veux-me-faire-vacciner.html#a-partir-de-quand-pourrai-je-recevoir-la-dose-de-rappel-dite-3-e-dose"
-emoji = "💉"

--- a/contenus/actualites/2022-01-24-rappel-adolescents.toml
+++ b/contenus/actualites/2022-01-24-rappel-adolescents.toml
@@ -1,0 +1,4 @@
+date = 2022-01-24
+texte = "ouverture du rappel vaccinal aux adolescent(e)s de 12 à 17 ans"
+lien = "je-veux-me-faire-vacciner.html#suis-je-concerne-par-la-dose-de-rappel-dite-3-e-dose"
+emoji = "💉"

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -94,6 +94,9 @@
     - Depuis le **15 janvier 2022** :
         * si vous avez entre **18 et 64 ans** et que votre dernière **injection** (ou votre dernière **infection** à la Covid) date de plus de **7 mois**, alors votre pass sanitaire sera désactivé. Pour prolonger sa validité, vous devrez recevoir votre rappel vaccinal (dit 3<sup>e</sup> dose).
 
+    - À partir du **24 janvier 2022** :
+        * si vous avez entre **12 et 17 ans**, vous serez éligible à une dose de rappel, mais celle-ci ne sera **pas obligatoire** dans le cadre du pass sanitaire.
+
     - À partir du **15 février 2022** :
         * si vous avez **18 ans ou plus** et que votre dernière **injection** (ou votre dernière **infection** à la Covid) date de plus de **4 mois**, alors votre pass sanitaire sera désactivé. Pour prolonger sa validité, vous devrez recevoir votre rappel vaccinal (dit 3<sup>e</sup> dose).
 
@@ -110,7 +113,7 @@
 .. question:: J’ai eu la Covid après ma vaccination complète, comment prolonger mon pass sanitaire ?
     :level: 3
 
-    Si vous êtes âgé de 18 ans ou plus, alors vous serez éligible à une dose de rappel dès **3 mois** après votre **infection**.
+    Si vous êtes âgé de 18 ans ou plus (*ou dès 12 ans à partir du 24 janvier 2022*), alors vous serez éligible à une dose de rappel dès **3 mois** après votre **infection**.
 
     En attendant de recevoir cette dose de rappel, vous pouvez utiliser le QR code de votre résultat de **test PCR ou antigénique positif** datant d’au moins 11 jours (aussi appelé *certificat de rétablissement*) comme pass sanitaire, valable pendant **6 mois**.
 

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -18,10 +18,7 @@
 
     Si vous avez **18 ans ou plus**, vous pouvez recevoir un rappel vaccinal, en respectant [un délai minimal](#a-partir-de-quand-pourrai-je-recevoir-la-dose-de-rappel-dite-3-e-dose) après votre dernière injection ou infection à la Covid.
 
-    Vous êtes également éligible au rappel si vous avez entre **12 et 17 ans** et que :
-
-    * vous êtes **sévèrement immunodéprimé(e)** ;
-    * vous avez une **comorbidité** (voir [la liste ci-dessous](#quels-sont-les-facteurs-de-risque-de-formes-graves-de-covid)) augmentant le risque de forme grave de Covid.
+    <span class="nouveau">nouveau</span> Si vous avez entre **12 et 17 ans**, le rappel vaccinal vous sera ouvert à partir du **lundi 24 janvier 2022**.
 
     {{ formulaire('rappel', prefixe='suis-je-concerne') }}
 
@@ -42,14 +39,11 @@
 .. question:: J’ai eu la Covid avant mon unique dose de vaccin. Suis-je concerné par la dose de rappel, dite 3<sup>e</sup> dose ?
     :level: 3
 
-    **Oui**, si vous avez **plus de 18 ans** vous pouvez recevoir un rappel vaccinal, en respectant [un délai minimal](#a-partir-de-quand-pourrai-je-recevoir-la-dose-de-rappel-dite-3-e-dose) après votre dernière injection ou infection à la Covid.
+    **Oui**, dans votre cas le rappel sera votre **2<sup>e</sup> dose**.
 
-    Vous êtes également éligible au rappel si vous avez entre **12 et 17 ans** et que :
+    Si vous avez **plus de 18 ans** vous pouvez recevoir un rappel vaccinal, en respectant [un délai minimal](#a-partir-de-quand-pourrai-je-recevoir-la-dose-de-rappel-dite-3-e-dose) après votre dernière injection ou infection à la Covid.
 
-    * vous êtes **sévèrement immunodéprimé(e)** ;
-    * vous avez une **comorbidité** (voir [la liste ci-dessous](#quels-sont-les-facteurs-de-risque-de-formes-graves-de-covid)) augmentant le risque de forme grave de Covid.
-
-    Dans votre cas, le rappel sera votre **2<sup>e</sup> dose**.
+    <span class="nouveau">nouveau</span> Si vous avez entre **12 et 17 ans**, le rappel vaccinal vous sera ouvert à partir du **lundi 24 janvier 2022**.
 
     <div class="voir-aussi">
 

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -386,16 +386,16 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
     </div>
 
 
-.. question:: La vaccination des mineurs de 12 ans et plus est-t-elle obligatoire pour obtenir le « pass sanitaire » ?
+.. question:: La vaccination des mineurs de 12 ans et plus est-t-elle obligatoire pour obtenir le « passe sanitaire » ?
     :level: 3
 
     <div class="conseil conseil-jaune">
 
-    <span class="nouveau">nouveau</span> À partir du **lundi 24 janvier 2022**, les adolescent(e)s de **12 à 17 ans** pourront recevoir une **dose de rappel** (dite 3<sup>e</sup> dose) : ce rappel vaccinal ne sera **pas obligatoire** dans le cadre du pass sanitaire.
+    <span class="nouveau">nouveau</span> À partir du **lundi 24 janvier 2022**, les adolescent(e)s de **12 à 17 ans** pourront recevoir une **dose de rappel** (dite 3<sup>e</sup> dose) : ce rappel vaccinal ne sera **pas obligatoire** dans le cadre du passe sanitaire.
 
     </div>
 
-    **Non**. Comme pour les adultes non-vacciné(e)s, plusieurs justificatifs, au choix, font office de « pass sanitaire » utilisable en France et pour les voyages en Union européenne :
+    **Non**. Comme pour les adultes non-vacciné(e)s, plusieurs justificatifs, au choix, font office de « passe sanitaire » utilisable en France et pour les voyages en Union européenne :
 
     * l’**attestation de vaccination complète** (toutes les doses et respect du délai de 7 jours après la dernière dose en France, ou 14 jours pour voyager à l’étranger) ;
     * un **test PCR ou antigénique négatif** de moins de 24 h ;
@@ -405,7 +405,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     <div class="voir-aussi">
 
-    * Pour plus d’informations, consultez notre page sur [les voyages et le pass sanitaire](/pass-sanitaire-qr-code-voyages.html).
+    * Pour plus d’informations, consultez notre page sur [les voyages et le passe sanitaire](/pass-sanitaire-qr-code-voyages.html).
 
     </div>
 

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -281,9 +281,9 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 .. question:: Les enfants de 5 à 11 ans peuvent-ils être vaccinés ?
     :level: 3
 
-    À compter du mercredi 22 décembre, la vaccination est possible pour tous les enfants âgés de **5 à 11 ans**, suite aux avis favorables de la Haute autorité de santé (HAS), du Conseil consultatif national d’éthique (CCNE) et du Conseil d’orientation de la stratégie vaccinale (COSV).
+    **Oui**. La vaccination est possible pour tous les enfants âgés de **5 à 11 ans**. Cette vaccination est **facultative**, et se fait avec une forme pédiatrique (trois fois moins dosée) du vaccin **Pfizer**. L’**accord des deux parents** (ou titulaires de l’autorité parentale) est nécessaire.
 
-    Cette vaccination est **facultative**, et se fait avec une forme pédiatrique (trois fois moins dosée) du vaccin **Pfizer**. L’**accord des deux parents** (ou titulaires de l’autorité parentale) est nécessaire.
+    Cette décision a été prise suite aux avis favorables de la Haute autorité de santé (HAS), du Conseil consultatif national d’éthique (CCNE) et du Conseil d’orientation de la stratégie vaccinale (COSV).
 
 
 .. question:: Où faire vacciner un mineur et avec quel vaccin ?
@@ -313,11 +313,11 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     * **une seule dose**, s’ils ont déjà été contaminés à la Covid (dans ce cas, il faut attendre **au minimum 2 mois** après le test positif avant de se faire vacciner) ;
     * **deux doses**, s’ils n’ont pas déjà été contaminés par la Covid.
-    
-    Le délai entre les deux doses dépend du vaccin et de l'âge de votre enfant : 
-    
+
+    Le délai entre les deux doses dépend du vaccin et de l'âge de votre enfant :
+
     * enfant âgé de **5 à 11 ans** (dosage pédiatrique du vaccin Pfizer) : entre **18 et 24 jours**.
-    
+
     * enfant âgé de **12 à 17 ans** :
         * 3 à 7 semaines après la première, pour le vaccin Pfizer ;
         * 4 à 7 semaines après la première, pour le vaccin Moderna.
@@ -603,7 +603,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
     :level: 3
 
     Si votre enfant en bas âge est cas contact, il doit être **testé immédiatement** (test PCR, PCR salivaire, antigénique). Les tests de dépistage sont toujours **gratuits** pour les enfants. Son accueil en crèche pourra reprendre à condition de présenter une **attestation** parentale de résultat **négatif**. Par sécurité, vous êtes encouragé à réaliser un second test, **7 jours après** la notification de contact à risque pour confirmer que l’enfant n’a pas été contaminé.
-    
+
     Sans test, votre enfant devra rester isolé 7 jours. Si nécessaire, vous pouvez obtenir un **arrêt de travail** pour le garder à la maison.
 
     <div class="voir-aussi">

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -309,7 +309,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 .. question:: Les mineurs reçoivent-ils le même nombre de doses que les adultes ?
     :level: 3
 
-    **Oui**. Comme pour les adultes, les mineurs reçoivent :
+    **Oui**. Comme pour les adultes, pour la vaccination initiale, les mineurs reçoivent :
 
     * **une seule dose**, s’ils ont déjà été contaminés à la Covid (dans ce cas, il faut attendre **au minimum 2 mois** après le test positif avant de se faire vacciner) ;
     * **deux doses**, s’ils n’ont pas déjà été contaminés par la Covid.
@@ -322,6 +322,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
         * 3 à 7 semaines après la première, pour le vaccin Pfizer ;
         * 4 à 7 semaines après la première, pour le vaccin Moderna.
 
+    <span class="nouveau">nouveau</span> À partir du lundi 24 janvier 2022, les adolescent(e)s de 12 à 17 ans pourront également recevoir une **dose de rappel** (dite 3<sup>e</sup> dose).
 
     <div class="voir-aussi">
 
@@ -387,6 +388,12 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
 .. question:: La vaccination des mineurs de 12 ans et plus est-t-elle obligatoire pour obtenir le « pass sanitaire » ?
     :level: 3
+
+    <div class="conseil conseil-jaune">
+
+    <span class="nouveau">nouveau</span> À partir du **lundi 24 janvier 2022**, les adolescent(e)s de **12 à 17 ans** pourront recevoir une **dose de rappel** (dite 3<sup>e</sup> dose) : ce rappel vaccinal ne sera **pas obligatoire** dans le cadre du pass sanitaire.
+
+    </div>
 
     **Non**. Comme pour les adultes non-vacciné(e)s, plusieurs justificatifs, au choix, font office de « pass sanitaire » utilisable en France et pour les voyages en Union européenne :
 

--- a/contenus/thematiques/formulaires/rappel.md
+++ b/contenus/thematiques/formulaires/rappel.md
@@ -21,7 +21,7 @@
             <input id="{{prefixe}}_age_radio_moins65" type="radio" required name="{{prefixe}}_age_radio" value="moins65">
             <label for="{{prefixe}}_age_radio_moins65">J’ai entre 18 et 64 ans</label>
             <input id="{{prefixe}}_age_radio_moins18" type="radio" required name="{{prefixe}}_age_radio" value="moins18">
-            <label for="{{prefixe}}_age_radio_moins18">J’ai moins de 18 ans</label>
+            <label for="{{prefixe}}_age_radio_moins18">J’ai entre 12 et 17 ans</label>
         </div>
     </fieldset>
     <div class="form-controls">
@@ -41,27 +41,6 @@
             <label for="{{prefixe}}_vaccination_initiale_radio_autre">J’ai été vacciné avec Pfizer, Moderna ou AstraZeneca</label>
             <input id="{{prefixe}}_vaccination_initiale_radio_janssen" type="radio" required name="{{prefixe}}_vaccination_initiale_radio" value="janssen">
             <label for="{{prefixe}}_vaccination_initiale_radio_janssen">J’ai été vacciné avec Janssen</label>
-        </div>
-    </fieldset>
-    <div class="form-controls">
-        <div class="button-with-progress">
-            <p id="aria-description-progress-{{prefixe}}-situation" class="progress">Il vous reste 1 étape</p>
-            <input type="submit" class="button button-arrow" value="Continuer" aria-describedby="aria-description-progress-{{prefixe}}-situation">
-        </div>
-    </div>
-</form>
-
-<form id="{{prefixe}}-situation-moins18-form" hidden>
-    <a href="javascript:;" data-precedent="vaccination-initiale" class="back-button">Retour</a>
-    <fieldset class="required">
-        <legend><h3 id="{{prefixe}}-situation-moins18-label">Ma situation</h3></legend>
-        <div role="radiogroup" aria-labelledby="{{prefixe}}-situation-moins18-label">
-            <input id="{{prefixe}}_situation_moins18_radio_immunodeprimee" type="radio" required name="{{prefixe}}_situation_moins18_radio" value="immunodeprimee">
-            <label for="{{prefixe}}_situation_moins18_radio_immunodeprimee">Je suis sévèrement immunodéprimé(e)</label>
-            <input id="{{prefixe}}_situation_moins18_radio_comorbidite" type="radio" required name="{{prefixe}}_situation_moins18_radio" value="comorbidite">
-            <label for="{{prefixe}}_situation_moins18_radio_comorbidite"><span>J’ai une <a href="/je-veux-me-faire-vacciner.html#quels-sont-les-facteurs-de-risque-de-formes-graves-de-covid">comorbidité</a> (risque de forme grave)</span></label>
-            <input id="{{prefixe}}_situation_moins18_radio_autre" type="radio" required name="{{prefixe}}_situation_moins18_radio" value="autre">
-            <label for="{{prefixe}}_situation_moins18_radio_autre">Autre situation</label>
         </div>
     </fieldset>
     <div class="form-controls">

--- a/src/scripts/tests/integration/test.rappel.js
+++ b/src/scripts/tests/integration/test.rappel.js
@@ -51,18 +51,6 @@ class Questionnaire {
         await bouton.click()
     }
 
-    async remplirSituationMoins18(reponse) {
-        const checkbox_label = await this.page.waitForSelector(
-            `#${this.prefixe}-situation-moins18-form label[for="${this.prefixe}_situation_moins18_radio_${reponse}"]`
-        )
-        await checkbox_label.click()
-
-        const bouton = await this.page.waitForSelector(
-            `#${this.prefixe}-situation-moins18-form >> text="Continuer"`
-        )
-        await bouton.click()
-    }
-
     async remplirDateDerniereDose(dateIso) {
         await this.page.fill(`#${this.prefixe}_date_derniere_dose`, dateIso)
 
@@ -409,8 +397,8 @@ describe('Mini-questionnaire dose de rappel', function () {
         })
     })
 
-    describe('Éligible au rappel mais pas concerné pour le pass sanitaire', function () {
-        it('Moins de 18 ans et immunodéprimé(e), 17 mai', async function () {
+    describe('Adolescents éligibles au rappel mais sans impact sur le pass sanitaire', function () {
+        it('12 à 17 ans, 17 octobre', async function () {
             const questionnaire = new Questionnaire(
                 this.test.page,
                 'pass-sanitaire-qr-code-voyages.html',
@@ -418,17 +406,15 @@ describe('Mini-questionnaire dose de rappel', function () {
             )
             await questionnaire.cEstParti()
             await questionnaire.remplirAge('moins18')
-            await questionnaire.remplirVaccinationInitiale('autre')
-            await questionnaire.remplirSituationMoins18('immunodeprimee')
-            await questionnaire.remplirDateDerniereDose('2021-05-17')
+            await questionnaire.remplirDateDerniereDose('2021-10-17')
 
             const statut = await questionnaire.recuperationStatut('rappel')
-            assert.include(statut, 'Vous avez moins de 18 ans')
-            assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
-            assert.include(statut, 'Votre dernière injection date du 17 mai 2021.')
+            assert.include(statut, 'Vous avez entre 12 et 17 ans')
+            assert.include(statut, 'avec le vaccin Pfizer ou Moderna')
+            assert.include(statut, 'Votre dernière injection date du 17 octobre 2021.')
             assert.include(
                 statut,
-                'Vous pourrez recevoir votre dose de rappel à partir du 1 septembre 2021.'
+                'Vous pourrez recevoir votre dose de rappel à partir du 24 janvier 2022.'
             ) // début de la campagne de rappel
 
             assert.include(
@@ -436,7 +422,7 @@ describe('Mini-questionnaire dose de rappel', function () {
                 'Vous ne serez pas concerné(e) par la désactivation du pass sanitaire, qui restera valable au delà du 15 décembre 2021.'
             )
         })
-        it('Moins de 18 ans et immunodéprimé(e), 17 juin', async function () {
+        it('12 à 17 ans, 17 novembre', async function () {
             const questionnaire = new Questionnaire(
                 this.test.page,
                 'pass-sanitaire-qr-code-voyages.html',
@@ -444,24 +430,23 @@ describe('Mini-questionnaire dose de rappel', function () {
             )
             await questionnaire.cEstParti()
             await questionnaire.remplirAge('moins18')
-            await questionnaire.remplirVaccinationInitiale('autre')
-            await questionnaire.remplirSituationMoins18('immunodeprimee')
-            await questionnaire.remplirDateDerniereDose('2021-06-17')
+            await questionnaire.remplirDateDerniereDose('2021-11-17')
 
             const statut = await questionnaire.recuperationStatut('rappel')
-            assert.include(statut, 'Vous avez moins de 18 ans')
-            assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
-            assert.include(statut, 'Votre dernière injection date du 17 juin 2021.')
+            assert.include(statut, 'Vous avez entre 12 et 17 ans')
+            assert.include(statut, 'avec le vaccin Pfizer ou Moderna')
+            assert.include(statut, 'Votre dernière injection date du 17 novembre 2021.')
             assert.include(
                 statut,
-                'Vous pourrez recevoir votre dose de rappel à partir du 17 septembre 2021.'
+                'Vous pourrez recevoir votre dose de rappel à partir du 17 février 2022.'
             )
+
             assert.include(
                 statut,
                 'Vous ne serez pas concerné(e) par la désactivation du pass sanitaire, qui restera valable au delà du 15 décembre 2021.'
             )
         })
-        it('Moins de 18 ans et comorbidité, 17 juin', async function () {
+        it('12 à 17 ans, 17 décembre', async function () {
             const questionnaire = new Questionnaire(
                 this.test.page,
                 'pass-sanitaire-qr-code-voyages.html',
@@ -469,18 +454,17 @@ describe('Mini-questionnaire dose de rappel', function () {
             )
             await questionnaire.cEstParti()
             await questionnaire.remplirAge('moins18')
-            await questionnaire.remplirVaccinationInitiale('autre')
-            await questionnaire.remplirSituationMoins18('comorbidite')
-            await questionnaire.remplirDateDerniereDose('2021-06-17')
+            await questionnaire.remplirDateDerniereDose('2021-12-17')
 
             const statut = await questionnaire.recuperationStatut('rappel')
-            assert.include(statut, 'Vous avez moins de 18 ans')
-            assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
-            assert.include(statut, 'Votre dernière injection date du 17 juin 2021.')
+            assert.include(statut, 'Vous avez entre 12 et 17 ans')
+            assert.include(statut, 'avec le vaccin Pfizer ou Moderna')
+            assert.include(statut, 'Votre dernière injection date du 17 décembre 2021.')
             assert.include(
                 statut,
-                'Vous pourrez recevoir votre dose de rappel à partir du 17 septembre 2021.'
+                'Vous pourrez recevoir votre dose de rappel à partir du 19 mars 2022.'
             )
+
             assert.include(
                 statut,
                 'Vous ne serez pas concerné(e) par la désactivation du pass sanitaire, qui restera valable au delà du 15 décembre 2021.'
@@ -561,52 +545,6 @@ describe('Mini-questionnaire dose de rappel', function () {
 
         formLegend = await page.waitForSelector(`#${prefixe}-age-form legend h3`)
         assert.equal(await formLegend.innerText(), 'Mon âge')
-    })
-
-    it('Bouton retour (date dernière dose via moins 18)', async function () {
-        const questionnaire = new Questionnaire(
-            this.test.page,
-            'pass-sanitaire-qr-code-voyages.html',
-            'avant-quelle-date-dois-je-recevoir-la-dose-de-rappel-dite-3-e-dose-pour-conserver-mon-pass-sanitaire'
-        )
-
-        const prefixe = await questionnaire.cEstParti()
-
-        const page = this.test.page
-
-        let formLegend = await page.waitForSelector(`#${prefixe}-age-form legend h3`)
-        assert.equal(await formLegend.innerText(), 'Mon âge')
-
-        await questionnaire.remplirAge('moins18')
-        await questionnaire.remplirVaccinationInitiale('autre')
-        await questionnaire.remplirSituationMoins18('comorbidite')
-
-        formLegend = await page.waitForSelector(
-            `#${prefixe}-date-derniere-dose-form legend h3`
-        )
-        assert.equal(await formLegend.innerText(), 'La date de ma dernière injection')
-
-        // On clique sur le bouton retour.
-        const bouton = await page.waitForSelector(
-            `#${prefixe}-date-derniere-dose-form >> text="Retour"`
-        )
-        await bouton.click()
-
-        formLegend = await page.waitForSelector(
-            `#${prefixe}-situation-moins18-form legend h3`
-        )
-        assert.equal(await formLegend.innerText(), 'Ma situation')
-
-        // On clique sur le bouton retour.
-        const bouton2 = await page.waitForSelector(
-            `#${prefixe}-situation-moins18-form >> text="Retour"`
-        )
-        await bouton2.click()
-
-        formLegend = await page.waitForSelector(
-            `#${prefixe}-vaccination-initiale-form legend h3`
-        )
-        assert.equal(await formLegend.innerText(), 'Ma vaccination initiale')
     })
 
     it('Bouton recommencer', async function () {


### PR DESCRIPTION
Source : https://www.gouvernement.fr/info-coronavirus

> À partir du 24 janvier, le rappel vaccinal est ouvert à tous les adolescents de 12 à 17 ans.