### PR TITLE
Tech: enlève les slash au début des liens internes

### DIFF
--- a/contenus/thematiques/1-cas-contact-a-risque.md
+++ b/contenus/thematiques/1-cas-contact-a-risque.md
@@ -8,11 +8,11 @@
 
 <div class="voir-aussi">
 
-- [Je suis cas contact d’une personne de mon foyer, que faire ?](/je-vis-avec-personne-covid-positive.html)
+- [Je suis cas contact d’une personne de mon foyer, que faire ?](je-vis-avec-personne-covid-positive.html)
 
-- [Je suis cas contact, puis-je me faire vacciner ?](/je-veux-me-faire-vacciner.html#je-suis-cas-contact-puis-je-me-faire-vacciner)
+- [Je suis cas contact, puis-je me faire vacciner ?](je-veux-me-faire-vacciner.html#je-suis-cas-contact-puis-je-me-faire-vacciner)
 
-- [Je suis cas contact, est-ce que mon test de dépistage est gratuit ?](/tests-de-depistage.html#je-suis-cas-contact-est-ce-que-mon-test-de-depistage-est-gratuit)
+- [Je suis cas contact, est-ce que mon test de dépistage est gratuit ?](tests-de-depistage.html#je-suis-cas-contact-est-ce-que-mon-test-de-depistage-est-gratuit)
 
 </div>
 

--- a/contenus/thematiques/2-j-ai-des-symptomes-covid.md
+++ b/contenus/thematiques/2-j-ai-des-symptomes-covid.md
@@ -60,8 +60,8 @@
 
     <div class="voir-aussi">
 
-    - [Je souhaite faire un test de dépistage](/tests-de-depistage.html)
-    - [Je suis cas contact d’une personne de mon foyer, que faire ?](/je-vis-avec-personne-covid-positive.html)
+    - [Je souhaite faire un test de dépistage](tests-de-depistage.html)
+    - [Je suis cas contact d’une personne de mon foyer, que faire ?](je-vis-avec-personne-covid-positive.html)
 
     </div>
 
@@ -75,8 +75,8 @@
 
     <div class="voir-aussi">
 
-    - [Je souhaite faire un test de dépistage](/tests-de-depistage.html)
-    - [Je suis cas contact d’une personne de mon foyer, que faire ?](/je-vis-avec-personne-covid-positive.html)
+    - [Je souhaite faire un test de dépistage](tests-de-depistage.html)
+    - [Je suis cas contact d’une personne de mon foyer, que faire ?](je-vis-avec-personne-covid-positive.html)
 
     </div>
 </div>

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -34,7 +34,7 @@
 
     <div class="voir-aussi">
 
-    - [Comment se passe mon rappel si je suis vacciné(e) avec une seule dose de Janssen ?](/je-veux-me-faire-vacciner.html#je-suis-vaccine-e-avec-une-seule-dose-de-janssen-comment-se-passe-mon-rappel)
+    - [Comment se passe mon rappel si je suis vacciné(e) avec une seule dose de Janssen ?](je-veux-me-faire-vacciner.html#je-suis-vaccine-e-avec-une-seule-dose-de-janssen-comment-se-passe-mon-rappel)
     - [Quand devrai-je recevoir ma dose de rappel pour conserver mon passe vaccinal ?](#avant-quelle-date-dois-je-recevoir-la-dose-de-rappel-dite-3-e-dose-pour-conserver-mon-passe-vaccinal)
 
     </div>
@@ -57,7 +57,7 @@
 
     <div class="voir-aussi">
 
-    - [Réponses à vos questions sur la primo-vaccination](/je-veux-me-faire-vacciner.html#la-vaccination-initiale-schema-vaccinal-a-1-ou-2-doses)
+    - [Réponses à vos questions sur la primo-vaccination](je-veux-me-faire-vacciner.html#la-vaccination-initiale-schema-vaccinal-a-1-ou-2-doses)
 
     </div>
 
@@ -126,8 +126,8 @@
 
     <div class="voir-aussi">
 
-    - [Suis-je concerné par la dose de rappel ?](/je-veux-me-faire-vacciner.html#suis-je-concerne-par-la-dose-de-rappel-dite-3-e-dose)
-    - [À partir de quand pourrai-je recevoir la dose de rappel ?](/je-veux-me-faire-vacciner.html#a-partir-de-quand-pourrai-je-recevoir-la-dose-de-rappel-dite-3-e-dose)
+    - [Suis-je concerné par la dose de rappel ?](je-veux-me-faire-vacciner.html#suis-je-concerne-par-la-dose-de-rappel-dite-3-e-dose)
+    - [À partir de quand pourrai-je recevoir la dose de rappel ?](je-veux-me-faire-vacciner.html#a-partir-de-quand-pourrai-je-recevoir-la-dose-de-rappel-dite-3-e-dose)
     - [Tout savoir sur le rappel vaccinal contre la Covid-19](https://www.gouvernement.fr/tout-savoir-sur-le-rappel-vaccinal-contre-la-covid-19) (gouvernement.fr)
 
     </div>
@@ -152,7 +152,7 @@
 .. question:: Je ne peux pas me faire vacciner, comment obtenir un passe vaccinal ?
     :level: 3
 
-    - En cas de **contre-indication médicale** (voir la [liste des contre-indications à la vaccination](/je-veux-me-faire-vacciner.html#y-a-t-il-des-contre-indications-a-la-vaccination)), vous pouvez demander à votre médecin d’établir un **certificat médical** (formulaire Cerfa n°16183*01).
+    - En cas de **contre-indication médicale** (voir la [liste des contre-indications à la vaccination](je-veux-me-faire-vacciner.html#y-a-t-il-des-contre-indications-a-la-vaccination)), vous pouvez demander à votre médecin d’établir un **certificat médical** (formulaire Cerfa n°16183*01).
 
       Il faudra envoyer le premier volet du certificat à votre **caisse d’Assurance Maladie**. Après vérification, elle vous adressera un **certificat de contre-indication à la vaccination**, avec un **QR code** valable  pous tous les lieux et activités en **France**.
 
@@ -216,7 +216,7 @@
 
     <div class="voir-aussi">
 
-    - Consultez notre page de [conseils pour les enfants et adolescents](/conseils-pour-les-enfants.html) pour plus d’informations sur leur vaccination et sur le protocole sanitaire dans les établissements scolaires.
+    - Consultez notre page de [conseils pour les enfants et adolescents](conseils-pour-les-enfants.html) pour plus d’informations sur leur vaccination et sur le protocole sanitaire dans les établissements scolaires.
 
     </div>
 
@@ -240,9 +240,9 @@
 
     <div class="voir-aussi">
 
-    - Consultez notre page « [Enfants et adolescents : vaccination et scolarité](/conseils-pour-les-enfants.html) ».
+    - Consultez notre page « [Enfants et adolescents : vaccination et scolarité](conseils-pour-les-enfants.html) ».
 
-    - Consultez notre page « [Je souhaite me faire vacciner, que faut-il savoir ?](/je-veux-me-faire-vacciner.html) ».
+    - Consultez notre page « [Je souhaite me faire vacciner, que faut-il savoir ?](je-veux-me-faire-vacciner.html) ».
 
     </div>
 
@@ -419,7 +419,7 @@
 
     - Pour savoir où faire un test (laboratoire, pharmacie…), consultez l’[annuaire des lieux de dépistage sur sante.fr](https://www.sante.fr/cf/centres-depistage-covid.html).
 
-    - Pour en savoir plus sur les différents tests, consultez notre page « [Les tests de dépistage](/tests-de-depistage.html) »
+    - Pour en savoir plus sur les différents tests, consultez notre page « [Les tests de dépistage](tests-de-depistage.html) »
 
     </div>
 
@@ -440,7 +440,7 @@
 
     <div class="conseil conseil-jaune">
 
-    Attention, les tests de dépistage sont **payants** (43,89 € pour les tests RT-PCR et de 22 à 45 € pour un test antigénique). Si vous êtes assuré social ou européen, ils peuvent êtres pris en charge sous [certaines conditions](/tests-de-depistage.html#dans-quels-cas-les-tests-de-depistage-sont-ils-gratuits).
+    Attention, les tests de dépistage sont **payants** (43,89 € pour les tests RT-PCR et de 22 à 45 € pour un test antigénique). Si vous êtes assuré social ou européen, ils peuvent êtres pris en charge sous [certaines conditions](tests-de-depistage.html#dans-quels-cas-les-tests-de-depistage-sont-ils-gratuits).
 
     </div>
 
@@ -448,7 +448,7 @@
 
     - Pour savoir où faire un test (laboratoire, pharmacie…), consultez l’[annuaire des lieux de dépistage sur sante.fr](https://www.sante.fr/cf/centres-depistage-covid.html).
 
-    - Pour en savoir plus sur les différents tests, consultez notre page « [Les tests de dépistage](/tests-de-depistage.html) »
+    - Pour en savoir plus sur les différents tests, consultez notre page « [Les tests de dépistage](tests-de-depistage.html) »
 
     </div>
 

--- a/contenus/thematiques/4-je-suis-vaccine.md
+++ b/contenus/thematiques/4-je-suis-vaccine.md
@@ -47,7 +47,7 @@
 
     <div class="voir-aussi">
 
-    - Tous les détails sur la conduite à tenir : [« Je suis cas contact Covid, que faire ? »](/cas-contact-a-risque.html#schema-vaccinal-complet).
+    - Tous les détails sur la conduite à tenir : [« Je suis cas contact Covid, que faire ? »](cas-contact-a-risque.html#schema-vaccinal-complet).
 
     </div>
 
@@ -68,6 +68,6 @@
 
     Nous vous conseillons de vérifier directement auprès des autorités du pays de destination les conditions d’accès sur leur territoire (tests, quarantaine, vaccin…), en consultant  par exemple le site internet de l’ambassade ou du consulat.
 
-    Pour en savoir plus, [consultez notre page sur le passe vaccinal et les voyages](/pass-sanitaire-qr-code-voyages.html).
+    Pour en savoir plus, [consultez notre page sur le passe vaccinal et les voyages](pass-sanitaire-qr-code-voyages.html).
 
 </div>

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -69,7 +69,7 @@
 
     * si vous avez été vacciné(e) avec le **vaccin Janssen** :
 
-        - consultez la question « [Je suis vacciné(e) avec une seule dose de Janssen. Comment se passe mon rappel ?](/je-veux-me-faire-vacciner.html#je-suis-vaccine-e-avec-une-seule-dose-de-janssen-comment-se-passe-mon-rappel) » ;
+        - consultez la question « [Je suis vacciné(e) avec une seule dose de Janssen. Comment se passe mon rappel ?](je-veux-me-faire-vacciner.html#je-suis-vaccine-e-avec-une-seule-dose-de-janssen-comment-se-passe-mon-rappel) » ;
 
     {{ formulaire('rappel', prefixe='a-partir-de-quand') }}
 
@@ -107,7 +107,7 @@
 .. question:: Je suis cas contact, puis-je recevoir la dose de rappel ?
     :level: 3
 
-    **Non**. Si vous êtes [cas contact](/cas-contact-a-risque.html) ou avez été alerté(e) d’un contact à risque par l’application TousAntiCovid, vous devez d’abord **vous assurer que vous n’avez pas été contaminé(e)** en vous faisant tester.
+    **Non**. Si vous êtes [cas contact](cas-contact-a-risque.html) ou avez été alerté(e) d’un contact à risque par l’application TousAntiCovid, vous devez d’abord **vous assurer que vous n’avez pas été contaminé(e)** en vous faisant tester.
 
     * Si votre primo-vaccination date d’il y a moins de 4 mois : faites un test **PCR ou antigénique** dès que possible, puis **2 autotests** de contrôle 2 jours après et 4 jours après le premier test.
     * Si votre primo-vaccination date d’il y a plus de 4 mois : faites un test antigénique ou PCR **7 jours après** votre dernier contact avec la personne positive.
@@ -116,7 +116,7 @@
 
     <div class="voir-aussi">
 
-    - [Je suis cas contact Covid, que faire ?](/cas-contact-a-risque.html)
+    - [Je suis cas contact Covid, que faire ?](cas-contact-a-risque.html)
 
     </div>
 
@@ -225,7 +225,7 @@
 
     **Oui**. Il est possible de réaliser le rappel du vaccin contre la Covid en même temps que le vaccin contre la grippe, mais il est aussi possible d’espacer les deux injections.
 
-    La campagne annuelle de vaccination contre la grippe a commencé le 22 octobre 2021 pour les publics prioritaires. Depuis le **23 novembre 2021**, elle est ouverte à **toute la population**. Si vous êtes [éligible au rappel vaccinal](/je-veux-me-faire-vacciner.html#suis-je-concerne-par-la-dose-de-rappel-dite-3-e-dose) contre la Covid, vous pourrez recevoir les deux vaccins en même temps.
+    La campagne annuelle de vaccination contre la grippe a commencé le 22 octobre 2021 pour les publics prioritaires. Depuis le **23 novembre 2021**, elle est ouverte à **toute la population**. Si vous êtes [éligible au rappel vaccinal](je-veux-me-faire-vacciner.html#suis-je-concerne-par-la-dose-de-rappel-dite-3-e-dose) contre la Covid, vous pourrez recevoir les deux vaccins en même temps.
 
     En ville, c’est possible dans les **pharmacies** qui vaccinent avec les deux vaccins, et dans les cabinets médicaux ou infirmiers.
 
@@ -236,7 +236,7 @@
 
  <div class="voir-aussi">
 
-- [Je veux des informations sur la vaccination des enfants et adolescents](/conseils-pour-les-enfants.html#la-vaccination-contre-la-covid)
+- [Je veux des informations sur la vaccination des enfants et adolescents](conseils-pour-les-enfants.html#la-vaccination-contre-la-covid)
 
  </div>
 
@@ -297,7 +297,7 @@
 
     <div class="voir-aussi">
 
-    - [Je ne peux pas me faire vacciner, comment obtenir un passe vaccinal ?](/pass-sanitaire-qr-code-voyages.html#je-ne-peux-pas-me-faire-vacciner-comment-obtenir-un-passe-vaccinal)
+    - [Je ne peux pas me faire vacciner, comment obtenir un passe vaccinal ?](pass-sanitaire-qr-code-voyages.html#je-ne-peux-pas-me-faire-vacciner-comment-obtenir-un-passe-vaccinal)
 
     </div>
 
@@ -305,7 +305,7 @@
 .. question:: Je suis cas contact, puis-je me faire vacciner ?
     :level: 3
 
-    **Non**. Si vous êtes [cas contact](/cas-contact-a-risque.html) ou avez été alerté(e) d’un contact à risque par l’application TousAntiCovid, vous devez d’abord **vous assurer que vous n’avez pas été contaminé(e)**.
+    **Non**. Si vous êtes [cas contact](cas-contact-a-risque.html) ou avez été alerté(e) d’un contact à risque par l’application TousAntiCovid, vous devez d’abord **vous assurer que vous n’avez pas été contaminé(e)**.
 
     Si vous n’êtes **pas vacciné(e)**, faites un test antigénique ou PCR **7 jours après** votre dernier contact avec la personne positive.
 
@@ -313,7 +313,7 @@
 
     <div class="voir-aussi">
 
-    - [Je suis cas contact Covid, que faire ?](/cas-contact-a-risque.html)
+    - [Je suis cas contact Covid, que faire ?](cas-contact-a-risque.html)
 
     </div>
 
@@ -388,7 +388,7 @@
 
     Cependant, les vaccins ne sont **jamais efficaces à 100 %**, et il reste donc possible d’attraper la Covid et de la transmettre. C’est pourquoi, même vacciné(e), il faut continuer à porter le **masque**, respecter les **gestes barrières** et les mesures de **prévention** (test et isolement si vous ressentez des symptômes ou si vous êtes cas contact).
 
-    Si vous ressentez des symptômes ou si vous êtes positif(ve) à la Covid, [obtenez en quelques clics des conseils sur la conduite à tenir](/j-ai-des-symptomes-covid.html).
+    Si vous ressentez des symptômes ou si vous êtes positif(ve) à la Covid, [obtenez en quelques clics des conseils sur la conduite à tenir](j-ai-des-symptomes-covid.html).
 
 
 .. question:: Quels sont les effets secondaires des vaccins contre la Covid ?
@@ -414,7 +414,7 @@
 
     **Non, la vaccination ne rend en aucun cas positif**, il n’y a pas de virus actif dans les vaccins. Vous pouvez ressentir des effets secondaires (fièvre, fatigue…) suite à la vaccination, mais vous n’êtes **pas contagieux**.
 
-    Si vous avez réalisé un [test de dépistage](/tests-de-depistage.html) après votre vaccination et qu’il est **positif**, cela n’est pas dû au vaccin. Cela signifie que vous avez été contaminé(e) avant ou après votre injection. Nous vous encourageons à vous isoler et à [décrire votre situation](/#symptomes) pour obtenir des conseils personnalisés sur la conduite à tenir.
+    Si vous avez réalisé un [test de dépistage](tests-de-depistage.html) après votre vaccination et qu’il est **positif**, cela n’est pas dû au vaccin. Cela signifie que vous avez été contaminé(e) avant ou après votre injection. Nous vous encourageons à vous isoler et à [décrire votre situation](/#symptomes) pour obtenir des conseils personnalisés sur la conduite à tenir.
 
 
 ## Vaccination, grossesse et allaitement

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -119,7 +119,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     <div class="voir-aussi">
 
-    - Notre page « [Je suis cas contact Covid, que faire ?](/cas-contact-a-risque.html) »
+    - Notre page « [Je suis cas contact Covid, que faire ?](cas-contact-a-risque.html) »
 
     - Le [protocole sanitaire](https://www.education.gouv.fr/annee-scolaire-2021-2022-protocole-sanitaire-et-mesures-de-fonctionnement-324257) et les [questions-réponses](https://www.education.gouv.fr/covid-19-questions-reponses) sur le site de l’Éducation nationale
 
@@ -169,7 +169,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     <div class="voir-aussi">
 
-    - Notre page « [Je suis cas contact Covid, que faire ?](/cas-contact-a-risque.html) »
+    - Notre page « [Je suis cas contact Covid, que faire ?](cas-contact-a-risque.html) »
 
     - Le [protocole sanitaire](https://www.education.gouv.fr/annee-scolaire-2021-2022-protocole-sanitaire-et-mesures-de-fonctionnement-324257) et les [questions-réponses](https://www.education.gouv.fr/covid-19-questions-reponses) sur le site de l’Éducation nationale
 
@@ -214,7 +214,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     <div class="voir-aussi">
 
-    - Notre page « [Je suis cas contact Covid, que faire ?](/cas-contact-a-risque.html) »
+    - Notre page « [Je suis cas contact Covid, que faire ?](cas-contact-a-risque.html) »
 
     - [Je ne peux pas télétravailler, puis-je obtenir un arrêt de travail pour garder mon enfant qui ne peut pas aller à l’école à cause de la Covid ?](#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid)
 
@@ -269,7 +269,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     - Notre rubrique sur la [vaccination des enfants et adolescents](#la-vaccination-contre-la-covid) ci-dessous
 
-    - Notre autre page sur le [passe vaccinal](/pass-sanitaire-qr-code-voyages.html)
+    - Notre autre page sur le [passe vaccinal](pass-sanitaire-qr-code-voyages.html)
 
     </div>
 
@@ -378,7 +378,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     <div class="voir-aussi">
 
-    * Pour plus d’informations, consultez notre page sur [les voyages et le passe vaccinal](/pass-sanitaire-qr-code-voyages.html).
+    * Pour plus d’informations, consultez notre page sur [les voyages et le passe vaccinal](pass-sanitaire-qr-code-voyages.html).
 
     </div>
 
@@ -406,7 +406,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     <div class="voir-aussi">
 
-    * Pour plus d’informations, consultez notre page sur [les voyages et le passe sanitaire](/pass-sanitaire-qr-code-voyages.html).
+    * Pour plus d’informations, consultez notre page sur [les voyages et le passe sanitaire](pass-sanitaire-qr-code-voyages.html).
 
     </div>
 
@@ -438,7 +438,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     <div class="voir-aussi">
 
-    - En savoir plus sur les [types de tests de dépistage](/tests-de-depistage.html) et trouver celui adapté à la situation de votre enfant.
+    - En savoir plus sur les [types de tests de dépistage](tests-de-depistage.html) et trouver celui adapté à la situation de votre enfant.
 
     </div>
 
@@ -457,7 +457,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     <div class="voir-aussi">
 
-    - [Je vis avec une personne positive, que dois-je faire ?](/je-vis-avec-personne-covid-positive.html)
+    - [Je vis avec une personne positive, que dois-je faire ?](je-vis-avec-personne-covid-positive.html)
 
     </div>
 
@@ -555,7 +555,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     <div class="voir-aussi">
 
-    * Consultez la conduite à suivre [lorsque l’on vit avec une personne positive](/je-vis-avec-personne-covid-positive.html) (test, isolement, conseils pratiques…)
+    * Consultez la conduite à suivre [lorsque l’on vit avec une personne positive](je-vis-avec-personne-covid-positive.html) (test, isolement, conseils pratiques…)
 
     </div>
 

--- a/contenus/thematiques/9-covid-et-travail.md
+++ b/contenus/thematiques/9-covid-et-travail.md
@@ -38,11 +38,11 @@
 
     - Consulter le guide : [Covid-19 conseils et bonnes pratiques pour les salariés](https://travail-emploi.gouv.fr/IMG/pdf/051021_fiches_covid_salariev7ok.pdf)
 
-    - [J’ai des symptômes ou mon test est positif, que faire ?](/j-ai-des-symptomes-covid.html)
+    - [J’ai des symptômes ou mon test est positif, que faire ?](j-ai-des-symptomes-covid.html)
 
-    - [Je suis cas contact, que faire ?](/cas-contact-a-risque.html)
+    - [Je suis cas contact, que faire ?](cas-contact-a-risque.html)
 
-    - [Je vis avec une personne positive à la Covid, que dois-je faire ?](/je-vis-avec-personne-covid-positive.html)
+    - [Je vis avec une personne positive à la Covid, que dois-je faire ?](je-vis-avec-personne-covid-positive.html)
 
     </div>
 
@@ -58,7 +58,7 @@
 
     <div class="voir-aussi">
 
-    - Voir notre page « [J’ai des symptômes de la Covid ou mon test est positif, que faire ?](/j-ai-des-symptomes-covid.html) »
+    - Voir notre page « [J’ai des symptômes de la Covid ou mon test est positif, que faire ?](j-ai-des-symptomes-covid.html) »
 
     - Voir la rubrique « Arrêt de travail » ci-dessous
 
@@ -219,7 +219,7 @@
         * l’obésité (IMC de 30 et plus),
         * un cancer évolutif sous traitement (hors hormonothérapie),
         * une cirrhose ayant atteint le stade B du score de Child Pugh ;
-    2. vous souffrez de l’une des **pathologies** mentionnées ci-dessus et d’une [contre-indication à la vaccination](/je-veux-me-faire-vacciner.html#y-a-t-il-des-contre-indications-a-la-vaccination) contre la Covid ;
+    2. vous souffrez de l’une des **pathologies** mentionnées ci-dessus et d’une [contre-indication à la vaccination](je-veux-me-faire-vacciner.html#y-a-t-il-des-contre-indications-a-la-vaccination) contre la Covid ;
     3. vous souffrez d’une **immunodépression grave :**
         * suite à une transplantation d’organe ou de cellules souches hématopoïétiques,
         * vous êtes sous chimiothérapie lymphopéniante,
@@ -244,7 +244,7 @@
 
     <div class="voir-aussi">
 
-    - Consultez notre page « [Je souhaite me faire vacciner](/je-veux-me-faire-vacciner.html) »
+    - Consultez notre page « [Je souhaite me faire vacciner](je-veux-me-faire-vacciner.html) »
 
     </div>
 
@@ -256,7 +256,7 @@
 
     <div class="voir-aussi">
 
-    - Consultez notre page de [conseils pour les mineurs et leur vaccination](/conseils-pour-les-enfants.html)
+    - Consultez notre page de [conseils pour les mineurs et leur vaccination](conseils-pour-les-enfants.html)
 
     </div>
 

--- a/contenus/thematiques/formulaires/tests-de-depistage.md
+++ b/contenus/thematiques/formulaires/tests-de-depistage.md
@@ -91,13 +91,13 @@
 
 <div id="{{prefixe}}-symptomes-moins-4-jours-reponse" class="statut statut-bleu" hidden>
 
-Vous avez des symptômes qui peuvent évoquer la Covid depuis moins de 4 jours, nous vous recommandons de faire un test **antigénique** ou **PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
+Vous avez des symptômes qui peuvent évoquer la Covid depuis moins de 4 jours, nous vous recommandons de faire un test **antigénique** ou **PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](j-ai-des-symptomes-covid.html).
 
 </div>
 
 <div id="{{prefixe}}-symptomes-plus-4-jours-reponse" class="statut statut-bleu" hidden>
 
-Vous avez des symptômes qui peuvent évoquer la Covid depuis plus de 4 jours, nous vous recommandons de faire un **test PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](/j-ai-des-symptomes-covid.html).
+Vous avez des symptômes qui peuvent évoquer la Covid depuis plus de 4 jours, nous vous recommandons de faire un **test PCR nasopharyngé**. Consultez notre page thématique [« J'ai des symptômes de la Covid, que faire ? »](j-ai-des-symptomes-covid.html).
 
 </div>
 
@@ -105,7 +105,7 @@ Vous avez des symptômes qui peuvent évoquer la Covid depuis plus de 4 jours, 
 
 Vous n’avez pas de symptômes qui peuvent évoquer la Covid mais vous êtes cas contact, nous vous recommandons de faire un **test antigénique** si vous venez de l’apprendre.
 
-Pour un test de contrôle (7 jours après votre contact à risque ), les tests **antigénique** ou **PCR nasopharyngé** sont indiqués.  Consultez notre page thématique [« Je suis cas contact Covid, que faire ? »](/cas-contact-a-risque.html).
+Pour un test de contrôle (7 jours après votre contact à risque ), les tests **antigénique** ou **PCR nasopharyngé** sont indiqués.  Consultez notre page thématique [« Je suis cas contact Covid, que faire ? »](cas-contact-a-risque.html).
 
 </div>
 
@@ -119,7 +119,7 @@ Vous n’avez pas de symptômes qui peuvent évoquer la Covid, vous n’êtes pa
 
 Vous n’avez pas de symptômes qui peuvent évoquer la Covid et vous n’êtes pas cas contact :
 
-* Si vous souhaitez obtenir un « [passe sanitaire](/pass-sanitaire-qr-code-voyages.html) » (mineurs de 12 à 15 ans), un test négatif **PCR nasopharyngé** ou **antigénique**, réalisé il y a moins de **24 h** est nécessaire.
+* Si vous souhaitez obtenir un « [passe sanitaire](pass-sanitaire-qr-code-voyages.html) » (mineurs de 12 à 15 ans), un test négatif **PCR nasopharyngé** ou **antigénique**, réalisé il y a moins de **24 h** est nécessaire.
 * Si vous rendez visite à des personnes vulnérables, un test **antigénique** ou **PCR nasopharyngé** est indiqué.
 * Si vous travaillez régulièrement avec des personnes fragiles, il est recommandé de vous tester régulièrement avec les **autotests** vendus en pharmacie (les professionnels exerçant à domicile auprès de personnes vulnérables peuvent obtenir la prise en charge de 10 autotests par mois en présentant leur carte professionnelle au pharmacien).
 


### PR DESCRIPTION
Les liens générés dans le HTML final seront bien toujours des liens absolus.

Le but est de faciliter la migration éventuelle à Parcel V2.