### PR TITLE
Préserve les espaces insécables en les codant en entités HTML

### DIFF
--- a/construction/directives/question.py
+++ b/construction/directives/question.py
@@ -95,7 +95,7 @@ class QuestionDirective(Directive):
             else ""
         )
         return f"""<details id="{question_id}" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question"{' open' if open_ else ''}>
-{render_html_summary('', typographie(question), level, extra_span=' itemprop="name"')}
+{render_html_summary('', typographie(question, html=True), level, extra_span=' itemprop="name"')}
 <div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
 <div itemprop="text">
 {text}</div>

--- a/construction/directives/renvoi.py
+++ b/construction/directives/renvoi.py
@@ -35,10 +35,10 @@ class RenvoiDirective(Directive):
     @staticmethod
     def render_html(text, nom_page, titre_page, id_question, titre_question, level):
         return f"""<details id="{id_question}">
-    {render_html_summary('', typographie(titre_question), level)}
+    {render_html_summary('', typographie(titre_question, html=True), level)}
     <p>
         Voir la réponse sur notre page
-        « <a href="/{nom_page}#{id_question}">{typographie(titre_page)}</a> ».
+        « <a href="/{nom_page}#{id_question}">{typographie(titre_page, html=True)}</a> ».
     </p>
 </details>
 """

--- a/construction/markdown.py
+++ b/construction/markdown.py
@@ -14,10 +14,10 @@ from .typographie import typographie
 
 class FrenchTypographyMixin:
     def text(self, text_):
-        return typographie(super().text(text_))
+        return typographie(super().text(text_), html=True)
 
     def block_html(self, html):
-        return typographie(super().block_html(html))
+        return typographie(super().block_html(html), html=True)
 
 
 class ClassMixin:

--- a/construction/tests/test_markdown.py
+++ b/construction/tests/test_markdown.py
@@ -257,7 +257,7 @@ class TestQuestionDirective:
                 <p>Vous pouvez vous faire vacciner <strong>dès maintenant</strong>&nbsp;:</p>
                 <ul>
                 <li>si vous avez <strong>18&nbsp;ans et plus</strong>, sans conditions&#8239;;</li>
-                <li>si vous avez entre <strong>16&nbsp;et 17&nbsp;ans</strong> et présentez un risque de développer une <strong>forme très grave</strong> de Covid (cancer, dialyse, trisomie 21, etc.)&#8239;;</li>
+                <li>si vous avez entre <strong>16&nbsp;et 17&nbsp;ans</strong> et présentez un risque de développer une <strong>forme très grave</strong> de Covid (cancer, dialyse, trisomie&nbsp;21, etc.)&#8239;;</li>
                 <li>si vous êtes au <strong>second trimestre</strong> de votre grossesse.</li>
                 </ul>
                 </div>
@@ -308,7 +308,7 @@ class TestQuestionDirective:
                 <p>Vous pouvez vous faire vacciner <strong>dès maintenant</strong>&nbsp;:</p>
                 <ul>
                 <li>si vous avez <strong>18&nbsp;ans et plus</strong>, sans conditions&#8239;;</li>
-                <li>si vous avez entre <strong>16&nbsp;et 17&nbsp;ans</strong> et présentez un risque de développer une <strong>forme très grave</strong> de Covid (cancer, dialyse, trisomie 21, etc.)&#8239;;</li>
+                <li>si vous avez entre <strong>16&nbsp;et 17&nbsp;ans</strong> et présentez un risque de développer une <strong>forme très grave</strong> de Covid (cancer, dialyse, trisomie&nbsp;21, etc.)&#8239;;</li>
                 <li>si vous êtes au <strong>second trimestre</strong> de votre grossesse.</li>
                 </ul>
                 </div>

--- a/construction/tests/test_typographie.py
+++ b/construction/tests/test_typographie.py
@@ -2,62 +2,81 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "in_,out_",
+    "in_,out_unicode, out_html",
     [
-        ("", ""),
-        (" ", " "),
-        ("\u00a0", "\u00a0"),
-        ("\u202f", "\u202f"),
-        ("ici !", "ici&#8239;!"),
-        ("non ?", "non&#8239;?"),
-        ("infos :", "infos&nbsp;:"),
-        ("entre « guillemets »", "entre «&nbsp;guillemets&nbsp;»"),
+        ("", "", ""),
+        (" ", " ", " "),
+        ("\u00a0", "\u00a0", "&nbsp;"),
+        ("\u202f", "\u202f", "&#8239;"),
+        ("ici !", "ici\u202f!", "ici&#8239;!"),
+        ("non ?", "non\u202f?", "non&#8239;?"),
+        ("infos :", "infos\u00a0:", "infos&nbsp;:"),
+        (
+            "entre « guillemets »",
+            "entre «\u00a0guillemets\u00a0»",
+            "entre «&nbsp;guillemets&nbsp;»",
+        ),
         (
             'entre « <a href="">guillemets avec lien</a> »',
+            'entre «\u00a0<a href="">guillemets avec lien</a>\u00a0»',
             'entre «&nbsp;<a href="">guillemets avec lien</a>&nbsp;»',
         ),
-        ("18 h", "18&#8239;h"),
-        ("24 heures", "24&nbsp;heures"),
-        ("24&nbsp;heures", "24&nbsp;heures"),
-        ("18 hibous", "18&nbsp;hibous"),
-        ("1 j", "1&#8239;j"),
-        ("1 jour", "1&nbsp;jour"),
-        ("2 j", "2&#8239;j"),
-        ("2 jours", "2&nbsp;jours"),
-        ("65 ans", "65&nbsp;ans"),
-        ("150 g", "150&#8239;g"),
-        ("150 g de farine", "150&#8239;g de farine"),
-        ("150 gibbons", "150&nbsp;gibbons"),
-        ("200 mg", "200&#8239;mg"),
-        ("200 µg", "200&#8239;µg"),
-        ("à 10 000 kilomètres", "à 10&#8239;000&nbsp;kilomètres"),
-        ("100&nbsp;%", "100&#8239;%"),
-        ("pour&nbsp;100&nbsp;% des cas", "pour&nbsp;100&#8239;% des cas"),
+        ("18 h", "18\u202fh", "18&#8239;h"),
+        ("24 heures", "24\u00a0heures", "24&nbsp;heures"),
+        ("24&nbsp;heures", "24\u00a0heures", "24&nbsp;heures"),
+        ("18 hibous", "18\u00a0hibous", "18&nbsp;hibous"),
+        ("1 j", "1\u202fj", "1&#8239;j"),
+        ("1 jour", "1\u00a0jour", "1&nbsp;jour"),
+        ("2 j", "2\u202fj", "2&#8239;j"),
+        ("2 jours", "2\u00a0jours", "2&nbsp;jours"),
+        ("65 ans", "65\u00a0ans", "65&nbsp;ans"),
+        ("150 g", "150\u202fg", "150&#8239;g"),
+        ("150 g de farine", "150\u202fg de farine", "150&#8239;g de farine"),
+        ("150 gibbons", "150\u00a0gibbons", "150&nbsp;gibbons"),
+        ("200 mg", "200\u202fmg", "200&#8239;mg"),
+        ("200 µg", "200\u202fµg", "200&#8239;µg"),
+        (
+            "à 10 000 kilomètres",
+            "à 10\u202f000\u00a0kilomètres",
+            "à 10&#8239;000&nbsp;kilomètres",
+        ),
+        ("100&nbsp;%", "100\u202f%", "100&#8239;%"),
+        (
+            "pour&nbsp;100&nbsp;% des cas",
+            "pour&nbsp;100\u202f% des cas",
+            "pour&nbsp;100&#8239;% des cas",
+        ),
         (
             '<h2 itemprop="name">Est-ce que je peux voyager&nbsp;?</h2>',
+            '<h2 itemprop="name">Est-ce que je peux voyager\u202f?</h2>',
             '<h2 itemprop="name">Est-ce que je peux voyager&#8239;?</h2>',
         ),
-        ("Covid-19 :", "Covid-19&nbsp;:"),
-        ("35,5&nbsp;°C", "35,5&#8239;°C"),
+        ("Covid-19 :", "Covid-19\u00a0:", "Covid-19&nbsp;:"),
+        ("35,5&nbsp;°C", "35,5\u202f°C", "35,5&#8239;°C"),
         (
             "« Comment mettre son masque ? »",
+            "«\u00a0Comment mettre son masque\u202f?\u00a0»",
             "«&nbsp;Comment mettre son masque&#8239;?&nbsp;»",
         ),
         (
             "« Comment mettre son masque ! »",
+            "«\u00a0Comment mettre son masque\u202f!\u00a0»",
             "«&nbsp;Comment mettre son masque&#8239;!&nbsp;»",
         ),
         (
             "« Comment mettre son masque. »",
+            "«\u00a0Comment mettre son masque.\u00a0»",
             "«&nbsp;Comment mettre son masque.&nbsp;»",
         ),
         (
             "« Comment mettre son masque… »",
+            "«\u00a0Comment mettre son masque…\u00a0»",
             "«&nbsp;Comment mettre son masque…&nbsp;»",
         ),
     ],
 )
-def test_espaces_insecables(in_, out_):
+def test_espaces_insecables(in_, out_unicode, out_html):
     from construction.typographie import typographie
 
-    assert typographie(in_) == out_
+    assert typographie(in_) == out_unicode
+    assert typographie(in_, html=True) == out_html

--- a/src/scripts/actions.js
+++ b/src/scripts/actions.js
@@ -63,7 +63,7 @@ export function bindSuppressionTotale(element, app) {
     element.addEventListener('click', (event) => {
         event.preventDefault()
         app.plausible('Suppression totale')
-        if (confirm('Êtes-vous sûr·e de vouloir supprimer tous les profils ?')) {
+        if (confirm('Êtes-vous sûr·e de vouloir supprimer tous les profils\u00a0?')) {
             app.supprimerTout().then(() => {
                 if (app.router) {
                     if (app.router.lastRouteResolved().url !== CHEMIN_ACCUEIL) {

--- a/src/scripts/injection.js
+++ b/src/scripts/injection.js
@@ -11,7 +11,7 @@ export function titreConseils(element, profil) {
     if (!element) return
     const titre = profil.estMonProfil()
         ? 'Mes conseils'
-        : `Conseils pour « ${profil.nom} »`
+        : `Conseils pour «\u00a0${profil.nom}\u00a0»`
     element.textContent = titre
 }
 
@@ -42,13 +42,15 @@ export function caracteristiquesARisques(element, algoOrientation) {
 function _caracteristiquesARisques(algoOrientation) {
     let caracteristiques = []
     if (algoOrientation.sup65) {
-        caracteristiques.push('vous êtes âgé·e de plus de 65 ans')
+        caracteristiques.push('vous êtes âgé·e de plus de 65\u00a0ans')
     } else if (algoOrientation.profil.grossesse_3e_trimestre) {
         caracteristiques.push('vous êtes au 3e trimestre de votre grossesse')
     }
     if (algoOrientation.imc > 30) {
         caracteristiques.push(
-            'vous avez un IMC supérieur à 30 (' + Math.round(algoOrientation.imc) + ')'
+            'vous avez un IMC supérieur\u00a0à\u00a030\u00a0(' +
+                Math.round(algoOrientation.imc) +
+                ')'
         )
     }
     return caracteristiques

--- a/src/scripts/page/introduction.js
+++ b/src/scripts/page/introduction.js
@@ -95,7 +95,7 @@ function bindSuppression(element, app) {
         const nom = element.dataset.deleteProfil
         const description =
             nom === 'mes_infos' ? 'vos réponses' : `les réponses de ${nom}`
-        if (confirm(`Êtes-vous sûr·e de vouloir supprimer ${description} ?`)) {
+        if (confirm(`Êtes-vous sûr·e de vouloir supprimer ${description}\u00a0?`)) {
             app.supprimerProfil(nom).then(() => {
                 app.chargerProfilActuel().then(() => {
                     // TODO: find a clever way to re-render the current page.

--- a/src/scripts/page/suiviintroduction.js
+++ b/src/scripts/page/suiviintroduction.js
@@ -17,7 +17,7 @@ function bindSuppression(element, app) {
         event.preventDefault()
         const nom = element.dataset.deleteSuivi
         const description = nom === 'mes_infos' ? 'votre suivi' : `le suivi de ${nom}`
-        if (confirm(`Êtes-vous sûr·e de vouloir supprimer ${description} ?`)) {
+        if (confirm(`Êtes-vous sûr·e de vouloir supprimer ${description}\u00a0?`)) {
             app.supprimerSuivi(nom).then(() => {
                 app.chargerProfilActuel().then(() => {
                     // TODO: find a clever way to re-render the current page.

--- a/src/scripts/page/thematiques/main.js
+++ b/src/scripts/page/thematiques/main.js
@@ -173,8 +173,8 @@ function feedbackPageEnCours(app) {
             opacityTransition(feedbackQuestionForm, 500, (feedbackQuestionForm) => {
                 let label =
                     choix === 'oui'
-                        ? 'Avez-vous des remarques ou des suggestions pour améliorer ces conseils ?'
-                        : 'Pouvez-vous nous en dire plus, afin que nous puissions améliorer ces conseils ?'
+                        ? 'Avez-vous des remarques ou des suggestions pour améliorer ces conseils\u00a0?'
+                        : 'Pouvez-vous nous en dire plus, afin que nous puissions améliorer ces conseils\u00a0?'
                 demandeRemarques(feedbackQuestionForm, choix, question, reponse, label)
             })
         })
@@ -215,8 +215,8 @@ function afficheRemerciements(feedbackQuestionForm, choix, reponse) {
     remerciements.style.textAlign = 'center'
     remerciements.style.border = '2px solid #d5dbef'
     remerciements.innerHTML = `
-        <p>Votre réponse : ${reponse}</p>
-        <p>Merci pour votre avis !</p>
+        <p>Votre réponse\u00a0: ${reponse}</p>
+        <p>Merci pour votre avis\u00a0!</p>
         `
     feedbackQuestionForm.parentNode.replaceChild(remerciements, feedbackQuestionForm)
 }

--- a/src/scripts/page/thematiques/rappelVaccinal.js
+++ b/src/scripts/page/thematiques/rappelVaccinal.js
@@ -235,11 +235,11 @@ class FormulaireRappelVaccinal extends Formulaire {
 
     libelleAge() {
         if (this.age === 'plus65') {
-            return '65 ans ou plus'
+            return '65\u00a0ans ou plus'
         } else if (this.age === 'moins65') {
-            return 'entre 18 et 64 ans'
+            return 'entre 18 et 64\u00a0ans'
         } else {
-            return 'entre 12 et 17 ans'
+            return 'entre 12 et 17\u00a0ans'
         }
     }
 

--- a/src/scripts/questionnaire.js
+++ b/src/scripts/questionnaire.js
@@ -189,10 +189,10 @@ export class Questionnaire {
         const remainingSteps = this.ordre.length - num
         switch (remainingSteps) {
             case 0:
-                message = `C’est la dernière étape !`
+                message = `C’est la dernière étape\u00a0!`
                 break
             case 1:
-                message = `Plus qu’une étape !`
+                message = `Plus qu’une étape\u00a0!`
                 break
             default:
                 message = `Il vous reste ${remainingSteps} étapes.`

--- a/src/scripts/suivi.js
+++ b/src/scripts/suivi.js
@@ -44,7 +44,7 @@ export default class SuiviView {
         const dernierEtat = this.profil.dernierEtat()
         if (dernierEtat) {
             const relativeDate = format(new Date(dernierEtat.date), 'fr')
-            return `<small>Dernière réponse : ${relativeDate}</small>`
+            return `<small>Dernière réponse\u00a0: ${relativeDate}</small>`
         }
         return ''
     }
@@ -60,14 +60,14 @@ export default class SuiviView {
     }
 
     renderDebutSymptomes() {
-        return `<p>Début des symptômes :
+        return `<p>Début des symptômes\u00a0:
             ${this.renderDate(this.profil.symptomes_start_date)}
             (<a href="#symptomes">modifier</a>)
         </p>`
     }
 
     renderDebutSuivi() {
-        return `<p>Début du suivi : ${this.renderDate(
+        return `<p>Début du suivi\u00a0: ${this.renderDate(
             this.profil.suivi_start_date
         )}</p>`
     }
@@ -151,9 +151,9 @@ export default class SuiviView {
     switchGravite(value) {
         switch (value) {
             case 'gravite_3':
-                return 'État grave, il est recommandé d’appeler le SAMU (15)'
+                return 'État grave, il est recommandé d’appeler le SAMU\u00a0(15)'
             case 'gravite_2':
-                return 'État préoccupant, consulter un médecin ou à défaut le SAMU (15)'
+                return 'État préoccupant, consulter un médecin ou à défaut le SAMU\u00a0(15)'
             case 'gravite_1':
                 return 'État à vérifier, consulter votre médecin traitant'
             case 'gravite_0':

--- a/src/scripts/tests/integration/test.pages.js
+++ b/src/scripts/tests/integration/test.pages.js
@@ -64,7 +64,7 @@ describe('Pages', function () {
 
         assert.equal(
             await page.title(),
-            'Conseils pour mon enfant — Mes Conseils Covid'
+            'Conseils pour mon\u00a0enfant — Mes Conseils Covid'
         )
     })
 

--- a/src/scripts/tests/integration/test.pages.js
+++ b/src/scripts/tests/integration/test.pages.js
@@ -25,7 +25,7 @@ describe('Pages', function () {
         await waitForPlausibleTrackingEvent(page, 'pageview:introduction')
 
         await page.click(
-            '.thematiques a >> text="Nouveau passe vaccinal, que faut-il savoir ?"'
+            '.thematiques a >> text="Nouveau passe vaccinal, que faut-il savoir\u00a0?"'
         )
         await waitForPlausibleTrackingEvent(
             page,

--- a/src/scripts/tests/integration/test.parcours.js
+++ b/src/scripts/tests/integration/test.parcours.js
@@ -13,7 +13,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -88,7 +88,7 @@ describe('Parcours', function () {
 
             await Promise.all([
                 page.click(
-                    '#page.ready .thematiques a >> text="Nouveau passe vaccinal, que faut-il savoir ?"'
+                    '#page.ready .thematiques a >> text="Nouveau passe vaccinal, que faut-il savoir\u00a0?"'
                 ),
                 page.waitForNavigation({
                     url: '**/pass-sanitaire-qr-code-voyages.html',
@@ -124,7 +124,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -174,7 +174,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -224,7 +224,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -263,7 +263,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -304,7 +304,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -342,7 +342,7 @@ describe('Parcours', function () {
             )
             assert.include(
                 (await contact_a_risque.innerText()).trim(),
-                '7 jours après la date du dernier contact'
+                '7\u00a0jours après la date du dernier contact'
             )
             await waitForPlausibleTrackingEvent(page, 'Questionnaire terminé:conseils')
         }
@@ -355,7 +355,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -394,7 +394,7 @@ describe('Parcours', function () {
             )
             assert.include(
                 (await contact_a_risque.innerText()).trim(),
-                '7 jours après la date du dernier contact'
+                '7\u00a0jours après la date du dernier contact'
             )
             await waitForPlausibleTrackingEvent(page, 'Questionnaire terminé:conseils')
         }
@@ -407,7 +407,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -446,7 +446,7 @@ describe('Parcours', function () {
             )
             assert.include(
                 (await contact_a_risque.innerText()).trim(),
-                '7 jours après la date du dernier contact'
+                '7\u00a0jours après la date du dernier contact'
             )
             await waitForPlausibleTrackingEvent(page, 'Questionnaire terminé:conseils')
         }
@@ -459,7 +459,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -513,7 +513,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -565,7 +565,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -605,7 +605,7 @@ describe('Parcours', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 

--- a/src/scripts/tests/integration/test.plausible.js
+++ b/src/scripts/tests/integration/test.plausible.js
@@ -43,7 +43,7 @@ describe('Plausible', function () {
         )
         await waitForPlausibleTrackingEvents(page, ['pageview:introduction:toto'])
 
-        await page.click('a >> text="Je suis cas contact Covid, que faire ?"')
+        await page.click('a >> text="Je suis cas contact Covid, que faire\u00a0?"')
         await waitForPlausibleTrackingEvents(page, [
             'pageview:cas-contact-a-risque.html:toto',
         ])
@@ -56,7 +56,7 @@ describe('Plausible', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -96,7 +96,7 @@ describe('Plausible', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -163,7 +163,7 @@ describe('Plausible', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -228,7 +228,7 @@ describe('Plausible', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -293,7 +293,7 @@ describe('Plausible', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -357,7 +357,7 @@ describe('Plausible', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 

--- a/src/scripts/tests/integration/test.profils.js
+++ b/src/scripts/tests/integration/test.profils.js
@@ -9,7 +9,7 @@ describe('Profils', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -61,7 +61,7 @@ describe('Profils', function () {
         {
             // On retrouve le titre explicite.
             let titre = await page.waitForSelector('#page.ready #conseils-block-titre')
-            assert.equal(await titre.innerText(), 'Conseils pour « Mamie »') // &nbsp; autour du nom
+            assert.equal(await titre.innerText(), 'Conseils pour «\u00a0Mamie\u00a0»')
 
             // On rend l’activité visible.
             await page.click('#page.ready #conseils-activite h3')

--- a/src/scripts/tests/integration/test.rappel.js
+++ b/src/scripts/tests/integration/test.rappel.js
@@ -82,7 +82,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-04-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez 65 ans ou plus')
+            assert.include(statut, 'Vous avez 65\u00a0ans ou plus')
             assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
             assert.include(statut, 'Votre dernière injection date du 17 avril 2021.')
             assert.include(
@@ -107,7 +107,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-05-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez 65 ans ou plus')
+            assert.include(statut, 'Vous avez 65\u00a0ans ou plus')
             assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
             assert.include(statut, 'Votre dernière injection date du 17 mai 2021.')
             assert.include(
@@ -132,7 +132,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-06-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez 65 ans ou plus')
+            assert.include(statut, 'Vous avez 65\u00a0ans ou plus')
             assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
             assert.include(statut, 'Votre dernière injection date du 17 juin 2021.')
             assert.include(
@@ -157,7 +157,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-07-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez 65 ans ou plus')
+            assert.include(statut, 'Vous avez 65\u00a0ans ou plus')
             assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
             assert.include(statut, 'Votre dernière injection date du 17 juillet 2021.')
             assert.include(
@@ -182,7 +182,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-06-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez 65 ans ou plus')
+            assert.include(statut, 'Vous avez 65\u00a0ans ou plus')
             assert.include(statut, 'avez été vacciné(e) avec le vaccin Janssen')
             assert.include(statut, 'Votre dernière injection date du 17 juin 2021.')
             assert.include(
@@ -207,7 +207,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-06-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez entre 18 et 64 ans')
+            assert.include(statut, 'Vous avez entre 18 et 64\u00a0ans')
             assert.include(statut, 'avez été vacciné(e) avec le vaccin Janssen')
             assert.include(statut, 'Votre dernière injection date du 17 juin 2021.')
             assert.include(
@@ -234,7 +234,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-05-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez entre 18 et 64 ans')
+            assert.include(statut, 'Vous avez entre 18 et 64\u00a0ans')
             assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
             assert.include(statut, 'Votre dernière injection date du 17 mai 2021.')
             assert.include(
@@ -258,7 +258,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-06-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez entre 18 et 64 ans')
+            assert.include(statut, 'Vous avez entre 18 et 64\u00a0ans')
             assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
             assert.include(statut, 'Votre dernière injection date du 17 juin 2021.')
             assert.include(
@@ -284,7 +284,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-07-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez entre 18 et 64 ans')
+            assert.include(statut, 'Vous avez entre 18 et 64\u00a0ans')
             assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
             assert.include(statut, 'Votre dernière injection date du 17 juillet 2021.')
             assert.include(
@@ -308,7 +308,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-08-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez entre 18 et 64 ans')
+            assert.include(statut, 'Vous avez entre 18 et 64\u00a0ans')
             assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
             assert.include(statut, 'Votre dernière injection date du 17 août 2021.')
             assert.include(
@@ -332,7 +332,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-09-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez entre 18 et 64 ans')
+            assert.include(statut, 'Vous avez entre 18 et 64\u00a0ans')
             assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
             assert.include(
                 statut,
@@ -359,7 +359,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-10-17')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez entre 18 et 64 ans')
+            assert.include(statut, 'Vous avez entre 18 et 64\u00a0ans')
             assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
             assert.include(statut, 'Votre dernière injection date du 17 octobre 2021.')
             assert.include(
@@ -383,7 +383,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2022-02-10')
 
             const statut = await questionnaire.recuperationStatut('rappel-et-pass')
-            assert.include(statut, 'Vous avez entre 18 et 64 ans')
+            assert.include(statut, 'Vous avez entre 18 et 64\u00a0ans')
             assert.include(statut, 'avec le vaccin Pfizer, Moderna ou AstraZeneca')
             assert.include(statut, 'Votre dernière injection date du 10 février 2022.')
             assert.include(
@@ -409,16 +409,17 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-10-17')
 
             const statut = await questionnaire.recuperationStatut('rappel')
-            assert.include(statut, 'Vous avez entre 12 et 17 ans')
+            assert.include(statut, 'Vous avez entre 12 et 17\u00a0ans')
             assert.include(statut, 'avec le vaccin Pfizer ou Moderna')
             assert.include(statut, 'Votre dernière injection date du 17 octobre 2021.')
             assert.include(
                 statut,
                 'Vous pourrez recevoir votre dose de rappel à partir du 24 janvier 2022.'
             ) // début de la campagne de rappel
+            console.log(statut)
             assert.include(
                 statut,
-                'Vous ne serez pas concerné(e) par la désactivation du passe vaccinal, qui restera valable au delà du 15 décembre 2021.'
+                'Vous ne serez pas concerné(e) par la désactivation du passe vaccinal, qui restera valable au delà du 15\u00a0décembre\u00a02021.'
             )
         })
         it('12 à 17 ans, 17 novembre', async function () {
@@ -432,7 +433,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-11-17')
 
             const statut = await questionnaire.recuperationStatut('rappel')
-            assert.include(statut, 'Vous avez entre 12 et 17 ans')
+            assert.include(statut, 'Vous avez entre 12 et 17\u00a0ans')
             assert.include(statut, 'avec le vaccin Pfizer ou Moderna')
             assert.include(statut, 'Votre dernière injection date du 17 novembre 2021.')
             assert.include(
@@ -442,7 +443,7 @@ describe('Mini-questionnaire dose de rappel', function () {
 
             assert.include(
                 statut,
-                'Vous ne serez pas concerné(e) par la désactivation du passe vaccinal, qui restera valable au delà du 15 décembre 2021.'
+                'Vous ne serez pas concerné(e) par la désactivation du passe vaccinal, qui restera valable au delà du 15\u00a0décembre\u00a02021.'
             )
         })
         it('12 à 17 ans, 17 décembre', async function () {
@@ -456,7 +457,7 @@ describe('Mini-questionnaire dose de rappel', function () {
             await questionnaire.remplirDateDerniereDose('2021-12-17')
 
             const statut = await questionnaire.recuperationStatut('rappel')
-            assert.include(statut, 'Vous avez entre 12 et 17 ans')
+            assert.include(statut, 'Vous avez entre 12 et 17\u00a0ans')
             assert.include(statut, 'avec le vaccin Pfizer ou Moderna')
             assert.include(statut, 'Votre dernière injection date du 17 décembre 2021.')
             assert.include(
@@ -466,7 +467,7 @@ describe('Mini-questionnaire dose de rappel', function () {
 
             assert.include(
                 statut,
-                'Vous ne serez pas concerné(e) par la désactivation du passe vaccinal, qui restera valable au delà du 15 décembre 2021.'
+                'Vous ne serez pas concerné(e) par la désactivation du passe vaccinal, qui restera valable au delà du 15\u00a0décembre\u00a02021.'
             )
         })
     })

--- a/src/scripts/tests/integration/test.suivi.js
+++ b/src/scripts/tests/integration/test.suivi.js
@@ -13,7 +13,7 @@ describe('Suivi', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 
@@ -222,7 +222,7 @@ describe('Suivi', function () {
         await page.goto('http://localhost:8080/j-ai-des-symptomes-covid.html')
 
         const summary = await page.waitForSelector(
-            'text="Que faire si j’ai des symptômes et/ou que je suis positif ?"'
+            'text="Que faire si j’ai des symptômes et/ou que je suis positif\u202f?"'
         )
         await summary.click()
 

--- a/src/scripts/tests/integration/test.tests.js
+++ b/src/scripts/tests/integration/test.tests.js
@@ -218,7 +218,7 @@ describe('Tests', function () {
         )
         assert.equal(
             await formLegend.innerText(),
-            'Avez-vous des symptômes qui peuvent évoquer la Covid ?'
+            'Avez-vous des symptômes qui peuvent évoquer la Covid\u202f?'
         )
 
         // On avance vers le formulaire suivant (depuis quand).
@@ -229,7 +229,7 @@ describe('Tests', function () {
         )
         assert.equal(
             await formLegend.innerText(),
-            'Depuis quand avez-vous des symptômes ?'
+            'Depuis quand avez-vous des symptômes\u202f?'
         )
 
         // On clique sur le bouton retour.
@@ -242,7 +242,7 @@ describe('Tests', function () {
         formLegend = await page.waitForSelector(`#${prefixe}-symptomes-form legend h3`)
         assert.equal(
             await formLegend.innerText(),
-            'Avez-vous des symptômes qui peuvent évoquer la Covid ?'
+            'Avez-vous des symptômes qui peuvent évoquer la Covid\u202f?'
         )
     })
 
@@ -271,7 +271,7 @@ describe('Tests', function () {
         )
         assert.equal(
             await formLegend.innerText(),
-            'Avez-vous des symptômes qui peuvent évoquer la Covid ?'
+            'Avez-vous des symptômes qui peuvent évoquer la Covid\u202f?'
         )
     })
 })

--- a/src/scripts/tests/integration/test.thematiques.js
+++ b/src/scripts/tests/integration/test.thematiques.js
@@ -9,7 +9,7 @@ describe('Thématiques', function () {
 
         assert.equal(
             await page.title(),
-            'Conseils pour mon enfant — Mes Conseils Covid'
+            'Conseils pour mon\u00a0enfant — Mes Conseils Covid'
         )
     })
 

--- a/src/scripts/tests/integration/test.thematiques.js
+++ b/src/scripts/tests/integration/test.thematiques.js
@@ -29,7 +29,7 @@ describe('Thématiques', function () {
 
         await Promise.all([
             page.click(
-                '.thematiques a >> text="Nouveau passe vaccinal, que faut-il savoir ?"'
+                '.thematiques a >> text="Nouveau passe vaccinal, que faut-il savoir\u00a0?"'
             ),
             page.waitForNavigation({
                 url: '**/pass-sanitaire-qr-code-voyages.html',

--- a/src/scripts/updater.js
+++ b/src/scripts/updater.js
@@ -54,7 +54,7 @@ export default class Updater {
             // if multiple releases are required within the same day.
             const datePart = fetchedVersion.substring(0, 10)
             const readableVersion = datePart.split('-').reverse().join('-')
-            element.innerText = ` - Mis à jour le : ${readableVersion}`
+            element.innerText = ` - Mis à jour le\u00a0: ${readableVersion}`
         }
     }
 


### PR DESCRIPTION
Sinon, le passage dans le minifieur htmlnano utilisé par Parcel va convertir nos espaces insécables Unicode en espaces classiques (module "collapseWhitespace").