### PR TITLE
Ajoute le lien vers l'arrêt de travail des parents vaccinés

### DIFF
--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -105,7 +105,7 @@ Même si vous ne présentez pas de symptômes, faites un **test de dépistage** 
     - **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal) ;
     - portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
 
-Si vous devez **garder votre enfant** positif à la Covid mais que vous ne pouvez pas télétravailler, vous pouvez bénéficier du **chômage partiel**. Pour plus d’information sur la démarche, consultez notre page dédiée aux [conseils pour les enfants et adolescents](/conseils-pour-les-enfants.html#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid).
+Si votre enfant de moins de 16 ans est positif à la Covid, vous pouvez bénéficier d'un **arrêt de travail**, même si vous êtes complètement vacciné(e). Rendez-vous sur [declare.ameli.fr](https://declare.ameli.fr/) pour en faire la demande.
 
 #### 2. Faites 2 autotests à J+2 et J+4
 


### PR DESCRIPTION
Lorsqu'un enfant de moins de 16 ans est positif à la Covid, les parents peuvent bénéficier d'un arrêt de travail, même s'ils sont complètement vaccinés. 
Précédemment on renvoyait vers la démarche pour obtenir le chômage partiel.
Merci au ministère du travail de nous avoir signalé ce point !