### PR TITLE
Fin de la campagne de vaccination contre la grippe le 28/2

### DIFF
--- a/contenus/thematiques/12-rappel-vaccinal-3e-dose.md
+++ b/contenus/thematiques/12-rappel-vaccinal-3e-dose.md
@@ -30,8 +30,6 @@
 
 .. injection:: je-veux-me-faire-vacciner.html#j-ai-des-difficultes-a-me-deplacer-puis-je-me-faire-vacciner-a-domicile
 
-.. injection:: je-veux-me-faire-vacciner.html#puis-je-me-faire-vacciner-contre-la-grippe-saisonniere-et-la-covid-en-meme-temps
-
 
 ## Prolonger mon passe vaccinal
 

--- a/contenus/thematiques/5-je-veux-me-faire-vacciner.md
+++ b/contenus/thematiques/5-je-veux-me-faire-vacciner.md
@@ -471,19 +471,6 @@
     *Les infirmiers ne sont pas autorisés à vacciner les femmes enceintes ou les personnes présentant un trouble de l’hémostase.*
 
 
-.. question:: Puis-je me faire vacciner contre la grippe saisonnière et la Covid en même temps ?
-    :level: 3
-    :expires: 28 février 2022
-
-    **Oui**. Il est possible de réaliser le rappel du vaccin contre la Covid en même temps que le vaccin contre la grippe, mais il est aussi possible d’espacer les deux injections.
-
-    La campagne annuelle de vaccination contre la grippe a commencé le 22 octobre 2021 pour les publics prioritaires. Depuis le **23 novembre 2021**, elle est ouverte à **toute la population**. Si vous êtes éligible au rappel vaccinal contre la Covid, vous pourrez recevoir les deux vaccins en même temps.
-
-    En ville, c’est possible dans les **pharmacies** qui vaccinent avec les deux vaccins, et dans les cabinets médicaux ou infirmiers.
-
-    Vous pouvez aussi acheter votre vaccin anti-grippe en pharmacie et venir avec au **centre de vaccination** le jour de votre rendez-vous de rappel vaccinal contre la Covid.
-
-
 ## La vaccination initiale (schéma vaccinal à 1 ou 2 doses)
 
  <div class="voir-aussi">


### PR DESCRIPTION
Source : https://solidarites-sante.gouv.fr/IMG/pdf/dgs_urgent_no2022_08_prolongation_de_la_campagne_de_vaccination_contre_la_grippe_saisonniere_jusqu_au_28_fevrier_2022.pdf