### PR TITLE
Ajoute wa.me aux domaines non vérifiés (check links)

### DIFF
--- a/check.py
+++ b/check.py
@@ -34,6 +34,7 @@ class LinkExtractor(HTMLParser):
                         "https://www.youtube.com/",
                         "https://twitter.com/",
                         "https://github.com/",
+                        "https://wa.me/",
                     )
                 ):
                     return


### PR DESCRIPTION
On n’a aucune autre possibilité sur ce domaine et de temps en temps ils décident que ça doit renvoyer une 404, ce qui casse notre build.

D’après la doc, on fait pourtant ce qu’il faut :
https://faq.whatsapp.com/general/chats/how-to-use-click-to-chat/?lang=en