### PR TITLE
Ajoute le lien vers le simulateur Mon rappel vaccin Covid

### DIFF
--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -148,7 +148,7 @@
 
     <div class="voir-aussi">
 
-    - [Calculer la date de mon rappel](https://monrappelvaccincovid.ameli.fr/) avec le simulateur de l'Assurance maladie
+    - [Calculer la date de mon rappel](https://monrappelvaccincovid.ameli.fr/) avec le simulateur de l’Assurance maladie
     - [Comment obtenir un certificat de rétablissement ?](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code)
     - [Tout savoir sur le rappel vaccinal contre la Covid-19](https://www.gouvernement.fr/tout-savoir-sur-le-rappel-vaccinal-contre-la-covid-19) (gouvernement.fr)
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -148,6 +148,7 @@
 
     <div class="voir-aussi">
 
+    - [Calculer la date de mon rappel](https://monrappelvaccincovid.ameli.fr/) avec le simulateur de l'Assurance maladie
     - [Comment obtenir un certificat de rétablissement ?](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code)
     - [Tout savoir sur le rappel vaccinal contre la Covid-19](https://www.gouvernement.fr/tout-savoir-sur-le-rappel-vaccinal-contre-la-covid-19) (gouvernement.fr)
 


### PR DESCRIPTION
Les règles du passe vaccinal et du rappel s'étant complexifiées depuis le 15 février, nous avons préféré supprimer le calculateur de date de rappel et renvoyer directement vers celui de l'Assurance maladie.