### PR TITLE
Reformule la réponse pour le certificat de rétablissement

### DIFF
--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -159,22 +159,19 @@
     :level: 3
 
     Si vous avez eu la Covid après votre vacination initiale, vous pourrez utiliser le QR code de votre **test PCR ou antigénique positif** datant d’au moins 11 jours (aussi appelé *certificat de rétablissement*) en tant que **passe vaccinal**.
+    
+    Sa durée de validité dépend du temps qui s'est écoulé entre votre vaccination et la contamination.
 
     - Si cette infection a eu lieu **moins de 3 mois** après votre vaccination initiale :
 
         * ce certificat de rétablissement sera valable **4 mois** comme passe vaccinal ou passe sanitaire ;
-        * vous pourrez recevoir une **dose de rappel** :
-
-            * dès **3 mois** après votre **infection** si vous êtes âgé de **18 ans ou plus**,
-            * dès **6 mois** après votre **infection** si vous êtes âgé de **12 à 17 ans**.
-
+        
     - Si cette infection a eu lieu **plus de 3 mois** après votre vaccination initiale :
 
-        * cette infection tiendra lieu de **dose de rappel** pour le passe vaccinal **en France** :
+        * cette infection tiendra lieu de **dose de rappel** pour le passe vaccinal **en France** ;
+        * ce certificat de rétablissement sera valable comme passe vaccinal ou passe sanitaire pour **une durée illimitée**
 
-            * si votre test positif date d’**avant le 15 février 2022**, vous pourrez le **combiner** avec votre certificat de vaccination initiale dans l’application TousAntiCovid, pour obtenir un passe vaccinal **sans date d’expiration** ;
-
-            * pour les tests positifs réalisés **après le 15 février 2022**, le professionnel de santé pourra la plupart du temps vous remettre directement un certificat de rétablissement **sans date d’expiration** si vous lui présentez votre certificat de vaccination initiale (sinon vous pourrez les combiner dans l’application TousAntiCovid).
+     [Consultez notre explication](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code) pour savoir comment obtenir un certificat de rétablissement en fonction de votre situation. 
 
     <div class="conseil conseil-jaune">
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -383,42 +383,29 @@
 
 .. question:: Comment obtenir un certificat de rétablissement avec QR code ?
     :level: 3
+    
+    Le certificat de rétablissement est le nom donné au **test de dépistage positif** (PCR ou antigénique) daté de **plus de 11 jours**. 
 
     #### Cas général
 
-    Le certificat de rétablissement n’est pas un nouveau document. Il s’agit du **résultat positif** de votre test de dépistage daté de **plus de 11 jours**.
-
-    **Obtenez-le** en le **téléchargeant** sur le portail SI-DEP grâce à un lien qui vous a été envoyé par courriel ou SMS après votre test de dépistage.
-
+    **Obtenez** votre certificat de rétablissement en le **téléchargeant** sur le portail SI-DEP, grâce au lien qui vous a été envoyé par courriel ou SMS suite à la réalisation de votre test de dépistage.  Si vous le souhaitez, vous pouvez le sauvegarder dans votre application TousAntiCovid.
 
     **Durée de validité du certificat de rétablissement**
 
-    Sa **durée de validité** dépend de votre situation vaccinale et de la date à laquelle vous avez été testé positif.
-
-    * Cas 1 : vous avez eu la Covid **avant ou pendant** votre **vaccination initiale** :
+    La **durée de validité** du certificat de rétablissement dépend du moment où vous avez été testé positif.
+    *Vous avez été contaminé(e) **avant ou après la 1<sup>ere</sup> dose**  :
         - validité : **4 mois**.
-
-    * Cas 2 : vous avez eu la **Covid après votre vaccination initiale** :    
-        a. dans les 3 mois suivants :
+    * Vous avez été contaminé(e) **après votre vaccination initiale** :    
+        * dans les 3 mois après :
         - validité : **4 mois**
         **ou**
-        b. à partir de 3 mois après :
+        * à partir de 3 mois après :
         - validité : **illimitée**
 
-
-    #### Cas particulier : testé positif avant le 15 février
-
-    Vous êtes dans la situation suivante :
-    * contaminé(e) au moins 3 mois après votre vaccination initiale
-    **et**
-    * testé positif avant le 15 février.
-
-    Vous pouvez **obtenir** un certificat de rétablissement valable pour **une durée illimitée**.
-
-    Pour cela, **combinez** votre **test positif** avec votre **certificat de vaccination** dans la rubrique Pass+ de l’application **TousAntiCovid**.
-    [Aidez-vous de cette vidéo explicative](https://tousanticovid.stonly.com/kb/guide/fr/pass-un-outil-pour-combiner-les-certificats-70S5BKyI4g/Steps/1148507).
-
-
+    #### Cas particulier : testé(e) positif avant le 15 février
+    
+    Si vous avez été testé(e) positif avant le 15 février **et** plus de 3 mois après votre vaccination initiale, vous pouvez obtenir un certificat de rétablissement **sans date d'expiration**. Pour cela, il faut combiner votre **test positif** avec votre **certificat de vaccination** dans la rubrique Pass+ de l’application **TousAntiCovid**. Vous pouvez vous [aider de cette vidéo explicative](https://tousanticovid.stonly.com/kb/guide/fr/pass-un-outil-pour-combiner-les-certificats-70S5BKyI4g/Steps/1148507).
+    
 .. question:: Je rencontre des difficultés techniques sur le portail SI-DEP, que faire ?
     :level: 3
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -396,19 +396,13 @@
     Sa **durée de validité** dépend de votre situation vaccinale et de la date à laquelle vous avez été testé positif.
 
     * Cas 1 : vous avez eu la Covid **avant ou pendant** votre **vaccination initiale** :
-
         - validité : **4 mois**.
 
-    * Cas 2 : vous avez eu la **Covid après votre vaccination initiale** :
-
+    * Cas 2 : vous avez eu la **Covid après votre vaccination initiale** :    
         a. dans les 3 mois suivants :
-
         - validité : **4 mois**
-
         **ou**
-
         b. à partir de 3 mois après :
-
         - validité : **illimitée**
 
 
@@ -416,9 +410,7 @@
 
     Vous êtes dans la situation suivante :
     * contaminé(e) au moins 3 mois après votre vaccination initiale
-
     **et**
-
     * testé positif avant le 15 février.
 
     Vous pouvez **obtenir** un certificat de rétablissement valable pour **une durée illimitée**.

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -159,19 +159,28 @@
     :level: 3
 
     Si vous avez eu la Covid après votre vacination initiale, vous pourrez utiliser le QR code de votre **test PCR ou antigénique positif** datant d’au moins 11 jours (aussi appelé *certificat de rétablissement*) en tant que **passe vaccinal**.
-    
-    Sa durée de validité dépend du temps qui s'est écoulé entre votre vaccination et la contamination.
 
-    - Si cette infection a eu lieu **moins de 3 mois** après votre vaccination initiale :
+    Sa **durée de validité** dépend du temps qui s’est écoulé entre votre vaccination et la contamination.
 
-        * ce certificat de rétablissement sera valable **4 mois** comme passe vaccinal ou passe sanitaire ;
-        
-    - Si cette infection a eu lieu **plus de 3 mois** après votre vaccination initiale :
+    <table class="table">
+    <thead>
+        <tr>
+            <th>Moment du test positif</th>
+            <th>Validité du certificat</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><b>Moins de 3 mois</b> après ma vaccination initiale</td>
+            <td>4 mois</td>
+        </tr>
+        <tr>
+            <td><b>3 mois ou plus</b> après ma vaccination initiale</td>
+            <td>illimitée</td>
+        </tr>
+    </table>
 
-        * cette infection tiendra lieu de **dose de rappel** pour le passe vaccinal **en France** ;
-        * ce certificat de rétablissement sera valable comme passe vaccinal ou passe sanitaire pour **une durée illimitée**
-
-     [Consultez notre explication](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code) pour savoir comment obtenir un certificat de rétablissement en fonction de votre situation. 
+    [Consultez notre explication](#comment-obtenir-un-certificat-de-retablissement-avec-qr-code) pour savoir comment obtenir votre certificat de rétablissement en fonction de votre situation.
 
     <div class="conseil conseil-jaune">
 
@@ -380,8 +389,8 @@
 
 .. question:: Comment obtenir un certificat de rétablissement avec QR code ?
     :level: 3
-    
-    Le certificat de rétablissement est le nom donné au **test de dépistage positif** (PCR ou antigénique) daté de **plus de 11 jours**. 
+
+    Le certificat de rétablissement est le nom donné au **test de dépistage positif** (PCR ou antigénique) daté de **plus de 11 jours**.
 
     #### Cas général
 
@@ -390,19 +399,41 @@
     **Durée de validité du certificat de rétablissement**
 
     La **durée de validité** du certificat de rétablissement dépend du moment où vous avez été testé positif.
-    *Vous avez été contaminé(e) **avant ou après la 1<sup>ere</sup> dose**  :
-        - validité : **4 mois**.
-    * Vous avez été contaminé(e) **après votre vaccination initiale** :    
-        * dans les 3 mois après :
-        - validité : **4 mois**
-        **ou**
-        * à partir de 3 mois après :
-        - validité : **illimitée**
 
-    #### Cas particulier : testé(e) positif avant le 15 février
-    
-    Si vous avez été testé(e) positif avant le 15 février **et** plus de 3 mois après votre vaccination initiale, vous pouvez obtenir un certificat de rétablissement **sans date d'expiration**. Pour cela, il faut combiner votre **test positif** avec votre **certificat de vaccination** dans la rubrique Pass+ de l’application **TousAntiCovid**. Vous pouvez vous [aider de cette vidéo explicative](https://tousanticovid.stonly.com/kb/guide/fr/pass-un-outil-pour-combiner-les-certificats-70S5BKyI4g/Steps/1148507).
-    
+    <table class="table">
+    <thead>
+        <tr>
+            <th>Moment du test positif</th>
+            <th>Validité du certificat</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><b>Avant</b> ma vaccination initiale<br><i>(avant ma 1<sup>re</sup> dose)</i></td>
+            <td rowspan="3">4 mois</td>
+        </tr>
+        <tr>
+            <td><b>Pendant</b> ma vaccination initiale<br><i>(entre ma 1<sup>re</sup> et ma 2<sup>e</sup>dose)</i></td>
+        </tr>
+        <tr>
+            <td><b>Moins de 3 mois</b> après ma vaccination initiale</td>
+        </tr>
+        <tr>
+            <td><b>3 mois ou plus</b> après ma vaccination initiale</td>
+            <td>illimitée</td>
+        </tr>
+    </table>
+
+
+    #### Cas particulier : test positif avant le 15 février
+
+    Si votre résultat de test positif date d’**avant le 15 février** et de **plus de 3 mois** après votre vaccination initiale, vous pouvez obtenir un certificat de rétablissement **sans date d’expiration** :
+
+    - pour cela, il faut **combiner** votre **test positif** avec votre **certificat de vaccination** dans la rubrique **Pass+** de l’application **TousAntiCovid** ;
+
+    - vous pouvez vous [aider de cette vidéo explicative](https://tousanticovid.stonly.com/kb/guide/fr/pass-un-outil-pour-combiner-les-certificats-70S5BKyI4g/Steps/1148507).
+
+
 .. question:: Je rencontre des difficultés techniques sur le portail SI-DEP, que faire ?
     :level: 3
 

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -384,17 +384,42 @@
 .. question:: Comment obtenir un certificat de rétablissement avec QR code ?
     :level: 3
 
-    Votre **résultat positif** de test de dépistage (PCR ou antigénique) de **plus de 11 jours** constitue un **certificat de rétablissement**.
+#### Cas général :
 
-    Vous pouvez le **télécharger** sur le [portail SI-DEP](https://sidep.gouv.fr/cyberlab/patientviewer.jsp). Nous vous conseillons de le faire **immédiatement** pour le conserver aussi longtemps que nécessaire.
+    Le certificat de rétablissement n'est pas un nouveau document. Il s'agit du **résultat positif** de votre test de dépistage daté de **plus de 11 jours**. 
+    ***Obtenez le** en le **téléchargeant** sur le portail SI-DEP grâce à un lien qui vous a été envoyé par courriel ou SMS après votre test de dépistage.
+    
+    
+    **Durée de validité du certificat de rétablissement**
+    
+    Sa **durée de validité** dépend de votre situation vaccinale et de la date à laquelle vous avez été testé positif. 
 
-    - Si vous avez eu la Covid **plus de 3 mois** après votre vaccination initiale, cette infection tiendra lieu de **dose de rappel** pour le passe vaccinal **en France** :
+    * Cas 1 : vous avez eu la Covid **avant ou pendant** votre **vaccination initiale** :
+        - validité : **4 mois**.
+    
+    * Cas 2 : vous avez eu la **Covid après votre vaccination initiale** : 
+     
+    a. dans les 3 mois suivants : 
+        - validité : **4 mois** ;
+        
+    **ou**
+    
+     b. à partir de 3 mois après :
+        - validitié : **illimitée** ;
+      
 
-        + si votre test positif date d’**avant le 15 février 2022**, vous pourrez **combiner** ce certificat de rétablissement avec votre certificat de vaccination initiale dans l’application TousAntiCovid, pour obtenir un passe vaccinal **sans date d’expiration** ;
+#### Cas particulier : testé positif avant le 15 février
+    
+    Vous êtes dans la situation suivante : 
+    * contaminé(e) au moins 3 mois après votre vaccination initiale
 
-        * pour les tests positifs réalisés **après le 15 février 2022**, le professionnel de santé pourra la plupart du temps vous remettre directement un certificat de rétablissement **sans date d’expiration** si vous lui présentez votre certificat de vaccination initiale (sinon vous pourrez les combiner dans l’application TousAntiCovid).
+    **et**
 
-    - Dans les autres cas, ce certificat de rétablissement sera valable comme passe vaccinal pour une **durée de 4 mois** à partir de la date du test.
+    * testé positif avant le 15 février.
+
+    Vous pouvez **obtenir** un certificat de rétablissement valable pour **une durée illimitée**.
+    Pour cela, **combinez** votre **test positif** avec votre **certificat de vaccination** dans la rubrique Pass+ de l'application **TousAntiCovid**. 
+    [Aidez-vous de cette vidéo explicative](https://tousanticovid.stonly.com/kb/guide/fr/pass-un-outil-pour-combiner-les-certificats-70S5BKyI4g/Steps/1148507).
 
 
 .. question:: Je rencontre des difficultés techniques sur le portail SI-DEP, que faire ?

--- a/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
+++ b/contenus/thematiques/3-pass-sanitaire-qr-code-voyages.md
@@ -64,9 +64,9 @@
     <div class="tableaux-vaccination-complete">
       {{ tableau_vaccination('vaccination_initiale') }}
     </div>
-  
+
     Pour conserver ce passe, si vous avez plus de **18 ans et 1 mois**, vous devrez   ensuite recevoir une **dose de rappel** (dite 3<sup>e</sup> dose) dans un délai de **3 à 4 mois**, sauf si vous êtes contaminé(e) par la Covid entre-temps.
-  
+
     <div class="tableaux-vaccination-complete">
       {{ tableau_vaccination('rappel_vaccinal') }}
     </div>
@@ -384,33 +384,37 @@
 .. question:: Comment obtenir un certificat de rétablissement avec QR code ?
     :level: 3
 
-#### Cas général :
+    #### Cas général
 
-    Le certificat de rétablissement n'est pas un nouveau document. Il s'agit du **résultat positif** de votre test de dépistage daté de **plus de 11 jours**. 
-    ***Obtenez le** en le **téléchargeant** sur le portail SI-DEP grâce à un lien qui vous a été envoyé par courriel ou SMS après votre test de dépistage.
-    
-    
+    Le certificat de rétablissement n’est pas un nouveau document. Il s’agit du **résultat positif** de votre test de dépistage daté de **plus de 11 jours**.
+
+    **Obtenez-le** en le **téléchargeant** sur le portail SI-DEP grâce à un lien qui vous a été envoyé par courriel ou SMS après votre test de dépistage.
+
+
     **Durée de validité du certificat de rétablissement**
-    
-    Sa **durée de validité** dépend de votre situation vaccinale et de la date à laquelle vous avez été testé positif. 
 
-    * Cas 1 : vous avez eu la Covid **avant ou pendant** votre **vaccination initiale** :
+    Sa **durée de validité** dépend de votre situation vaccinale et de la date à laquelle vous avez été testé positif.
+
+    * Cas 1 : vous avez eu la Covid **avant ou pendant** votre **vaccination initiale** :
+
         - validité : **4 mois**.
-    
-    * Cas 2 : vous avez eu la **Covid après votre vaccination initiale** : 
-     
-    a. dans les 3 mois suivants : 
-        - validité : **4 mois** ;
-        
-    **ou**
-    
-     b. à partir de 3 mois après :
-        - validitié : **illimitée** ;
-      
 
-#### Cas particulier : testé positif avant le 15 février
-    
-    Vous êtes dans la situation suivante : 
+    * Cas 2 : vous avez eu la **Covid après votre vaccination initiale** :
+
+        a. dans les 3 mois suivants :
+
+        - validité : **4 mois**
+
+        **ou**
+
+        b. à partir de 3 mois après :
+
+        - validité : **illimitée**
+
+
+    #### Cas particulier : testé positif avant le 15 février
+
+    Vous êtes dans la situation suivante :
     * contaminé(e) au moins 3 mois après votre vaccination initiale
 
     **et**
@@ -418,7 +422,8 @@
     * testé positif avant le 15 février.
 
     Vous pouvez **obtenir** un certificat de rétablissement valable pour **une durée illimitée**.
-    Pour cela, **combinez** votre **test positif** avec votre **certificat de vaccination** dans la rubrique Pass+ de l'application **TousAntiCovid**. 
+
+    Pour cela, **combinez** votre **test positif** avec votre **certificat de vaccination** dans la rubrique Pass+ de l’application **TousAntiCovid**.
     [Aidez-vous de cette vidéo explicative](https://tousanticovid.stonly.com/kb/guide/fr/pass-un-outil-pour-combiner-les-certificats-70S5BKyI4g/Steps/1148507).
 
 


### PR DESCRIPTION
L'information autour du certificat de rétablissement s'est densifiée et complexifiée depuis le 15 février. 
J'ai tenté d'aérer l'information et de la diviser un maximum pour favoriser une lecture rapide en fonction de sa situation personnelle (inspirée de mes lectures des méthodes d'UX Writing) et particulièrement pour les (nombreuses ?) personnes qui ont été contaminées avant le 15 février.

Source issue #2087 et Le communiqué de presse du 15/02/2022 https://solidarites-sante.gouv.fr/actualites/presse/communiques-de-presse/article/evolution-du-pass-vaccinal-au-15-fevrier-2022-quand-faire-mon-rappel-pour-avoir