### PR TITLE
[Page passe sanitaire] Change le titre

### DIFF
--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -1,4 +1,4 @@
-# Pass sanitaire, QR code et voyages, que faut-il savoir ?
+# Nouveau passe vaccinal, que faut-il savoir ?
 
 <img src="illustrations/pass_sanitaire.svg">
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -1,4 +1,4 @@
-# Nouveau passe vaccinal, que faut-il savoir ?
+# Nouveau passe vaccinal, que faut-il savoir ?
 
 <img src="illustrations/pass_sanitaire.svg">
 

--- a/src/scripts/tests/integration/test.pages.js
+++ b/src/scripts/tests/integration/test.pages.js
@@ -25,7 +25,7 @@ describe('Pages', function () {
         await waitForPlausibleTrackingEvent(page, 'pageview:introduction')
 
         await page.click(
-            '.thematiques a >> text="Pass sanitaire, QR code et voyages, que faut-il savoir ?"'
+            '.thematiques a >> text="Nouveau passe vaccinal, que faut-il savoir ?"'
         )
         await waitForPlausibleTrackingEvent(
             page,

--- a/src/scripts/tests/integration/test.parcours.js
+++ b/src/scripts/tests/integration/test.parcours.js
@@ -88,7 +88,7 @@ describe('Parcours', function () {
 
             await Promise.all([
                 page.click(
-                    '#page.ready .thematiques a >> text="Pass sanitaire, QR code et voyages, que faut-il savoir ?"'
+                    '#page.ready .thematiques a >> text="Nouveau passe vaccinal, que faut-il savoir ?"'
                 ),
                 page.waitForNavigation({
                     url: '**/pass-sanitaire-qr-code-voyages.html',

--- a/src/scripts/tests/integration/test.thematiques.js
+++ b/src/scripts/tests/integration/test.thematiques.js
@@ -29,7 +29,7 @@ describe('Thématiques', function () {
 
         await Promise.all([
             page.click(
-                '.thematiques a >> text="Pass sanitaire, QR code et voyages, que faut-il savoir ?"'
+                '.thematiques a >> text="Nouveau passe vaccinal, que faut-il savoir ?"'
             ),
             page.waitForNavigation({
                 url: '**/pass-sanitaire-qr-code-voyages.html',


### PR DESCRIPTION
Le Passe vaccinal a remplacé le passe sanitaire pour les plus de 16 ans le 24 janvier. Sur les recommandations de la content designer (Gladys) et pour plus de lisibilité, j'enlève les autres mots clés du titre (d'autant qu'ils sont mentionnés dans le chapô). Les utilisateurs ont eu le temps de se familiariser avec ces thèmes et font à présent le lien entre le passe sanitaire/vaccinal, le QR code et les voyages.