### PR TITLE
On ne recommande le Paxlovid que si la personne est symptomatique

### DIFF
--- a/contenus/conseils/conseils_personnels_depistage_positif_asymptomatique.md
+++ b/contenus/conseils/conseils_personnels_depistage_positif_asymptomatique.md
@@ -2,7 +2,6 @@ Nous vous conseillons de :
 
 1. {.seulement-si-vaccine} Vous maintenir **en isolement** pour une durée de **7 jours** à partir de la date du test ; vous pourrez lever l’isolement **dès le 5<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
 1. {.seulement-si-non-vaccine} Vous maintenir **en isolement** pour une durée de **10 jours** à partir de la date du test ; vous pourrez lever l’isolement **dès le 7<sup>e</sup> jour** en cas de test négatif (test PCR ou antigénique) et d’absence de fièvre ou de symptômes depuis au moins 48 h.
-1. {.seulement-si-paxlovid} Votre **médecin** pourra peut-être vous prescrire du **Paxlovid**, un médicament qui diminue le risque d’hospitalisation pour les personnes à **risque de forme grave**. Le traitement doit commencer le plus tôt possible et toujours avant le 5<sup>e</sup> jour des symptômes. Si vous prenez d’autres médicaments, votre médecin vérifiera que vous pouvez aussi prendre celui-ci.
 1. {.seulement-si-activite-pro} Vous allez être contacté par l’Assurance maladie ; si vous ne pouvez pas **télétravailler**, elle pourra vous prescrire un **arrêt de travail** couvrant toute votre période d’isolement.
 1. {.seulement-si-foyer} Mettre en place des **mesures d’hygiène renforcée** dans votre foyer pour protéger vos proches (voir la section **Isolement** plus bas).
 1. {.seulement-si-foyer} Les autres membres de votre foyer sont maintenant considérés comme **cas contact**.


### PR DESCRIPTION
Il n’est donc pas utile d’inclure ce point dans les conseils destinés aux personnes
testées positives mais aymptomatiques.