### PR TITLE
Tech: évite certaines transformations de code JS après Babel

### DIFF
--- a/.terserrc
+++ b/.terserrc
@@ -1,0 +1,5 @@
+{
+  "compress": {
+    "arrows": false
+  }
+}


### PR DESCRIPTION
Parcel fait passer le code JS transpilé par Babel dans Terser, qui peut faire des transformations de code qui ne marchent pas forcément avec nos navigateurs cible.

On désactive ici l’option "arrows" pour éviter d’appliquer des transformations produisant des arrow functions.

Références :
- https://terser.org/docs/api-reference#compress-options
- https://github.com/terser/terser/issues/178