### PR TITLE
Supprime la mention de la visite d’un infirmier pour les cas positifs

### DIFF
--- a/contenus/conseils/conseils_isolement_ctai.md
+++ b/contenus/conseils/conseils_isolement_ctai.md
@@ -1,6 +1,6 @@
 #### Aide à l’isolement
 
-Pendant votre période d’isolement, si vous avez **besoin d’aide** pour vos démarches administratives, une aide à domicile, une garde d’enfants ou encore un dispositif de soutien psychologique, vous pouvez contacter l’Assurance Maladie de votre département au 36 46. Un infirmier ou une infirmière pourra venir à votre domicile pour tester les membres de votre foyer.
+Pendant votre période d’isolement, si vous avez **besoin d’aide** pour vos démarches administratives, une aide à domicile, une garde d’enfants ou encore un dispositif de soutien psychologique, vous pouvez contacter l’Assurance Maladie de votre département au 36 46.
 
 ℹ️ Si vous ne pouvez pas rester isolé·e chez vous, l’Assurance Maladie pourra vous aider à trouver un autre logement pendant la durée de votre isolement.
 


### PR DESCRIPTION
Source : https://www.ameli.fr/paris/assure/covid-19/symptomes-gestes-barrieres-cas-contact-et-isolement/en-cas-de-test-positif-au-covid-19

Mise à jour le 15/02/2022 : suppression de la section suivante :

> ~~Visite à domicile d'un infirmier~~
>
> ~~Pour vous accompagner dans votre isolement, notamment vis-à-vis de vos proches, vous pouvez bénéficier d’une visite à domicile d’un infirmier. Cette visite est accessible à toute personne positive partageant son domicile avec des personnes cas contact.~~

Cf. https://github.com/Delegation-numerique-en-sante/mesconseilscovid/issues/2085