### PR TITLE
Duplique la question sur la vaccination des cas contact et précise le délai

### DIFF
--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -104,6 +104,21 @@
 .. injection:: pass-sanitaire-qr-code-voyages.html#avant-quelle-date-dois-je-recevoir-la-dose-de-rappel-dite-3-e-dose-pour-conserver-mon-passe-vaccinal
 
 
+.. question:: Je suis cas contact, puis-je recevoir la dose de rappel ?
+    :level: 3
+
+    **Non**. Si vous êtes [cas contact](/cas-contact-a-risque.html) ou avez été alerté(e) d’un contact à risque par l’application TousAntiCovid, vous devez d’abord **vous assurer que vous n’avez pas été contaminé(e)** en vous faisant tester.
+    
+    * Si votre primo-vaccination date d'il y a moins de 4 mois : faites un test **PCR ou antigénique** dès que possible, puis **2 autotests** de contrôle 2 jours après et 4 jours après le premier test.
+    * Si votre primo-vaccination date d'il y a plus de 4 mois : faites un test antigénique ou PCR **7 jours après** votre dernier contact avec la personne positive.
+         
+     Si à l'issue de cette période de vigilance votre test est **négatif**, alors vous pourrez vous faire vacciner. 
+    
+    <div class="voir-aussi">
+
+    - [Je suis cas contact Covid, que faire ?](/cas-contact-a-risque.html)
+
+    </div>
 .. question:: Quels sont les facteurs de risque de formes graves de Covid ?
     :level: 3
 
@@ -289,7 +304,10 @@
     :level: 3
 
     **Non**. Si vous êtes [cas contact](/cas-contact-a-risque.html) ou avez été alerté(e) d’un contact à risque par l’application TousAntiCovid, vous devez d’abord **vous assurer que vous n’avez pas été contaminé(e)**.
-
+    Si vous n'êtes **pas vacciné(e)**, faites un test antigénique ou PCR **7 jours après** votre dernier contact avec la personne positive.
+         
+     Si le résultat est négatif, alors vous pourrez vous faire vacciner. 
+    
     <div class="voir-aussi">
 
     - [Je suis cas contact Covid, que faire ?](/cas-contact-a-risque.html)

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -108,17 +108,19 @@
     :level: 3
 
     **Non**. Si vous êtes [cas contact](/cas-contact-a-risque.html) ou avez été alerté(e) d’un contact à risque par l’application TousAntiCovid, vous devez d’abord **vous assurer que vous n’avez pas été contaminé(e)** en vous faisant tester.
-    
-    * Si votre primo-vaccination date d'il y a moins de 4 mois : faites un test **PCR ou antigénique** dès que possible, puis **2 autotests** de contrôle 2 jours après et 4 jours après le premier test.
-    * Si votre primo-vaccination date d'il y a plus de 4 mois : faites un test antigénique ou PCR **7 jours après** votre dernier contact avec la personne positive.
-         
-     Si à l'issue de cette période de vigilance votre test est **négatif**, alors vous pourrez vous faire vacciner. 
-    
+
+    * Si votre primo-vaccination date d’il y a moins de 4 mois : faites un test **PCR ou antigénique** dès que possible, puis **2 autotests** de contrôle 2 jours après et 4 jours après le premier test.
+    * Si votre primo-vaccination date d’il y a plus de 4 mois : faites un test antigénique ou PCR **7 jours après** votre dernier contact avec la personne positive.
+
+    Si à l’issue de cette période de vigilance votre test est **négatif**, alors vous pourrez vous faire vacciner.
+
     <div class="voir-aussi">
 
     - [Je suis cas contact Covid, que faire ?](/cas-contact-a-risque.html)
 
     </div>
+
+
 .. question:: Quels sont les facteurs de risque de formes graves de Covid ?
     :level: 3
 
@@ -304,10 +306,11 @@
     :level: 3
 
     **Non**. Si vous êtes [cas contact](/cas-contact-a-risque.html) ou avez été alerté(e) d’un contact à risque par l’application TousAntiCovid, vous devez d’abord **vous assurer que vous n’avez pas été contaminé(e)**.
-    Si vous n'êtes **pas vacciné(e)**, faites un test antigénique ou PCR **7 jours après** votre dernier contact avec la personne positive.
-         
-     Si le résultat est négatif, alors vous pourrez vous faire vacciner. 
-    
+
+    Si vous n’êtes **pas vacciné(e)**, faites un test antigénique ou PCR **7 jours après** votre dernier contact avec la personne positive.
+
+    Si le résultat est négatif, alors vous pourrez vous faire vacciner.
+
     <div class="voir-aussi">
 
     - [Je suis cas contact Covid, que faire ?](/cas-contact-a-risque.html)


### PR DESCRIPTION
Pour plus de simplicité, nous avions supprimé l'indication de délai "raisonnable" entre une notification de cas contact et la vaccination (Cf PR #2001 ), mais sans cette indication la réponse était moins utile. J'ai re-précisé ce délai.

La question de se faire vacciner en étant cas contact concerne à la fois les personnes qui doivent faire leur rappel vaccinal que celles qui souhaitent faire leur primo-vaccination. J'ai ajouté la question : « Je suis cas contact, puis-je recevoir la dose de rappel ? » dans la première partie de la page, consacrée au rappel vaccinal.