### PR TITLE
Retire le lien vers les fiches conseil métiers

### DIFF
--- a/contenus/conseils/conseils_activité_pro_infos.md
+++ b/contenus/conseils/conseils_activité_pro_infos.md
@@ -1,4 +1,3 @@
 * [L’espace dédié pour les professionnels](https://www.gouvernement.fr/info-coronavirus/espace-pour-les-professionnels) sur le site du gouvernement.
 * [Les conditions de reprise de l’activité](https://travail-emploi.gouv.fr/le-ministere-en-action/coronavirus-covid-19/conditions-de-reprise-et-relance-de-l-activite/).
-* [Les **fiches-conseils métier**](https://travail-emploi.gouv.fr/le-ministere-en-action/coronavirus-covid-19/proteger-les-travailleurs/article/fiches-conseils-metiers-et-guides-pour-les-salaries-et-les-employeurs) du ministère du travail.
 * [Les questions-réponses](https://travail-emploi.gouv.fr/le-ministere-en-action/coronavirus-covid-19/questions-reponses-par-theme/) du ministère du travail.


### PR DESCRIPTION
La page a été supprimée sur le site du ministère du travail.