### PR TITLE
Autotests gratuits pour les personnels de l’Éducation nationale

### DIFF
--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -137,6 +137,7 @@
     Il est pris en charge par l’Assurance maladie uniquement dans les cas suivants :
      + dépistage des personnes contact à risque en milieu scolaire (enfants de moins de 12 ans, ou personnes de 12 ans et plus complètement vaccinées) ;
      + tests de surveillance à J+2 et J+4 pour les personnes contact à risque (enfants de moins de 12 ans, ou personnes de 12 ans et plus complètement vaccinées) ;
+     + personnels de l’Éducation nationale exerçant en école maternelle, primaire, collège et lycée, ainsi que dans les services d’hébergement, d’accueil et d’activités périscolaires associés ;
      + professionnels exerçant auprès de personnes vulnérables (âgées, handicapées…) et dans la limite de 10 par mois.
 
     En dehors de ces situations, le prix de vente maximal d’un autotest est de 5,20 €.

--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -132,14 +132,15 @@
 .. question:: Qu’est-ce qu’un autotest ?
     :level: 4
 
-    L’autotest est un prélèvement nasal à réaliser chez soi vendu en pharmacie.
+    L’**autotest** est un prélèvement nasal à réaliser chez soi, et disponible en pharmacie.
 
-    Il est pris en charge par l’Assurance maladie uniquement dans les cas suivants :
-     + dépistage des personnes contact à risque en milieu scolaire (enfants de moins de 12 ans, ou personnes de 12 ans et plus complètement vaccinées) ;
-     + tests de surveillance à J+2 et J+4 pour les personnes contact à risque (enfants de moins de 12 ans, ou personnes de 12 ans et plus complètement vaccinées) ;
-     + personnels de l’Éducation nationale exerçant en école maternelle, primaire, collège et lycée, ainsi que dans les services d’hébergement, d’accueil et d’activités périscolaires associés ;
-     + professionnels exerçant auprès de personnes vulnérables (âgées, handicapées…) et dans la limite de 10 par mois.
+    Il est **pris en charge** par l’Assurance maladie dans les cas suivants :
 
-    En dehors de ces situations, le prix de vente maximal d’un autotest est de 5,20 €.
+    * dépistage des personnes **contact à risque** en **milieu scolaire** (enfants de moins de 12 ans, ou personnes de 12 ans et plus complètement vaccinées) ;
+    * tests de surveillance à J+2 et J+4 pour les personnes **contact à risque** (enfants de moins de 12 ans, ou personnes de 12 ans et plus complètement vaccinées) ;
+    * personnels de l’**Éducation nationale** exerçant en école maternelle, primaire, collège et lycée, ainsi que dans les services d’hébergement, d’accueil et d’activités périscolaires associés ;
+    * professionnels exerçant auprès de **personnes vulnérables** (âgées, handicapées…) et dans la limite de 10 par mois.
+
+    En dehors de ces situations, le prix de vente **maximal** d’un autotest est de **5,20 €**.
 
 </div>


### PR DESCRIPTION
Source : https://www.ameli.fr/paris/assure/covid-19/tester-alerter-proteger-comprendre-la-strategie-pour-stopper-l-epidemie/les-tests-de-depistage-du-covid-19/les-autotests-sur-prelevement-nasal

> Ils peuvent être pris en charge :
> (...)
> * pour le personnel de l’Éducation nationale exerçant en école maternelle, primaire, collège et lycée (c’est-à-dire les établissements du premier et du second degré) ainsi que dans les services d’hébergement, d’accueil et d’activités périscolaires qui y sont associés ;

cf. #2021