### PR TITLE
Supprime l'indication du nombre de jour d'isolement dans une réponse

### DIFF
--- a/contenus/thematiques/9-covid-et-travail.md
+++ b/contenus/thematiques/9-covid-et-travail.md
@@ -196,9 +196,15 @@
 .. question:: Mon employeur peut-il exiger un certificat attestant de mon rétablissement de la Covid avant mon retour au travail ?
     :level: 3
 
-    **Non**. Votre employeur n'a pas le droit d'exiger de justificatif relatif à votre état de santé (sauf dans les cas prévus par la loi).
-    
-    Si vous avez **respecté** la durée de votre **isolement** (10 ou 7 jours, ou J+5 ou J+7 en cas de sortie anticipée suite à un test antigénique négatif), et que vous n'avez plus de fièvre depuis 48 H, alors vous pouvez retourner au travail.
+    **Non**. Votre employeur n’a pas le droit d’exiger de justificatif relatif à votre état de santé (sauf dans les cas prévus par la loi).
+
+    Vous pouvez retourner au travail si :
+
+    - vous avez **respecté** la durée de votre **isolement** :
+        - au moins **7 jours** si vous êtes complètement vacciné(e) (seulement 5 jours en cas de test antigénique négatif),
+        - au moins **10 jours** si vous n’êtes pas complètement vacciné(e) (seulement 7 jours en cas de test antigénique négatif),
+    - **et** que vous n’avez **plus de fièvre depuis 48 h**.
+
 
 .. renvoi:: conseils-pour-les-enfants.html#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid
     :level: 3

--- a/contenus/thematiques/9-covid-et-travail.md
+++ b/contenus/thematiques/9-covid-et-travail.md
@@ -201,8 +201,8 @@
     Vous pouvez retourner au travail si :
 
     - vous avez **respecté** la durée de votre **isolement** :
-        - au moins **7 jours** si vous êtes complètement vacciné(e) (seulement 5 jours en cas de test antigénique négatif),
-        - au moins **10 jours** si vous n’êtes pas complètement vacciné(e) (seulement 7 jours en cas de test antigénique négatif),
+        - au moins **7 jours** si vous êtes complètement vacciné(e) (seulement 5 jours en cas de test antigénique négatif),
+        - au moins **10 jours** si vous n’êtes pas complètement vacciné(e) (seulement 7 jours en cas de test antigénique négatif),
     - **et** que vous n’avez **plus de fièvre depuis 48 h**.
 
 

--- a/contenus/thematiques/9-covid-et-travail.md
+++ b/contenus/thematiques/9-covid-et-travail.md
@@ -196,8 +196,9 @@
 .. question:: Mon employeur peut-il exiger un certificat attestant de mon rétablissement de la Covid avant mon retour au travail ?
     :level: 3
 
-    Si vous avez eu la Covid et que vous avez respecté toute la durée de votre isolement (10 ou 7 jours), alors vous pouvez retourner au travail sans présenter de certificat ou de nouveau test de dépistage.
-
+    **Non**. Votre employeur n'a pas le droit d'exiger de justificatif relatif à votre état de santé (sauf dans les cas prévus par la loi).
+    
+    Si vous avez **respecté** la durée de votre **isolement** (10 ou 7 jours, ou J+5 ou J+7 en cas de sortie anticipée suite à un test antigénique négatif), et que vous n'avez plus de fièvre depuis 48 H, alors vous pouvez retourner au travail.
 
 .. renvoi:: conseils-pour-les-enfants.html#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid
     :level: 3

--- a/contenus/thematiques/9-covid-et-travail.md
+++ b/contenus/thematiques/9-covid-et-travail.md
@@ -196,7 +196,7 @@
 .. question:: Mon employeur peut-il exiger un certificat attestant de mon rétablissement de la Covid avant mon retour au travail ?
     :level: 3
 
-    **Non**. Si vous avez eu la Covid et que vous avez respecté la durée de votre isolement (10 jours au moins après le début de vos symptômes ou de votre test positif et que vous ne présentez plus de fièvre), alors vous pouvez retourner au travail sans présenter de certificat ou de nouveau test de dépistage.
+    Si vous avez eu la Covid et que vous avez respecté toute la durée de votre isolement (10 ou 7 jours), alors vous pouvez retourner au travail sans présenter de certificat ou de nouveau test de dépistage.
 
 
 .. renvoi:: conseils-pour-les-enfants.html#je-ne-peux-pas-teletravailler-puis-je-obtenir-un-arret-de-travail-pour-garder-mon-enfant-qui-ne-peut-pas-aller-a-l-ecole-a-cause-de-la-covid


### PR DESCRIPTION
Notre réponse mentionnait encore la durée d'isolement de 10 jours, or, elle dépend maintenant du statut vaccinal (10 ou 7 jours). 
 Dans un second temps nous pourrons reformuler la réponse pour dire qu'il est possible de réduire la durée de l'isolement à 7 ou 5 jours, dans certaines conditions, et de fournir un justificatif à l'employeur.