### PR TITLE
L’autorisation d’un seul parent suffit pour la vaccination des 5-11 ans

### DIFF
--- a/contenus/conseils/conseils_vaccins_pas_encore_vaccine.md
+++ b/contenus/conseils/conseils_vaccins_pas_encore_vaccine.md
@@ -18,7 +18,7 @@ Trouvez les <a href="https://www.sante.fr/cf/centres-vaccination-covid.html">lie
 Vous pouvez vous faire vacciner :
 
 * si vous avez **18 ans et plus**, sans conditions ;
-* si vous avez entre **12 et 17 ans**, un [formulaire d’autorisation](https://solidarites-sante.gouv.fr/IMG/pdf/fiche_-_autorisation_parentale_vaccin_covid-19.pdf) doit être rempli pour attester du consentement des parents ou du tuteur légal, la **carte vitale** du parent ou tuteur accompagnant est requise, même pour les enfants de plus de 16 ans disposant de leur propre carte vitale ;
+* si vous avez entre **12 et 17 ans**, un [formulaire d’autorisation](https://solidarites-sante.gouv.fr/IMG/pdf/dgs-urgent_no2022_15_-_fiche_-_autorisation_parentale_26.01.22.pdf) doit être rempli pour attester du consentement des parents ou du tuteur légal, la **carte vitale** du parent ou tuteur accompagnant est requise, même pour les enfants de plus de 16 ans disposant de leur propre carte vitale ;
 * si vous êtes **enceinte**, dès le premier trimestre de votre grossesse.
 
 Pour en savoir plus :

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -334,13 +334,11 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 .. question:: Faut-il une autorisation parentale pour vacciner un mineur ?
     :level: 3
 
-    * Pour un enfant de **5 à 11 ans**, l’accord des **deux parents** ou tuteurs est obligatoire. Le formulaire d’autorisation peut être [téléchargé à l’avance](https://solidarites-sante.gouv.fr/IMG/pdf/fiche_-_autorisation_parentale_vaccin_covid-19_pour_les_enfants_de_5_a_11_ans.pdf) et sera également disponible dans le centre de vaccination.
-        * Si les deux parents sont présents, ils signent tous les deux le formulaire d’autorisation parentale.
-        * Si un seul des deux parents est présent, il signe le formulaire d’autorisation parentale et déclare sur l’honneur que l’autre parent a donné également son consentement à la vaccination de l’enfant.
+    * Pour un enfant de **5 à 11 ans**, , le consentement écrit d’un parent ou tuteur est obligatoire. Un formulaire d’autorisation peut être [téléchargé à l’avance](https://solidarites-sante.gouv.fr/IMG/pdf/dgs-urgent_no2022_15_-_fiche_-_autorisation_parentale_26.01.22.pdf) et sera également disponible dans le centre de vaccination.
 
       Le jour de la vaccination, l’enfant **doit être accompagné** de l’un de ses parents (ou titulaires de l’autorité parentale).
 
-    * Pour un(e) adolescent(e) de **12 à 15 ans**, le consentement écrit d’un parent ou tuteur est obligatoire. Un formulaire d’autorisation peut être [téléchargé à l’avance](https://solidarites-sante.gouv.fr/IMG/pdf/fiche_-_autorisation_parentale_vaccin_covid-19.pdf) et sera également disponible dans le centre de vaccination.
+    * Pour un(e) adolescent(e) de **12 à 15 ans**, le consentement écrit d’un parent ou tuteur est obligatoire. Un formulaire d’autorisation peut être [téléchargé à l’avance](https://solidarites-sante.gouv.fr/IMG/pdf/dgs-urgent_no2022_15_-_fiche_-_autorisation_parentale_26.01.22.pdf) et sera également disponible dans le centre de vaccination.
 
       Le jour de la vaccination, l’adolescent(e) **peut venir accompagné(e)** de l’un de ses parents (ou titulaires de l’autorité parentale), mais ce n’est pas obligatoire.
 
@@ -364,8 +362,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 .. question:: Quels justificatifs apporter le jour du rendez-vous de vaccination ?
     :level: 3
 
-    * Pour un enfant de **5 à 11 ans** [l’autorisation parentale de vaccination](https://solidarites-sante.gouv.fr/IMG/pdf/fiche_-_autorisation_parentale_vaccin_covid-19_pour_les_enfants_de_5_a_11_ans.pdf) signée par les **deux parents** lorsqu’ils sont présents, ou seulement par **le parent accompagnateur**, qui atteste alors sur l’honneur que l’autre parent a aussi donné son accord.
-    * Pour un(e) adolescent(e) de **12 à 15 ans**, [l’autorisation parentale de vaccination](https://solidarites-sante.gouv.fr/IMG/pdf/fiche_-_autorisation_parentale_vaccin_covid-19.pdf) signée par **un des deux parents** ou par le tuteur.
+    * Pour un enfant ou un(e) adolescent(e) de **moins de 16 ans**, [l’autorisation parentale de vaccination](https://solidarites-sante.gouv.fr/IMG/pdf/dgs-urgent_no2022_15_-_fiche_-_autorisation_parentale_26.01.22.pdf) signée par **un des deux parents** ou par le tuteur.
     * La **carte vitale** de l’adolescent(e) (si disponible), et **celle d’un parent** (ou une [attestation de droits](https://www.ameli.fr/paris/assure/adresses-et-contacts/lobtention-dun-document/obtenir-une-attestation/obtenir-une-attestation-de-droits) mentionnant le numéro de sécurité sociale d’un parent).
     * La preuve de contamination antérieure, si le mineur a déjà été contaminé par la Covid. Cette preuve peut-être un ancien **test positif** (PCR ou antigénique), ou une **sérologie** (prise de sang) indiquant la présence d’anticorps. Il faut respecter un délai de **2 mois minimum** après ce test positif avant de se faire vacciner.
 

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -336,7 +336,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     * Pour un enfant de **5 à 11 ans**, , le consentement écrit d’un parent ou tuteur est obligatoire. Un formulaire d’autorisation peut être [téléchargé à l’avance](https://solidarites-sante.gouv.fr/IMG/pdf/dgs-urgent_no2022_15_-_fiche_-_autorisation_parentale_26.01.22.pdf) et sera également disponible dans le centre de vaccination.
 
-      Le jour de la vaccination, l’enfant **doit être accompagné** de l’un de ses parents (ou titulaires de l’autorité parentale).
+      Le jour de la vaccination, l’enfant **doit être accompagné** soit par l’un de ses parents (ou des titulaires de l’autorité parentale), soit par une personne munie du formulaire d’autorisation signé par un des parents.
 
     * Pour un(e) adolescent(e) de **12 à 15 ans**, le consentement écrit d’un parent ou tuteur est obligatoire. Un formulaire d’autorisation peut être [téléchargé à l’avance](https://solidarites-sante.gouv.fr/IMG/pdf/dgs-urgent_no2022_15_-_fiche_-_autorisation_parentale_26.01.22.pdf) et sera également disponible dans le centre de vaccination.
 


### PR DESCRIPTION
Source : https://solidarites-sante.gouv.fr/IMG/pdf/dgs-urgent_no2022_15_-_evolution_de_l_autorisation_parentale_necessaire_a_la_vaccination_de_tous_les_enfants_de_5_ans_et_plus.pdf

cf. #1989