### PR TITLE
Ajoute la levée d’isolement anticipée dans les conseils personnalisés

### DIFF
--- a/contenus/conseils/conseils_personnels_depistage_positif_asymptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_asymptomatique.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
-1. {.seulement-si-vaccine} Vous maintenir **en isolement**, au moins 7 jours à partir de la date du test.
-1. {.seulement-si-non-vaccine} Vous maintenir **en isolement**, au moins 10 jours à partir de la date du test.
+1. {.seulement-si-vaccine} Vous maintenir **en isolement** pour une durée de **7 jours** à partir de la date du test ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+1. {.seulement-si-non-vaccine} Vous maintenir **en isolement** pour une durée de **10 jours** à partir de la date du test ; vous pourrez lever l’isolement **dès le 7<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 1. {.seulement-si-activite-pro} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).
 1. {.seulement-si-foyer} Les autres membres de votre foyer sont maintenant considérés comme **cas contact**.

--- a/contenus/conseils/conseils_personnels_depistage_positif_autotest_asymptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_autotest_asymptomatique.md
@@ -1,8 +1,8 @@
 Nous vous conseillons de :
 
 1. Réaliser un **test PCR ou antigénique (gratuit)** en consultant la <a href="https://www.sante.fr/cf/centres-depistage-covid.html">carte des lieux de test</a> (vous serez prioritaire), pour **confirmer** le résultat.
-1. {.seulement-si-vaccine} Vous maintenir **en isolement** pendant au moins **7 jours** à partir de la date du test PCR ou antigénique.
-1. {.seulement-si-non-vaccine} Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date du test PCR ou antigénique antigénique.
+1. {.seulement-si-vaccine} Vous maintenir **en isolement** pour une durée de **7 jours** à partir de la date du test PCR ou antigénique ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+1. {.seulement-si-non-vaccine} Vous maintenir **en isolement** pour une durée de **10 jours** à partir de la date du test PCR ou antigénique ; vous pourrez lever l’isolement **dès le 7<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 1. {.seulement-si-activite-pro-et-autotest} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat du test.
 1. {.seulement-si-activite-pro-et-pas-autotest} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).

--- a/contenus/conseils/conseils_personnels_depistage_positif_autotest_symptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_autotest_symptomatique.md
@@ -1,8 +1,8 @@
 Nous vous conseillons de :
 
 1. Réaliser un **test PCR ou antigénique (gratuit)** en consultant la <a href="https://www.sante.fr/cf/centres-depistage-covid.html">carte des lieux de test</a> (vous serez prioritaire), pour **confirmer** le résultat.
-1. {.seulement-si-vaccine} Vous maintenir **en isolement** pendant au moins **7 jours** à partir de la date d’apparition des symptômes.
-1. {.seulement-si-non-vaccine} Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes.
+1. {.seulement-si-vaccine} Vous maintenir **en isolement** pour une durée de **7 jours** à partir de la date d’apparition des symptômes ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+1. {.seulement-si-non-vaccine} Vous maintenir **en isolement** pour une durée de **10 jours** à partir de la date d’apparition des symptômes ; vous pourrez lever l’isolement **dès le 7<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 1. {.seulement-si-activite-pro-et-autotest} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat du test.
 1. {.seulement-si-activite-pro-et-pas-autotest} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).

--- a/contenus/conseils/conseils_personnels_depistage_positif_symptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_symptomatique.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
-1. {.seulement-si-vaccine} Vous maintenir **en isolement**, au moins 7 jours à partir de la date d’apparition des symptômes, et de contacter votre médecin au moindre doute.
-1. {.seulement-si-non-vaccine} Vous maintenir **en isolement**, au moins 10 jours à partir de la date d’apparition des symptômes, et de contacter votre médecin au moindre doute.
+1. {.seulement-si-vaccine} Vous maintenir **en isolement** pour une durée de **7 jours** à partir de la date d’apparition des symptômes, et de contacter votre médecin au moindre doute ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+1. {.seulement-si-non-vaccine} Vous maintenir **en isolement** pour une durée de **10 jours** à partir de la date d’apparition des symptômes, et de contacter votre médecin au moindre doute ; vous pourrez lever l’isolement **dès le 7<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 1. {.seulement-si-activite-pro} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).
 1. {.seulement-si-foyer} Les autres membres de votre foyer sont considérés comme **cas contact**.

--- a/contenus/conseils/conseils_personnels_symptômes_passés_positif.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_positif.md
@@ -1,7 +1,7 @@
 Nous vous conseillons de :
 
-1. {.seulement-si-vaccine} Vous maintenir **en isolement** au moins 7 jours à partir de la date d’apparition des symptômes.
-1. {.seulement-si-non-vaccine} Vous maintenir **en isolement** au moins 10 jours à partir de la date d’apparition des symptômes.
+1. {.seulement-si-vaccine} Vous maintenir **en isolement** pour une durée de **7 jours** à partir de la date d’apparition des symptômes ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+1. {.seulement-si-non-vaccine} Vous maintenir **en isolement** pour une durée de **10 jours** à partir de la date d’apparition des symptômes ; vous pourrez lever l’isolement **dès le 7<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 1. {.seulement-si-activite-pro} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).
 1. {.seulement-si-foyer} Les autres membres de votre foyer sont maintenant considérés comme **cas contact**.

--- a/contenus/conseils/conseils_personnels_symptômes_passés_positif_autotest.md
+++ b/contenus/conseils/conseils_personnels_symptômes_passés_positif_autotest.md
@@ -1,8 +1,8 @@
 Nous vous conseillons de :
 
 1. Réaliser un **test PCR ou antigénique (gratuit)** en consultant la <a href="https://www.sante.fr/cf/centres-depistage-covid.html">carte des lieux de test</a> (vous serez prioritaire), pour **confirmer** le résultat.
-1. {.seulement-si-vaccine} Vous maintenir **en isolement** pendant au moins **7 jours** à partir de la date d’apparition des symptômes.
-1. {.seulement-si-non-vaccine} Vous maintenir **en isolement** pendant au moins **10 jours** à partir de la date d’apparition des symptômes.
+1. {.seulement-si-vaccine} Vous maintenir **en isolement** pour une durée de **7 jours** à partir de la date d’apparition des symptômes ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+1. {.seulement-si-non-vaccine} Vous maintenir **en isolement** pour une durée de **10 jours** à partir de la date d’apparition des symptômes ; vous pourrez lever l’isolement **dès le 7<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 1. {.seulement-si-activite-pro-et-autotest} Si vous ne pouvez pas **télétravailler**, vous pouvez [demander un arrêt de travail](https://declare.ameli.fr/isolement/conditions) sans délai de carence, pour pouvoir rester chez vous en attendant le résultat du test PCR.
 1. {.seulement-si-activite-pro-et-pas-autotest} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).


### PR DESCRIPTION
Cette possibilité n’était pas précisée dans certains scénarios à l’issue du questionnaire.

Source : https://solidarites-sante.gouv.fr/IMG/pdf/reply_dgs_urgent_01_doctrines_isolement_et_40n.pdf