### PR TITLE
Allègement du dépistage pour les cas contact vaccinés au 28/2

### DIFF
--- a/contenus/thematiques/1-cas-contact-a-risque.md
+++ b/contenus/thematiques/1-cas-contact-a-risque.md
@@ -45,65 +45,44 @@ Si vous avez **déjà eu la Covid** il y a **moins de 2 mois**, alors vous n’�
 
 </summary>
 
-#### 1. Faites un test
+
+#### 1. Soyez prudent(e)
+
+Comme vous êtes complètement vacciné(e), on considère que vous avez un **risque modéré**, et qu’il n’est **pas nécessaire de vous isoler**, mais restez quand même prudent(e) :
+
+* respectez les **mesures barrières** au sein de votre foyer,
+* ayez recours au **télétravail** lorsque c’est possible,
+* **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal),
+* portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
+
+#### 2. Faites un test à J+2
 
 <div class="conseil">
 
-Faites un **test antigénique** en pharmacie **dès que possible** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+Faites un **test PCR**, un **test antigénique** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)) ou un **autotest**, **deux jours après** avoir appris que vous étiez cas contact.
 
-Le test est toujours **gratuit** quand vous êtes cas contact.
+Ces tests sont toujours **gratuits** quand vous êtes cas contact.
 
 </div>
 
 ##### Si le test est négatif 👇
 
-* vous devrez faire **2 autotests** de contrôle (voir plus bas) :
-    - **2 jours** après et **4 jours** après la date du **premier test**,
-    - ces autotests vous seront délivrés **gratuitement** en pharmacie ;
-* comme vous êtes complètement vacciné(e), on considère que vous avez un **risque modéré**, et qu’il n’est **pas nécessaire de vous isoler** ;
-* en attendant, restez quand même prudent(e) :
-    - respectez les **mesures barrières** au sein de votre foyer,
-    - ayez recours au **télétravail** lorsque c’est possible,
-    - **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal),
-    - portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas ;
-* en cas d’apparition de **fièvre** ou de **symptômes** :
-    * faites un **test de dépistage gratuit** (test PCR ou antigénique) dès que possible, et restez isolé(e) en attendant le résultat,
-    * contactez un médecin ou le 15 en cas de difficultés respiratoires.
+* En cas d’apparition de **fièvre** ou de **symptômes** :
+    - faites un **test de dépistage gratuit** (test PCR ou antigénique) dès que possible, et restez isolé(e) en attendant le résultat,
+    - contactez un médecin ou le 15 en cas de difficultés respiratoires.
 
 ##### Si le test est positif 👇
 
-* vous avez contracté la Covid, et vous êtes **contagieux** ;
-* restez en **isolement au moins 7 jours** à partir de la date du test ;
-    - en l’absence de fièvre ou de difficultés respiratoires depuis **48 heures**, vous pourrez mettre fin à votre isolement après 5 jours seulement, suite à test de dépistage négatif (antigénique ou PCR) ;
-- surveillez l’apparition de **symptômes**, et contactez un médecin ou le 15 en cas de difficultés respiratoires ;
-* les **membres de votre foyer** seront à leur tour considérés comme **cas contact**.
+* En cas d’autotest positif :
+    - faites un **test antigénique** (en pharmacie) ou **PCR** (en laboratoire) pour **confirmer** ce résultat positif ;
+    - restez isolé(e) en attendant ;
 
-#### 2. Faites deux autotests de contrôle
-
-<div class="conseil">
-
-Si votre premier test était **négatif**, vous devrez faire **2 autotests** de contrôle :
-    - **2 jours** après et **4 jours** après la date du **premier test**,
-    - ces autotests vous seront délivrés **gratuitement** en pharmacie.
-
-</div>
-
-##### Si les 2 autotests sont négatifs 👇
-
-* vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale.
-
-
-##### Si l’un des autotests est positif 👇
-
-* faites un **test antigénique** (en pharmacie) ou **PCR** (en laboratoire) pour **confirmer** ce résultat positif et restez isolé en attendant ;
-
-* si le résultat positif à l’autotest est **confirmé** :
+* En cas de test PCR ou antigénique positif, ou de confirmation de l’autotest :
     - vous avez contracté la Covid, et vous êtes **contagieux** ;
     - restez en **isolement au moins 7 jours** à partir de la date du test ;
         + en l’absence de fièvre ou de difficultés respiratoires depuis **48 heures**, vous pourrez mettre fin à votre isolement après 5 jours seulement, suite à test de dépistage négatif (antigénique ou PCR) ;
     - surveillez l’apparition de **symptômes**, et contactez un médecin ou le 15 en cas de difficultés respiratoires ;
     - les **membres de votre foyer** seront à leur tour considérés comme **cas contact**.
-
 
 </details>
 

--- a/contenus/thematiques/13-conseils-pour-les-jeunes.md
+++ b/contenus/thematiques/13-conseils-pour-les-jeunes.md
@@ -138,34 +138,52 @@
 
     </div>
 
-    #### 1. Pas d’isolement mais un test de dépistage
+
+    #### 1. Pas d’isolement, mais sois prudent(e)
 
     Si tu es « **cas contact** » et que tu es **vacciné(e)**, alors tu n’auras pas besoin de t’isoler, et pourras continuer à aller au collège ou au lycée.
-    Tu devras faire **dès que possible** un **test** PCR ou antigénique (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)). Les tests de dépistage sont **gratuits** pour les mineurs.
 
-    * Si le test est **positif** :
-        - tu as attrapé la Covid. Ce n’est pas grave, mais tu es **contagieux(se)** et tu dois protéger les personnes qui t’entourent ;
-        - tu dois rester isolé **7 jours** à partir de la date du test ;
+    Comme tu êtes vacciné(e), on considère que tu as un **risque modéré**, mais reste quand même prudent(e) :
 
-            - si tu n’as plus de fièvre depuis au moins 48 h, tu pourras mettre fin à ton isolement après 5 jours seulement, si ton nouveau test de dépistage (antigénique ou PCR) est négatif  ;
+    - respecte les **mesures barrières** en particulier à la maison,
+    - **limite** les sorties et les activités sociales, et évite de passer du temps avec des personnes vulnérables ou fragiles (comme tes grands-parents ou des personnes âgées ou malades),
+    - porte un **masque** à l’extérieur et à l’intérieur, même là où ce n’est pas obligatoire.
 
-        - les personnes qui vivent avec toi sont **cas contacts** (sauf s’ils ont déjà eu la Covid dans les 2 derniers mois) et devront :
-            * s’**isoler** s’ils ne sont pas complètement vaccinés (les autres enfants ne doivent pas aller à l’école) ;
-            * faire un **test** antigénique ou PCR dès que possible.
 
-    * Si le résultat est **négatif**, tu pourras retourner en cours.
+    #### 2. Fais un test à J+2
 
-    #### 2. Deux autotests de contrôle
+    <div class="conseil">
 
-    * Si ton  1<sup>er</sup> test est **négatif** :
+    Fais un **test PCR**, un **test antigénique** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)) ou un **autotest**, **deux jours après** avoir appris que tu es cas contact.
 
-        * tu devras faire un **autotest de contrôle** 2 jours après ton dernier contact avec la personne positive (voir ci-dessous) ;
-        * puis, un 2<sup>e</sup> autotest de contrôle 2 jours après le premier.
+    Les tests sont toujours **gratuits** pour les mineurs et pour les cas contact.
 
-      Si les autotests sont négatifs, alors tu pourras continuer à aller au collège ou au lycée, mais :
+    </div>
 
-        * tu devras rester **prudent** et éviter de passer du temps avec des personnes vulnérables ou fragiles (comme tes grands-parents ou des personnes âgées ou malades) ;
-        * en cas de **fièvre** ou de **symptômes** fais un nouveau test sans attendre.
+    ##### Si le test est négatif 👇
+
+    - En cas d’apparition de **fièvre** ou de **symptômes** :
+        + fais un **test de dépistage gratuit** (test PCR ou antigénique) sans attendre, et reste isolé(e) en attendant le résultat,
+        + contacte un médecin ou le 15 si tu sens que tu as du mal à respirer.
+
+    ##### Si le test est positif 👇
+
+    - En cas d’autotest positif :
+        + fais un **test antigénique** (en pharmacie) ou **PCR** (en laboratoire) pour **confirmer** ce résultat positif ;
+        + reste isolé(e) en attendant ;
+
+    - En cas de test PCR ou antigénique positif, ou de confirmation de l’autotest :
+        + tu as attrapé la Covid :
+            - même si ce n’est généralement pas grave, tu es **contagieux(se)** et tu dois protéger les personnes qui t’entourent ;
+            - surveille l’apparition de **symptômes**, et contacte un médecin ou le 15 en cas de difficultés pour respirer ;
+
+        + tu dois rester isolé(e) **7 jours** à partir de la date du test ;
+            - si tu n’as plus de fièvre depuis au moins 48 h, tu pourras mettre fin à ton isolement après 5 jours seulement, si ton nouveau test de dépistage (antigénique ou PCR) est négatif ;
+
+        + les personnes qui vivent avec toi sont **cas contacts** (sauf s’ils ont déjà eu la Covid dans les 2 derniers mois) et devront :
+            * s’**isoler** puis faire un test après 7 jours si elles ne sont pas complètement vaccinées (les enfants non vaccinés de plus de 12 ans ne doivent pas aller à l’école) ;
+            * ou faire un **test** de dépistage 2 jours plus tard si elles sont complètement vaccinées.
+
 
     <div class="voir-aussi">
 

--- a/contenus/thematiques/4-je-suis-vaccine.md
+++ b/contenus/thematiques/4-je-suis-vaccine.md
@@ -34,7 +34,7 @@
         * **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal) ;
         * portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
 
-    2. Faites un **test de dépistage gratuit** (test PCR, test antigénique ou autotest) **deux jours après** avoir appris que vous étiez cas contact (voir la <a href="https://www.sante.fr/cf/centres-depistage-covid.html">carte des lieux de test</a>).
+    2. Faites un **test de dépistage gratuit** (test PCR, test antigénique ou autotest) **2 jours après** avoir appris que vous étiez cas contact (voir la <a href="https://www.sante.fr/cf/centres-depistage-covid.html">carte des lieux de test</a>).
         * Si le test est **positif** : isolez-vous pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 
 

--- a/contenus/thematiques/4-je-suis-vaccine.md
+++ b/contenus/thematiques/4-je-suis-vaccine.md
@@ -26,22 +26,17 @@
 
 .. question:: Est-ce que je dois m’isoler si je suis « cas contact »  et vacciné(e) ?
 
-    Si vous êtes vacciné(e), en cas de contact à risque avec une personne positive à la Covid :
+    Si vous êtes complètement vacciné(e), en cas de contact à risque avec une personne positive à la Covid :
 
-    1. Faites un **test de dépistage gratuit** (test PCR ou antigénique) **dès que possible** (voir la <a href="https://www.sante.fr/cf/centres-depistage-covid.html">carte des lieux de test</a>).
+    1. Il n’est **pas nécessaire de vous isoler**, mais restez prudent(e) :
+        * respectez les **mesures barrières**, en particulier au sein de votre foyer ;
+        * ayez recours au **télétravail** lorsque c’est possible ;
+        * **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal) ;
+        * portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
+
+    2. Faites un **test de dépistage gratuit** (test PCR, test antigénique ou autotest) **deux jours après** avoir appris que vous étiez cas contact (voir la <a href="https://www.sante.fr/cf/centres-depistage-covid.html">carte des lieux de test</a>).
         * Si le test est **positif** : isolez-vous pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 
-        * Si le test est **négatif**, il n’est **pas nécessaire de vous isoler**, mais restez prudent(e) :
-            * respectez les **mesures barrières** au sein de votre foyer ;
-            * ayez recours au **télétravail** lorsque c’est possible ;
-            * **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal) ;
-            * portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
-
-    1. Faites **2 autotests de contrôle**, 2 jours après et 4 jours après la date du **premier test**.
-        - Si les résultats de ces deux autotests sont **négatifs** : vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale.
-        - Si le résultat d’un de ces autotests est **positif** :
-            + faites un **test antigénique ou PCR** pour **confirmer** ce résultat positif et restez isolé(e) en attendant ;
-            + si le résultat positif à l’autotest est **confirmé** : maintenez votre isolement pour une durée de **7 jours** ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 
     <div class="voir-aussi">
 

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -342,10 +342,10 @@
 
     **Non**. Si vous êtes [cas contact](cas-contact-a-risque.html) ou avez été alerté(e) d’un contact à risque par l’application TousAntiCovid, vous devez d’abord **vous assurer que vous n’avez pas été contaminé(e)** en vous faisant tester.
 
-    * Si votre primo-vaccination date d’il y a moins de 4 mois : faites un test **PCR ou antigénique** dès que possible, puis **2 autotests** de contrôle 2 jours après et 4 jours après le premier test.
+    * Si votre primo-vaccination date d’il y a moins de 4 mois : soyez prudent(e) pendant 7 jours, et faites un **test de dépistage gratuit** (test PCR, test antigénique ou autotest) 2 jours après avoir appris que vous étiez cas contact.
     * Si votre primo-vaccination date d’il y a plus de 4 mois : faites un test antigénique ou PCR **7 jours après** votre dernier contact avec la personne positive.
 
-    Si à l’issue de cette période de vigilance votre test est **négatif**, alors vous pourrez vous faire vacciner.
+    À l’issue de cette **période de vigilance**, et si votre test est **négatif**, alors vous pourrez vous faire vacciner.
 
     <div class="voir-aussi">
 

--- a/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
+++ b/contenus/thematiques/6-je-vis-avec-personne-covid-positive.md
@@ -85,44 +85,48 @@ Si vous ne pouvez pas **télétravailler**, l’Assurance Maladie pourra vous pr
 
 </summary>
 
+
 <p class="big">Voici ce que nous vous conseillons de faire :</p>
 
-#### 1. Faites un test de dépistage
+#### 1. Soyez prudent(e)
+
+Comme vous êtes complètement vacciné(e), on considère que vous avez un **risque modéré**, et qu’il n’est **pas nécessaire de vous isoler**, mais restez quand même prudent(e) :
+
+* respectez les **mesures barrières** au sein de votre foyer,
+* ayez recours au **télétravail** lorsque c’est possible,
+* **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal),
+* portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
+
+#### 2. Faites un test à J+2
 
 <div class="conseil">
 
-Même si vous ne présentez pas de symptômes, faites un **test de dépistage** (test PCR ou antigénique) dès que possible. Le test est **toujours gratuit** quand vous êtes cas contact.
+Faites un **test PCR**, un **test antigénique** (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)) ou un **autotest**, **deux jours après** avoir appris que vous étiez cas contact.
+
+Ces tests sont toujours **gratuits** quand vous êtes cas contact.
 
 </div>
 
-* Si le test est **positif** :
-    - isolez-vous pour une durée de **7 jours** ;
-    - vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
+##### Si le test est négatif 👇
 
-* Si le test est **négatif**, il n’est **pas nécessaire de vous isoler**, mais restez prudent(e) :
-    - respectez les **mesures barrières** au sein de votre foyer ;
-    - ayez recours au **télétravail** lorsque c’est possible ;
-    - **limitez** vos interactions sociales, et évitez tout contact avec une **personne à risque** de forme grave non vaccinée, ou une personne fortement immunodéprimée (quel que soit son statut vaccinal) ;
-    - portez un **masque** à l’extérieur et à l’intérieur, même dans les lieux qui ne l’exigeraient pas.
+* en cas d’apparition de **fièvre** ou de **symptômes** :
+    - faites un **test de dépistage gratuit** (test PCR ou antigénique) dès que possible, et restez isolé(e) en attendant le résultat,
+    - contactez un médecin ou le 15 en cas de difficultés respiratoires.
+
+##### Si le test est positif 👇
+
+* En cas d’autotest positif :
+    - faites un **test antigénique** (en pharmacie) ou **PCR** (en laboratoire) pour **confirmer** ce résultat positif ;
+    - restez isolé(e) en attendant ;
+
+* En cas de test PCR ou antigénique positif, ou de confirmation de l’autotest :
+    - vous avez contracté la Covid, et vous êtes **contagieux** ;
+    - restez en **isolement au moins 7 jours** à partir de la date du test ;
+        + en l’absence de fièvre ou de difficultés respiratoires depuis **48 heures**, vous pourrez mettre fin à votre isolement après 5 jours seulement, suite à test de dépistage négatif (antigénique ou PCR) ;
+    - surveillez l’apparition de **symptômes**, et contactez un médecin ou le 15 en cas de difficultés respiratoires ;
+    - les **membres de votre foyer** seront à leur tour considérés comme **cas contact**.
 
 Si votre enfant de moins de 16 ans est positif à la Covid, vous pouvez bénéficier d’un **arrêt de travail**, même si vous êtes complètement vacciné(e). Rendez-vous sur [declare.ameli.fr](https://declare.ameli.fr/) pour en faire la demande.
-
-#### 2. Faites 2 autotests à J+2 et J+4
-
-<div class="conseil">
-
-Si votre premier test était **négatif**, vous devrez faire **2 autotests de contrôle** (délivrés **gratuitement** en pharmacie) au **2<sup>e</sup> jour** et au **4<sup>e</sup> jour** après la date du **premier test**.
-
-</div>
-
-* Si les résultats de ces deux autotests sont **négatifs** : vous pourrez retirer le masque dans les lieux où il n’est plus obligatoire et reprendre prudemment votre vie sociale.
-
-* Si le résultat d’un de ces autotests est **positif** :
-    - faites un **test antigénique** (en pharmacie) ou **PCR** (en laboratoire) pour **confirmer** ce résultat positif et restez isolé(e) en attendant ;
-
-    - si le résultat positif à l’autotest est **confirmé** :
-        + maintenez votre isolement pour une durée de **7 jours** ;
-        + vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test antigénique négatif et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 
 <div class="conseil conseil-jaune">
 

--- a/contenus/thematiques/7-tests-de-depistage.md
+++ b/contenus/thematiques/7-tests-de-depistage.md
@@ -137,7 +137,7 @@
     Il est **pris en charge** par l’Assurance maladie dans les cas suivants :
 
     * dépistage des personnes **contact à risque** en **milieu scolaire** (enfants de moins de 12 ans, ou personnes de 12 ans et plus complètement vaccinées) ;
-    * tests de surveillance à J+2 et J+4 pour les personnes **contact à risque** (enfants de moins de 12 ans, ou personnes de 12 ans et plus complètement vaccinées) ;
+    * tests de surveillance à J+2 pour les personnes **contact à risque** (enfants de moins de 12 ans, ou personnes de 12 ans et plus complètement vaccinées) ;
     * personnels de l’**Éducation nationale** exerçant en école maternelle, primaire, collège et lycée, ainsi que dans les services d’hébergement, d’accueil et d’activités périscolaires associés ;
     * professionnels exerçant auprès de **personnes vulnérables** (âgées, handicapées…) et dans la limite de 10 par mois.
 

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -45,7 +45,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
     * Pour les élèves de **moins de 12 ans** (quel que soit leur statut vaccinal), lorsqu’**un cas positif** est confirmé dans la classe :
 
       * les élèves pourront poursuivre les enseignements en **présentiel** ;
-      * ils seront invités à réaliser un **test de dépistage gratuit** (test PCR, test antigénique ou autotest) **deux jours après** avoir été prévenus de ce contact à risque.
+      * ils seront invités à réaliser un **test de dépistage gratuit** (test PCR, test antigénique ou autotest) **2 jours après** avoir été prévenus de ce contact à risque.
 
         *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, votre enfant n’aura pas à refaire un test.*
 
@@ -54,7 +54,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
       * s’ils sont **complètement vaccinés** :
         * les élèves pourront poursuivre les enseignements en **présentiel** ;
-        * ils seront invités à réaliser un **test de dépistage gratuit** (test PCR, test antigénique ou autotest) **deux jours après** avoir été prévenus de ce contact à risque.
+        * ils seront invités à réaliser un **test de dépistage gratuit** (test PCR, test antigénique ou autotest) **2 jours après** avoir été prévenus de ce contact à risque.
 
           *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, votre enfant n’aura pas à refaire un test.*
 

--- a/contenus/thematiques/8-conseils-pour-les-enfants.md
+++ b/contenus/thematiques/8-conseils-pour-les-enfants.md
@@ -41,39 +41,22 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
 .. question:: Que se passe-t-il si un élève est testé positif dans la classe de mon enfant ?
     :level: 3
-    :expires: 28 février 2022
 
     * Pour les élèves de **moins de 12 ans** (quel que soit leur statut vaccinal), lorsqu’**un cas positif** est confirmé dans la classe :
 
-      * les élèves seront invités à réaliser au plus tôt un **autotest**, délivré **gratuitement** en pharmacie : si le résultat du test est **négatif**, ils pourront poursuivre les enseignements en **présentiel** ;
+      * les élèves pourront poursuivre les enseignements en **présentiel** ;
+      * ils seront invités à réaliser un **test de dépistage gratuit** (test PCR, test antigénique ou autotest) **deux jours après** avoir été prévenus de ce contact à risque.
 
-        *Note: ce premier test peut aussi être un test PCR ou antigénique (toujours gratuit pour les enfants) lorsque les parents le souhaitent.*
+        *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, votre enfant n’aura pas à refaire un test.*
 
-      * ils devront ensuite réaliser à la maison **2 autotests** de surveillance (délivrés **gratuitement** en pharmacie) **2 jours** après et **4 jours** après la date du **premier test** (en cas de difficultés pour obtenir des autotests, la surveillance peut aussi se faire par test antigénique ou PCR).
-
-        *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, votre enfant n’aura pas à recommencer ce parcours de trois tests.*
-
-        <div class="conseil">
-
-        À partir du **28 février 2022**, les élèves cas contact de moins de 12 ans poursuivront leurs apprentissages en présentiel, et devront seulement réaliser un autotest à **J+2**.
-
-        </div>
 
     * Pour les élèves de **12 ans et plus**, un protocole de _contact-tracing_ sera mis en œuvre pour identifier les élèves ayant eu des contacts à risque avec un cas positif. La conduite à tenir pour les élèves **« cas contact »** dépend alors de leur statut vaccinal :
 
       * s’ils sont **complètement vaccinés** :
-        - les élèves seront invités à réaliser au plus tôt un **autotest**, délivré **gratuitement** en pharmacie : si le résultat du test est **négatif**, ils pourront poursuivre les enseignements en **présentiel** ;
+        * les élèves pourront poursuivre les enseignements en **présentiel** ;
+        * ils seront invités à réaliser un **test de dépistage gratuit** (test PCR, test antigénique ou autotest) **deux jours après** avoir été prévenus de ce contact à risque.
 
-          *Note: ce premier test peut aussi être un test PCR ou antigénique (toujours gratuit pour les enfants) lorsque les parents le souhaitent.*
-        - ils devront ensuite réaliser à la maison **2 autotests** de surveillance (délivrés **gratuitement** en pharmacie) **2 jours** après et **4 jours** après la date du **premier test** (en cas de difficultés pour obtenir des autotests, la surveillance peut aussi se faire par test antigénique ou PCR).
-
-          *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, votre enfant n’aura pas à recommencer ce parcours de trois tests.*
-
-          <div class="conseil">
-
-          À partir du **28 février 2022**, les élèves cas contact complètement vaccinés poursuivront leurs apprentissages en présentiel, et devront seulement réaliser un autotest à **J+2**.
-
-          </div>
+          *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, votre enfant n’aura pas à refaire un test.*
 
       * s’ils ne sont **pas complètement vaccinés** :
         - ils devront **s’isoler** pendant **7 jours**, et poursuivre leurs apprentissages **à distance** pendant cette période.
@@ -93,7 +76,6 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
 .. question:: Que se passe-t-il si mon enfant de moins de 12 ans est cas contact ?
     :level: 3
-    :expires: 28 février 2022
 
     <div class="conseil conseil-jaune">
 
@@ -103,20 +85,13 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     #### 1. Pas d’isolement
 
-    Si votre enfant de moins de 12 ans est « **cas contact** », qu’il soit **vacciné ou non**, alors il n’aura pas besoin de s’isoler, et pourra continuer à aller à l’école à condition de faire un **test immédiat**, puis **2 autotests** de surveillance.
+    Si votre enfant de moins de 12 ans est « **cas contact** », qu’il soit **vacciné ou non**, alors il n’aura pas besoin de s’isoler, et pourra continuer à aller à l’école.
 
-    <div class="conseil">
+    #### 2. Test de dépistage à J+2
 
-    À partir du **28 février 2022**, les élèves cas contact de moins de 12 ans poursuivront leurs apprentissages en présentiel, et devront seulement réaliser un autotest à **J+2**.
-
-    </div>
-
-    #### 2. Test de dépistage
-
-    Votre enfant devra faire **dès que possible** un **test antigénique** en pharmacie (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+    Votre enfant devra faire un **test de dépistage** (test PCR, test antigénique ou autotest) **2 jours** après avoir été prévenu du contact à risque (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
 
     * Si le test est **négatif** :
-        * il devra faire **2 autotests** de surveillance (voir plus bas) ;
         * il devra rester **prudent** et éviter de rencontrer des personnes vulnérables ou fragiles ;
         * en cas d’apparition de **fièvre** ou de **symptômes**, faites lui passer un nouveau test sans attendre, et contactez un **médecin** (ou le 15) en cas de difficultés respiratoires.
 
@@ -127,15 +102,7 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
             - en l’absence de fièvre ou de difficultés respiratoires depuis **48 heures**, vous pourrez mettre fin à l’isolement après 5 jours seulement, suite à test de dépistage négatif (antigénique ou PCR) ;
         - les autres membres du **foyer** sont à leur tour **cas contacts** (sauf s’ils ont déjà eu la Covid dans les 2 derniers mois).
 
-    #### 3. Surveillance par autotests
-
-    Si le 1<sup>er</sup> test de votre enfant était négatif, alors il devra faire **2 autotests** de surveillance :
-    - **2 jours** après et **4 jours** après la date du **premier test**,
-    - ces autotests vous seront délivrés **gratuitement** en pharmacie.
-
-    En cas de difficultés pour obtenir des autotests, la surveillance peut aussi se faire par test antigénique ou PCR.
-
-    *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, votre enfant n’aura pas à recommencer ce parcours de trois tests.*
+    *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, votre enfant n’aura pas à refaire un test.*
 
     <div class="voir-aussi">
 
@@ -148,7 +115,6 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
 .. question:: Que se passe-t-il si mon enfant de 12 ans ou plus est cas contact et qu’il est vacciné ?
     :level: 3
-    :expires: 28 février 2022
 
     <div class="conseil conseil-jaune">
 
@@ -160,20 +126,13 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
 
     #### 1. Pas d’isolement
 
-    Si votre enfant de 12 ans ou plus est « **cas contact** » et qu’il est **vacciné**, alors il n’aura pas besoin de s’isoler, et pourra continuer à aller à l’école à condition de faire un **test de dépistage**, puis **2 autotests** de surveillance.
+    Si votre enfant de 12 ans ou plus est « **cas contact** » et qu’il est **vacciné**, alors il n’aura pas besoin de s’isoler, et pourra continuer à aller à l’école.
 
-    <div class="conseil">
+    #### 2. Test de dépistage à J+2
 
-    À partir du **28 février 2022**, les élèves cas contact complètement vaccinés poursuivront leurs apprentissages en présentiel, et devront seulement réaliser un autotest à **J+2**.
-
-    </div>
-
-    #### 2. Test de dépistage
-
-    Votre enfant devra faire **dès que possible** un **test antigénique** en pharmacie (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
+    Votre enfant devra faire un **test de dépistage** (test PCR, test antigénique ou autotest) **2 jours** après avoir été prévenu du contact à risque (voir la [carte des lieux de test](https://www.sante.fr/cf/centres-depistage-covid.html)).
 
     * Si le test est **négatif** :
-        * il devra faire **2 autotests** de surveillance (voir plus bas) ;
         * il devra rester **prudent** et éviter de rencontrer des personnes vulnérables ou fragiles ;
         * en cas d’apparition de **fièvre** ou de **symptômes**, faites lui passer un nouveau test sans attendre, et contactez un **médecin** (ou le 15) en cas de difficultés respiratoires.
 
@@ -184,15 +143,8 @@ Le forfait « *100% Psy Enfant Ado* » donne accès à 10 séances de **souti
             - en l’absence de fièvre ou de difficultés respiratoires depuis **48 heures**, vous pourrez mettre fin à l’isolement après 5 jours seulement, suite à test de dépistage négatif (antigénique ou PCR) ;
         - les autres membres du **foyer** sont à leur tour **cas contacts** (sauf s’ils ont déjà eu la Covid dans les 2 derniers mois).
 
-    #### 3. Surveillance par autotests
 
-    Si le 1<sup>er</sup> test de votre enfant était négatif, alors il devra faire **2 autotests** de surveillance :
-    - **2 jours** après et **4 jours** après la date du **premier test**,
-    - ces autotests vous seront délivrés **gratuitement** en pharmacie.
-
-    En cas de difficultés pour obtenir des autotests, la surveillance peut aussi se faire par test antigénique ou PCR.
-
-    *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, ils n’aura pas à recommencer ce parcours de trois tests.*
+    *Note : si de nouveaux cas positifs sont signalés dans la classe dans les 7 jours, votre enfant n’aura pas à refaire un test.*
 
     <div class="voir-aussi">
 


### PR DESCRIPTION
Source : https://solidarites-sante.gouv.fr/IMG/pdf/dgs-urgent_no2022_31_evolution_du_depistage_et_de_l_isolement-2.pdf

> Les évolutions portent sur la stratégie de dépistage pour les personnes contacts avec un schéma vaccinal complet, pour lesquelles il est proposé de limiter, en phase favorable, le nombre de test à un seul test, à réaliser à J2 de la date d’information/notification du statut de personne contact. Le test peut être un autotest ou un test antigénique ou RT-PCR (s’agissant des enfants de moins de 12 ans, il n’y a plus de distinction pour le test entre les secteurs scolaire/périscolaire et extrascolaire). Il n’y a aucune évolution s’agissant des durées d’isolement des cas et de quarantaine des personnes contacts non vaccinées ou ayant un schéma vaccinal incomplet.

Cf. https://github.com/Delegation-numerique-en-sante/mesconseilscovid/issues/2098